### PR TITLE
add NATS service

### DIFF
--- a/ocis/templates/nats/deployment.yaml
+++ b/ocis/templates/nats/deployment.yaml
@@ -1,0 +1,44 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: nats
+  namespace: {{ $.Release.Namespace }}
+  labels:
+    {{- include "ocis.labels" . | nindent 4 }}
+spec:
+  selector:
+    matchLabels:
+        app: nats
+  {{- if and (not .Values.autoscaling.enabled) (.Values.replicas) }}
+  replicas: {{ .Values.replicas }}
+  {{- end }}
+  template:
+    metadata:
+      labels:
+          app: nats
+    spec:
+      containers:
+        - name: nats
+          {{- if .Values.image.sha }}
+          image: "{{ .Values.image.repository }}:{{ .Values.image.tag }}@sha256:{{ .Values.image.sha }}"
+          {{- else }}
+          image: "{{ .Values.image.repository }}:{{ .Values.image.tag }}"
+          {{- end }}
+          command: ["ocis"]
+          args: ["nats-server", "server"]
+          env:
+            - name: NATS_LOG_COLOR
+              value: "{{ $.Values.logging.color }}"
+            - name: NATS_LOG_LEVEL
+              value: "{{ $.Values.logging.level }}"
+            - name: NATS_LOG_PRETTY
+              value: "{{ $.Values.logging.pretty }}"
+
+            - name: NATS_NATS_HOST
+              value: "0.0.0.0"
+            - name: NATS_NATS_PORT
+              value: "9233"
+
+          resources: {{ toYaml .Values.resources | nindent 12 }}
+          ports:
+          - containerPort: 9233 # NATS

--- a/ocis/templates/nats/service.yaml
+++ b/ocis/templates/nats/service.yaml
@@ -1,0 +1,14 @@
+apiVersion: v1
+kind: Service
+metadata:
+  name: nats
+  namespace: {{ $.Release.Namespace }}
+  labels:
+    {{- include "ocis.labels" . | nindent 4 }}
+spec:
+  ports:
+  - name: nats
+    port: 9233
+    protocol: TCP
+  selector:
+    app: nats

--- a/ocis/templates/storage-metadata/deployment.yaml
+++ b/ocis/templates/storage-metadata/deployment.yaml
@@ -37,7 +37,7 @@ spec:
 
             - name: STORAGE_HOME_DATAPROVIDER_INSECURE
               value: "true"
-            - name: STORAGE_METADATA_GRPC_PROVIDER_ADDR
+            - name: STORAGE_METADATA_GRPC_ADDR
               value: 0.0.0.0:9215
             - name: STORAGE_METADATA_HTTP_ADDR
               value: 0.0.0.0:9216


### PR DESCRIPTION
adds NATS service to adapt to latest oCIS changes. Also fixes a Metadata service config change done in https://github.com/owncloud/ocis/pull/3169