### PR TITLE
various improvements

### DIFF
--- a/ocis/templates/accounts/deployment.yaml
+++ b/ocis/templates/accounts/deployment.yaml
@@ -25,6 +25,7 @@ spec:
           {{- else }}
           image: "{{ .Values.image.repository }}:{{ .Values.image.tag }}"
           {{- end }}
+          imagePullPolicy: {{ .Values.image.pullPolicy }}
           command: ["ocis"]
           args: ["accounts", "server"]
           env:

--- a/ocis/templates/accounts/deployment.yaml
+++ b/ocis/templates/accounts/deployment.yaml
@@ -10,6 +10,9 @@ spec:
     matchLabels:
         app: accounts
   replicas: 1 #TODO: scale out?
+  {{- if .Values.deploymentStrategy }}
+  strategy: {{ toYaml .Values.deploymentStrategy | nindent 4 }}
+  {{ end }}
   template:
     metadata:
       labels:

--- a/ocis/templates/glauth/deployment.yaml
+++ b/ocis/templates/glauth/deployment.yaml
@@ -12,6 +12,9 @@ spec:
   {{- if and (not .Values.autoscaling.enabled) (.Values.replicas) }}
   replicas: {{ .Values.replicas }}
   {{- end }}
+  {{- if .Values.deploymentStrategy }}
+  strategy: {{ toYaml .Values.deploymentStrategy | nindent 4 }}
+  {{ end }}
   template:
     metadata:
       labels:

--- a/ocis/templates/glauth/deployment.yaml
+++ b/ocis/templates/glauth/deployment.yaml
@@ -27,6 +27,7 @@ spec:
           {{- else }}
           image: "{{ .Values.image.repository }}:{{ .Values.image.tag }}"
           {{- end }}
+          imagePullPolicy: {{ .Values.image.pullPolicy }}
           command: ["ocis"]
           args: ["glauth", "server"]
           env:

--- a/ocis/templates/graph/deployment.yaml
+++ b/ocis/templates/graph/deployment.yaml
@@ -27,6 +27,7 @@ spec:
           {{- else }}
           image: "{{ .Values.image.repository }}:{{ .Values.image.tag }}"
           {{- end }}
+          imagePullPolicy: {{ .Values.image.pullPolicy }}
           command: ["ocis"]
           args: ["graph", "server"]
           env:

--- a/ocis/templates/graph/deployment.yaml
+++ b/ocis/templates/graph/deployment.yaml
@@ -12,6 +12,9 @@ spec:
   {{- if and (not .Values.autoscaling.enabled) (.Values.replicas) }}
   replicas: {{ .Values.replicas }}
   {{- end }}
+  {{- if .Values.deploymentStrategy }}
+  strategy: {{ toYaml .Values.deploymentStrategy | nindent 4 }}
+  {{ end }}
   template:
     metadata:
       labels:

--- a/ocis/templates/idp/deployment.yaml
+++ b/ocis/templates/idp/deployment.yaml
@@ -10,6 +10,9 @@ spec:
     matchLabels:
         app: idp
   replicas: 1 #TODO: scale out ?
+  {{- if .Values.deploymentStrategy }}
+  strategy: {{ toYaml .Values.deploymentStrategy | nindent 4 }}
+  {{ end }}
   template:
     metadata:
       labels:

--- a/ocis/templates/idp/deployment.yaml
+++ b/ocis/templates/idp/deployment.yaml
@@ -25,6 +25,7 @@ spec:
           {{- else }}
           image: "{{ .Values.image.repository }}:{{ .Values.image.tag }}"
           {{- end }}
+          imagePullPolicy: {{ .Values.image.pullPolicy }}
           command: ["ocis"]
           args: ["idp", "server"]
           env:

--- a/ocis/templates/nats/deployment.yaml
+++ b/ocis/templates/nats/deployment.yaml
@@ -9,9 +9,10 @@ spec:
   selector:
     matchLabels:
         app: nats
-  {{- if and (not .Values.autoscaling.enabled) (.Values.replicas) }}
-  replicas: {{ .Values.replicas }}
-  {{- end }}
+  replicas: 1 #TODO: scale out ?
+  {{- if .Values.deploymentStrategy }}
+  strategy: {{ toYaml .Values.deploymentStrategy | nindent 4 }}
+  {{ end }}
   template:
     metadata:
       labels:

--- a/ocis/templates/nats/deployment.yaml
+++ b/ocis/templates/nats/deployment.yaml
@@ -25,6 +25,7 @@ spec:
           {{- else }}
           image: "{{ .Values.image.repository }}:{{ .Values.image.tag }}"
           {{- end }}
+          imagePullPolicy: {{ .Values.image.pullPolicy }}
           command: ["ocis"]
           args: ["nats-server", "server"]
           env:

--- a/ocis/templates/ocs/deployment.yaml
+++ b/ocis/templates/ocs/deployment.yaml
@@ -12,6 +12,9 @@ spec:
   {{- if and (not .Values.autoscaling.enabled) (.Values.replicas) }}
   replicas: {{ .Values.replicas }}
   {{- end }}
+  {{- if .Values.deploymentStrategy }}
+  strategy: {{ toYaml .Values.deploymentStrategy | nindent 4 }}
+  {{ end }}
   template:
     metadata:
       labels:

--- a/ocis/templates/ocs/deployment.yaml
+++ b/ocis/templates/ocs/deployment.yaml
@@ -27,6 +27,7 @@ spec:
           {{- else }}
           image: "{{ .Values.image.repository }}:{{ .Values.image.tag }}"
           {{- end }}
+          imagePullPolicy: {{ .Values.image.pullPolicy }}
           command: ["ocis"]
           args: ["ocs", "server"]
           env:

--- a/ocis/templates/proxy/deployment.yaml
+++ b/ocis/templates/proxy/deployment.yaml
@@ -12,6 +12,9 @@ spec:
   {{- if and (not .Values.autoscaling.enabled) (.Values.replicas) }}
   replicas: {{ .Values.replicas }}
   {{- end }}
+  {{- if .Values.deploymentStrategy }}
+  strategy: {{ toYaml .Values.deploymentStrategy | nindent 4 }}
+  {{ end }}
   template:
     metadata:
       labels:

--- a/ocis/templates/proxy/deployment.yaml
+++ b/ocis/templates/proxy/deployment.yaml
@@ -34,6 +34,7 @@ spec:
           {{- else }}
           image: "{{ .Values.image.repository }}:{{ .Values.image.tag }}"
           {{- end }}
+          imagePullPolicy: {{ .Values.image.pullPolicy }}
           command: ["ocis"]
           args: ["proxy", "server"]
           env:

--- a/ocis/templates/settings/deployment.yaml
+++ b/ocis/templates/settings/deployment.yaml
@@ -18,6 +18,18 @@ spec:
       labels:
           app: settings
     spec:
+      {{- if $.Values.settings.persistence.enabled }}
+      initContainers:
+        - name: init-chown-data
+          image: busybox
+          securityContext:
+            runAsNonRoot: false
+            runAsUser: 0
+          command: ["chown", "-R", "1000:1000", "/var/lib/ocis"]
+          volumeMounts:
+          - name: settings-data
+            mountPath: /var/lib/ocis
+      {{ end }}
       containers:
         - name: settings
           {{- if .Values.image.sha }}

--- a/ocis/templates/settings/deployment.yaml
+++ b/ocis/templates/settings/deployment.yaml
@@ -10,6 +10,9 @@ spec:
     matchLabels:
         app: settings
   replicas: 1 #TODO: scale out?
+  {{- if .Values.deploymentStrategy }}
+  strategy: {{ toYaml .Values.deploymentStrategy | nindent 4 }}
+  {{ end }}
   template:
     metadata:
       labels:

--- a/ocis/templates/storage-authbasic/deployment.yaml
+++ b/ocis/templates/storage-authbasic/deployment.yaml
@@ -12,6 +12,9 @@ spec:
   {{- if and (not .Values.autoscaling.enabled) (.Values.replicas) }}
   replicas: {{ .Values.replicas }}
   {{- end }}
+  {{- if .Values.deploymentStrategy }}
+  strategy: {{ toYaml .Values.deploymentStrategy | nindent 4 }}
+  {{ end }}
   template:
     metadata:
       labels:

--- a/ocis/templates/storage-authbasic/deployment.yaml
+++ b/ocis/templates/storage-authbasic/deployment.yaml
@@ -27,6 +27,7 @@ spec:
           {{- else }}
           image: "{{ .Values.image.repository }}:{{ .Values.image.tag }}"
           {{- end }}
+          imagePullPolicy: {{ .Values.image.pullPolicy }}
           command: ["ocis"]
           args: ["storage-auth-basic", "server"]
           env:

--- a/ocis/templates/storage-authbearer/deployment.yaml
+++ b/ocis/templates/storage-authbearer/deployment.yaml
@@ -12,6 +12,9 @@ spec:
   {{- if and (not .Values.autoscaling.enabled) (.Values.replicas) }}
   replicas: {{ .Values.replicas }}
   {{- end }}
+  {{- if .Values.deploymentStrategy }}
+  strategy: {{ toYaml .Values.deploymentStrategy | nindent 4 }}
+  {{ end }}
   template:
     metadata:
       labels:

--- a/ocis/templates/storage-authbearer/deployment.yaml
+++ b/ocis/templates/storage-authbearer/deployment.yaml
@@ -27,6 +27,7 @@ spec:
           {{- else }}
           image: "{{ .Values.image.repository }}:{{ .Values.image.tag }}"
           {{- end }}
+          imagePullPolicy: {{ .Values.image.pullPolicy }}
           command: ["ocis"]
           args: ["storage-auth-bearer", "server"]
           env:

--- a/ocis/templates/storage-authmachine/deployment.yaml
+++ b/ocis/templates/storage-authmachine/deployment.yaml
@@ -12,6 +12,9 @@ spec:
   {{- if and (not .Values.autoscaling.enabled) (.Values.replicas) }}
   replicas: {{ .Values.replicas }}
   {{- end }}
+  {{- if .Values.deploymentStrategy }}
+  strategy: {{ toYaml .Values.deploymentStrategy | nindent 4 }}
+  {{ end }}
   template:
     metadata:
       labels:

--- a/ocis/templates/storage-authmachine/deployment.yaml
+++ b/ocis/templates/storage-authmachine/deployment.yaml
@@ -27,6 +27,7 @@ spec:
           {{- else }}
           image: "{{ .Values.image.repository }}:{{ .Values.image.tag }}"
           {{- end }}
+          imagePullPolicy: {{ .Values.image.pullPolicy }}
           command: ["ocis"]
           args: ["storage-auth-machine", "server"]
           env:

--- a/ocis/templates/storage-frontend/deployment.yaml
+++ b/ocis/templates/storage-frontend/deployment.yaml
@@ -12,6 +12,9 @@ spec:
   {{- if and (not .Values.autoscaling.enabled) (.Values.replicas) }}
   replicas: {{ .Values.replicas }}
   {{- end }}
+  {{- if .Values.deploymentStrategy }}
+  strategy: {{ toYaml .Values.deploymentStrategy | nindent 4 }}
+  {{ end }}
   template:
     metadata:
       labels:

--- a/ocis/templates/storage-frontend/deployment.yaml
+++ b/ocis/templates/storage-frontend/deployment.yaml
@@ -27,6 +27,7 @@ spec:
           {{- else }}
           image: "{{ .Values.image.repository }}:{{ .Values.image.tag }}"
           {{- end }}
+          imagePullPolicy: {{ .Values.image.pullPolicy }}
           command: ["ocis"]
           args: ["storage-frontend", "server"]
           env:

--- a/ocis/templates/storage-gateway/deployment.yaml
+++ b/ocis/templates/storage-gateway/deployment.yaml
@@ -27,6 +27,7 @@ spec:
           {{- else }}
           image: "{{ .Values.image.repository }}:{{ .Values.image.tag }}"
           {{- end }}
+          imagePullPolicy: {{ .Values.image.pullPolicy }}
           command: ["ocis"]
           args: ["storage-gateway", "server"]
           env:

--- a/ocis/templates/storage-gateway/deployment.yaml
+++ b/ocis/templates/storage-gateway/deployment.yaml
@@ -12,6 +12,9 @@ spec:
   {{- if and (not .Values.autoscaling.enabled) (.Values.replicas) }}
   replicas: {{ .Values.replicas }}
   {{- end }}
+  {{- if .Values.deploymentStrategy }}
+  strategy: {{ toYaml .Values.deploymentStrategy | nindent 4 }}
+  {{ end }}
   template:
     metadata:
       labels:

--- a/ocis/templates/storage-groupprovider/deployment.yaml
+++ b/ocis/templates/storage-groupprovider/deployment.yaml
@@ -12,6 +12,9 @@ spec:
   {{- if and (not .Values.autoscaling.enabled) (.Values.replicas) }}
   replicas: {{ .Values.replicas }}
   {{- end }}
+  {{- if .Values.deploymentStrategy }}
+  strategy: {{ toYaml .Values.deploymentStrategy | nindent 4 }}
+  {{ end }}
   template:
     metadata:
       labels:

--- a/ocis/templates/storage-groupprovider/deployment.yaml
+++ b/ocis/templates/storage-groupprovider/deployment.yaml
@@ -27,6 +27,7 @@ spec:
           {{- else }}
           image: "{{ .Values.image.repository }}:{{ .Values.image.tag }}"
           {{- end }}
+          imagePullPolicy: {{ .Values.image.pullPolicy }}
           command: ["ocis"]
           args: ["storage-groupprovider", "server"]
           env:

--- a/ocis/templates/storage-metadata/deployment.yaml
+++ b/ocis/templates/storage-metadata/deployment.yaml
@@ -18,6 +18,18 @@ spec:
       labels:
           app: storage-metadata
     spec:
+      {{- if $.Values.storageMetadata.persistence.enabled }}
+      initContainers:
+        - name: init-chown-data
+          image: busybox
+          securityContext:
+            runAsNonRoot: false
+            runAsUser: 0
+          command: ["chown", "-R", "1000:1000", "/var/lib/ocis"]
+          volumeMounts:
+          - name: storage-metadata-data
+            mountPath: /var/lib/ocis
+      {{ end }}
       containers:
         - name: store
           {{- if .Values.image.sha }}

--- a/ocis/templates/storage-metadata/deployment.yaml
+++ b/ocis/templates/storage-metadata/deployment.yaml
@@ -31,7 +31,7 @@ spec:
             mountPath: /var/lib/ocis
       {{ end }}
       containers:
-        - name: store
+        - name: storage-metadata
           {{- if .Values.image.sha }}
           image: "{{ .Values.image.repository }}:{{ .Values.image.tag }}@sha256:{{ .Values.image.sha }}"
           {{- else }}

--- a/ocis/templates/storage-metadata/deployment.yaml
+++ b/ocis/templates/storage-metadata/deployment.yaml
@@ -25,6 +25,7 @@ spec:
           {{- else }}
           image: "{{ .Values.image.repository }}:{{ .Values.image.tag }}"
           {{- end }}
+          imagePullPolicy: {{ .Values.image.pullPolicy }}
           command: ["ocis"]
           args: ["storage-metadata", "server"]
           env:

--- a/ocis/templates/storage-metadata/deployment.yaml
+++ b/ocis/templates/storage-metadata/deployment.yaml
@@ -10,6 +10,9 @@ spec:
     matchLabels:
         app: storage-metadata
   replicas: 1 #TODO: scale out?
+  {{- if .Values.deploymentStrategy }}
+  strategy: {{ toYaml .Values.deploymentStrategy | nindent 4 }}
+  {{ end }}
   template:
     metadata:
       labels:

--- a/ocis/templates/storage-publiclink/deployment.yaml
+++ b/ocis/templates/storage-publiclink/deployment.yaml
@@ -12,6 +12,9 @@ spec:
   {{- if and (not .Values.autoscaling.enabled) (.Values.replicas) }}
   replicas: {{ .Values.replicas }}
   {{- end }}
+  {{- if .Values.deploymentStrategy }}
+  strategy: {{ toYaml .Values.deploymentStrategy | nindent 4 }}
+  {{ end }}
   template:
     metadata:
       labels:

--- a/ocis/templates/storage-publiclink/deployment.yaml
+++ b/ocis/templates/storage-publiclink/deployment.yaml
@@ -27,6 +27,7 @@ spec:
           {{- else }}
           image: "{{ .Values.image.repository }}:{{ .Values.image.tag }}"
           {{- end }}
+          imagePullPolicy: {{ .Values.image.pullPolicy }}
           command: ["ocis"]
           args: ["storage-public-link", "server"]
           env:

--- a/ocis/templates/storage-shares/deployment.yaml
+++ b/ocis/templates/storage-shares/deployment.yaml
@@ -27,6 +27,7 @@ spec:
           {{- else }}
           image: "{{ .Values.image.repository }}:{{ .Values.image.tag }}"
           {{- end }}
+          imagePullPolicy: {{ .Values.image.pullPolicy }}
           command: ["ocis"]
           args: ["storage-shares", "server"]
           env:

--- a/ocis/templates/storage-shares/deployment.yaml
+++ b/ocis/templates/storage-shares/deployment.yaml
@@ -12,6 +12,9 @@ spec:
   {{- if and (not .Values.autoscaling.enabled) (.Values.replicas) }}
   replicas: {{ .Values.replicas }}
   {{- end }}
+  {{- if .Values.deploymentStrategy }}
+  strategy: {{ toYaml .Values.deploymentStrategy | nindent 4 }}
+  {{ end }}
   template:
     metadata:
       labels:

--- a/ocis/templates/storage-sharing/deployment.yaml
+++ b/ocis/templates/storage-sharing/deployment.yaml
@@ -18,6 +18,18 @@ spec:
       labels:
           app: storage-sharing
     spec:
+      {{- if $.Values.storageSharing.persistence.enabled }}
+      initContainers:
+        - name: init-chown-data
+          image: busybox
+          securityContext:
+            runAsNonRoot: false
+            runAsUser: 0
+          command: ["chown", "-R", "1000:1000", "/var/lib/ocis"]
+          volumeMounts:
+          - name: storage-sharing-data
+            mountPath: /var/lib/ocis
+      {{ end }}
       containers:
         - name: store
           {{- if .Values.image.sha }}

--- a/ocis/templates/storage-sharing/deployment.yaml
+++ b/ocis/templates/storage-sharing/deployment.yaml
@@ -31,7 +31,7 @@ spec:
             mountPath: /var/lib/ocis
       {{ end }}
       containers:
-        - name: store
+        - name: storage-sharing
           {{- if .Values.image.sha }}
           image: "{{ .Values.image.repository }}:{{ .Values.image.tag }}@sha256:{{ .Values.image.sha }}"
           {{- else }}
@@ -76,12 +76,12 @@ spec:
           resources: {{ toYaml .Values.resources | nindent 12 }}
           ports:
           - containerPort: 9150 # GRPC
-          {{- if $.Values.storageMetadata.persistence.enabled }}
+          {{- if $.Values.storageSharing.persistence.enabled }}
           volumeMounts:
           - name: storage-sharing-data
             mountPath: /var/lib/ocis
           {{ end }}
-      {{- if $.Values.storageMetadata.persistence.enabled }}
+      {{- if $.Values.storageSharing.persistence.enabled }}
       volumes:
         - name: storage-sharing-data
           persistentVolumeClaim:

--- a/ocis/templates/storage-sharing/deployment.yaml
+++ b/ocis/templates/storage-sharing/deployment.yaml
@@ -66,6 +66,9 @@ spec:
             - name: STORAGE_SHARING_PUBLIC_DRIVER
               value: "json"
 
+            - name: STORAGE_SHARING_EVENTS_ADDRESS
+              value: nats:9233
+
             - name: STORAGE_JWT_SECRET
               value: "{{ $.Values.secrets.jwt }}"
             - name: REVA_GATEWAY

--- a/ocis/templates/storage-sharing/deployment.yaml
+++ b/ocis/templates/storage-sharing/deployment.yaml
@@ -25,6 +25,7 @@ spec:
           {{- else }}
           image: "{{ .Values.image.repository }}:{{ .Values.image.tag }}"
           {{- end }}
+          imagePullPolicy: {{ .Values.image.pullPolicy }}
           command: ["ocis"]
           args: ["storage-sharing", "server"]
           env:

--- a/ocis/templates/storage-sharing/deployment.yaml
+++ b/ocis/templates/storage-sharing/deployment.yaml
@@ -10,6 +10,9 @@ spec:
     matchLabels:
         app: storage-sharing
   replicas: 1 #TODO: scale out?
+  {{- if .Values.deploymentStrategy }}
+  strategy: {{ toYaml .Values.deploymentStrategy | nindent 4 }}
+  {{ end }}
   template:
     metadata:
       labels:

--- a/ocis/templates/storage-userprovider/deployment.yaml
+++ b/ocis/templates/storage-userprovider/deployment.yaml
@@ -12,6 +12,9 @@ spec:
   {{- if and (not .Values.autoscaling.enabled) (.Values.replicas) }}
   replicas: {{ .Values.replicas }}
   {{- end }}
+  {{- if .Values.deploymentStrategy }}
+  strategy: {{ toYaml .Values.deploymentStrategy | nindent 4 }}
+  {{ end }}
   template:
     metadata:
       labels:

--- a/ocis/templates/storage-userprovider/deployment.yaml
+++ b/ocis/templates/storage-userprovider/deployment.yaml
@@ -27,6 +27,7 @@ spec:
           {{- else }}
           image: "{{ .Values.image.repository }}:{{ .Values.image.tag }}"
           {{- end }}
+          imagePullPolicy: {{ .Values.image.pullPolicy }}
           command: ["ocis"]
           args: ["storage-userprovider", "server"]
           env:

--- a/ocis/templates/storage-users/deployment.yaml
+++ b/ocis/templates/storage-users/deployment.yaml
@@ -25,6 +25,7 @@ spec:
           {{- else }}
           image: "{{ .Values.image.repository }}:{{ .Values.image.tag }}"
           {{- end }}
+          imagePullPolicy: {{ .Values.image.pullPolicy }}
           command: ["ocis"]
           args: ["storage-users", "server"]
           env:

--- a/ocis/templates/storage-users/deployment.yaml
+++ b/ocis/templates/storage-users/deployment.yaml
@@ -18,6 +18,18 @@ spec:
       labels:
           app: storage-users
     spec:
+      {{- if $.Values.storageUsers.persistence.enabled }}
+      initContainers:
+        - name: init-chown-data
+          image: busybox
+          securityContext:
+            runAsNonRoot: false
+            runAsUser: 0
+          command: ["chown", "-R", "1000:1000", "/var/lib/ocis"]
+          volumeMounts:
+          - name: storage-users-data
+            mountPath: /var/lib/ocis
+      {{ end }}
       containers:
         - name: store
           {{- if .Values.image.sha }}

--- a/ocis/templates/storage-users/deployment.yaml
+++ b/ocis/templates/storage-users/deployment.yaml
@@ -31,7 +31,7 @@ spec:
             mountPath: /var/lib/ocis
       {{ end }}
       containers:
-        - name: store
+        - name: storage-users
           {{- if .Values.image.sha }}
           image: "{{ .Values.image.repository }}:{{ .Values.image.tag }}@sha256:{{ .Values.image.sha }}"
           {{- else }}
@@ -51,12 +51,6 @@ spec:
             - name: OCIS_LOG_PRETTY
               value: "{{ $.Values.logging.pretty }}"
 
-            - name: STORAGE_USERS_DATAPROVIDER_INSECURE
-              value: "true"
-
-            - name: STORAGE_USERS_DRIVER
-              value: "ocis"
-
             - name: STORAGE_USERS_GRPC_ADDR
               value: 0.0.0.0:9157
             - name: STORAGE_USERS_ENDPOINT
@@ -67,13 +61,33 @@ spec:
             - name: STORAGE_USERS_DATA_SERVER_URL
               value: "http://storage-users:9158/data"
 
+            - name: STORAGE_USERS_DATAPROVIDER_INSECURE
+              value: "true"
+
+            {{- if  eq $.Values.storageUsers.storageBackend.driver "ocis" }}
+            - name: STORAGE_USERS_DRIVER
+              value: ocis
+            {{- end }}
+
+            {{- if  eq $.Values.storageUsers.storageBackend.driver "s3ng" }}
+            - name: STORAGE_USERS_DRIVER
+              value: s3ng
+            - name: STORAGE_USERS_DRIVER_S3NG_ENDPOINT
+              value: "{{ $.Values.storageUsers.storageBackend.driverConfig.s3ng.endpoint }}"
+            - name: STORAGE_USERS_DRIVER_S3NG_REGION
+              value: "{{ $.Values.storageUsers.storageBackend.driverConfig.s3ng.region }}"
+            - name: STORAGE_USERS_DRIVER_S3NG_ACCESS_KEY
+              value: "{{ $.Values.storageUsers.storageBackend.driverConfig.s3ng.accessKey }}"
+            - name: STORAGE_USERS_DRIVER_S3NG_SECRET_KEY
+              value: "{{ $.Values.storageUsers.storageBackend.driverConfig.s3ng.secretKey }}"
+            - name: STORAGE_USERS_DRIVER_S3NG_BUCKET
+              value: "{{ $.Values.storageUsers.storageBackend.driverConfig.s3ng.bucket }}"
+            {{- end }}
+
             - name: STORAGE_JWT_SECRET
               value: "{{ $.Values.secrets.jwt }}"
             - name: STORAGE_TRANSFER_SECRET
               value: "{{ $.Values.secrets.transfer }}"
-
-            - name: STORAGE_USERS_DRIVER
-              value: "ocis" #TODO: use S3!?
 
             - name: REVA_GATEWAY
               value: "storage-gateway:9142"

--- a/ocis/templates/storage-users/deployment.yaml
+++ b/ocis/templates/storage-users/deployment.yaml
@@ -10,6 +10,9 @@ spec:
     matchLabels:
         app: storage-users
   replicas: 1 #TODO: scale out!!!?
+  {{- if .Values.deploymentStrategy }}
+  strategy: {{ toYaml .Values.deploymentStrategy | nindent 4 }}
+  {{ end }}
   template:
     metadata:
       labels:

--- a/ocis/templates/storage-users/deployment.yaml
+++ b/ocis/templates/storage-users/deployment.yaml
@@ -95,12 +95,12 @@ spec:
           ports:
           - containerPort: 9157 # GRPC
           - containerPort: 9158 # HTTP
-          {{- if $.Values.storageMetadata.persistence.enabled }}
+          {{- if $.Values.storageUsers.persistence.enabled }}
           volumeMounts:
           - name: storage-users-data
             mountPath: /var/lib/ocis
           {{ end }}
-      {{- if $.Values.storageMetadata.persistence.enabled }}
+      {{- if $.Values.storageUsers.persistence.enabled }}
       volumes:
         - name: storage-users-data
           persistentVolumeClaim:

--- a/ocis/templates/store/deployment.yaml
+++ b/ocis/templates/store/deployment.yaml
@@ -60,12 +60,12 @@ spec:
           resources: {{ toYaml .Values.resources | nindent 12 }}
           ports:
           - containerPort: 9460 # GRPC
-          {{- if $.Values.storageMetadata.persistence.enabled }}
+          {{- if $.Values.store.persistence.enabled }}
           volumeMounts:
           - name: store-data
             mountPath: /var/lib/ocis
           {{ end }}
-      {{- if $.Values.storageMetadata.persistence.enabled }}
+      {{- if $.Values.store.persistence.enabled }}
       volumes:
         - name: store-data
           persistentVolumeClaim:

--- a/ocis/templates/store/deployment.yaml
+++ b/ocis/templates/store/deployment.yaml
@@ -14,6 +14,9 @@ spec:
     matchLabels:
         app: store
   replicas: 1 #TODO: scale out?
+  {{- if .Values.deploymentStrategy }}
+  strategy: {{ toYaml .Values.deploymentStrategy | nindent 4 }}
+  {{ end }}
   template:
     metadata:
       labels:

--- a/ocis/templates/store/deployment.yaml
+++ b/ocis/templates/store/deployment.yaml
@@ -22,6 +22,18 @@ spec:
       labels:
           app: store
     spec:
+      {{- if $.Values.store.persistence.enabled }}
+      initContainers:
+        - name: init-chown-data
+          image: busybox
+          securityContext:
+            runAsNonRoot: false
+            runAsUser: 0
+          command: ["chown", "-R", "1000:1000", "/var/lib/ocis"]
+          volumeMounts:
+          - name: store-data
+            mountPath: /var/lib/ocis
+      {{ end }}
       containers:
         - name: store
           {{- if .Values.image.sha }}

--- a/ocis/templates/store/deployment.yaml
+++ b/ocis/templates/store/deployment.yaml
@@ -29,6 +29,7 @@ spec:
           {{- else }}
           image: "{{ .Values.image.repository }}:{{ .Values.image.tag }}"
           {{- end }}
+          imagePullPolicy: {{ .Values.image.pullPolicy }}
           command: ["ocis"]
           args: ["store", "server"]
           env:

--- a/ocis/templates/thumbnails/deployment.yaml
+++ b/ocis/templates/thumbnails/deployment.yaml
@@ -27,6 +27,7 @@ spec:
           {{- else }}
           image: "{{ .Values.image.repository }}:{{ .Values.image.tag }}"
           {{- end }}
+          imagePullPolicy: {{ .Values.image.pullPolicy }}
           command: ["ocis"]
           args: ["thumbnails", "server"]
           env:

--- a/ocis/templates/thumbnails/deployment.yaml
+++ b/ocis/templates/thumbnails/deployment.yaml
@@ -12,6 +12,9 @@ spec:
   {{- if and (not .Values.autoscaling.enabled) (.Values.replicas) }}
   replicas: {{ .Values.replicas }}
   {{- end }}
+  {{- if .Values.deploymentStrategy }}
+  strategy: {{ toYaml .Values.deploymentStrategy | nindent 4 }}
+  {{ end }}
   template:
     metadata:
       labels:

--- a/ocis/templates/thumbnails/deployment.yaml
+++ b/ocis/templates/thumbnails/deployment.yaml
@@ -20,6 +20,18 @@ spec:
       labels:
           app: thumbnails
     spec:
+      {{- if $.Values.thumbnails.persistence.enabled }}
+      initContainers:
+        - name: init-chown-data
+          image: busybox
+          securityContext:
+            runAsNonRoot: false
+            runAsUser: 0
+          command: ["chown", "-R", "1000:1000", "/var/lib/ocis"]
+          volumeMounts:
+          - name: store-data
+            mountPath: /var/lib/ocis
+      {{ end }}
       containers:
         - name: thumbnails
           {{- if .Values.image.sha }}

--- a/ocis/templates/web/deployment.yaml
+++ b/ocis/templates/web/deployment.yaml
@@ -12,6 +12,9 @@ spec:
   {{- if and (not .Values.autoscaling.enabled) (.Values.replicas) }}
   replicas: {{ .Values.replicas }}
   {{- end }}
+  {{- if .Values.deploymentStrategy }}
+  strategy: {{ toYaml .Values.deploymentStrategy | nindent 4 }}
+  {{ end }}
   template:
     metadata:
       labels:

--- a/ocis/templates/web/deployment.yaml
+++ b/ocis/templates/web/deployment.yaml
@@ -27,6 +27,7 @@ spec:
           {{- else }}
           image: "{{ .Values.image.repository }}:{{ .Values.image.tag }}"
           {{- end }}
+          imagePullPolicy: {{ .Values.image.pullPolicy }}
           command: ["ocis"]
           args: ["web", "server"]
           env:

--- a/ocis/templates/webdav/deployment.yaml
+++ b/ocis/templates/webdav/deployment.yaml
@@ -12,6 +12,9 @@ spec:
   {{- if and (not .Values.autoscaling.enabled) (.Values.replicas) }}
   replicas: {{ .Values.replicas }}
   {{- end }}
+  {{- if .Values.deploymentStrategy }}
+  strategy: {{ toYaml .Values.deploymentStrategy | nindent 4 }}
+  {{ end }}
   template:
     metadata:
       labels:

--- a/ocis/templates/webdav/deployment.yaml
+++ b/ocis/templates/webdav/deployment.yaml
@@ -27,6 +27,7 @@ spec:
           {{- else }}
           image: "{{ .Values.image.repository }}:{{ .Values.image.tag }}"
           {{- end }}
+          imagePullPolicy: {{ .Values.image.pullPolicy }}
           command: ["ocis"]
           args: ["webdav", "server"]
           env:

--- a/ocis/values.yaml
+++ b/ocis/values.yaml
@@ -9,6 +9,9 @@ logging:
   pretty: "false"
   color: "false"
 
+# deploymentStrategy:
+#   type: Recreate
+
 externalDomain: ocis.kube.owncloud.test
 
 ingress:

--- a/ocis/values.yaml
+++ b/ocis/values.yaml
@@ -69,6 +69,16 @@ storageSharing:
     # existingClaim:
 
 storageUsers:
+  storageBackend:
+    driver: ocis # stores all data in the persistent volume if persistence is enabled
+    # driver: s3ng # stores all metadata in the persistent volume and uploads blobs to s3 if persistence is enabled
+    # driverConfig:
+    #   s3ng:
+    #     endpoint: https://localhost:1234
+    #     region: default
+    #     bucket: example-bucket
+    #     accessKey: lorem-ipsum
+    #     secretKey: lorem-ipsum
   persistence:
     enabled: true
     # storageClassName: default


### PR DESCRIPTION
- make the deployment strategy configurable
- use the already existing `image.pullPolicy` everywhere
- add init containers to services with volumes to fix the permissions (oCIS runs as non-root)
- add config option for s3ng storage for the users-storage
- use the right nats address in the sharing service
- fix some persistence references and container names