### PR TITLE
add audit and notifications service

### DIFF
--- a/charts/ocis/templates/audit/deployment.yaml
+++ b/charts/ocis/templates/audit/deployment.yaml
@@ -1,0 +1,43 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: audit
+  namespace: {{ $.Release.Namespace }}
+  labels:
+    {{- include "ocis.labels" . | nindent 4 }}
+spec:
+  selector:
+    matchLabels:
+        app: audit
+  replicas: 1 #TODO: https://github.com/owncloud/ocis-charts/issues/12
+  {{- if .Values.deploymentStrategy }}
+  strategy: {{ toYaml .Values.deploymentStrategy | nindent 4 }}
+  {{ end }}
+  template:
+    metadata:
+      labels:
+          app: audit
+    spec:
+      containers:
+        - name: audit
+          {{- if .Values.image.sha }}
+          image: "{{ .Values.image.repository }}:{{ .Values.image.tag }}@sha256:{{ .Values.image.sha }}"
+          {{- else }}
+          image: "{{ .Values.image.repository }}:{{ .Values.image.tag }}"
+          {{- end }}
+          imagePullPolicy: {{ .Values.image.pullPolicy }}
+          command: ["ocis"]
+          args: ["audit", "server"]
+          env:
+            - name: MICRO_REGISTRY
+              value: kubernetes
+
+            - name: AUDIT_LOG_TO_CONSOLE
+              value: "true"
+            - name: AUDIT_FORMAT
+              value: "json"
+
+            - name: AUDIT_EVENTS_ENDPOINT
+              value: nats:9233
+
+          resources: {{ toYaml .Values.resources | nindent 12 }}

--- a/charts/ocis/templates/audit/service.yaml
+++ b/charts/ocis/templates/audit/service.yaml
@@ -1,0 +1,10 @@
+apiVersion: v1
+kind: Service
+metadata:
+  name: audit
+  namespace: {{ $.Release.Namespace }}
+  labels:
+    {{- include "ocis.labels" . | nindent 4 }}
+spec:
+  selector:
+    app: audit

--- a/charts/ocis/templates/notifications/deployment.yaml
+++ b/charts/ocis/templates/notifications/deployment.yaml
@@ -1,0 +1,60 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: notifications
+  namespace: {{ $.Release.Namespace }}
+  labels:
+    {{- include "ocis.labels" . | nindent 4 }}
+spec:
+  selector:
+    matchLabels:
+        app: notifications
+  {{- if and (not .Values.autoscaling.enabled) (.Values.replicas) }}
+  replicas: {{ .Values.replicas }}
+  {{- end }}
+  {{- if .Values.deploymentStrategy }}
+  strategy: {{ toYaml .Values.deploymentStrategy | nindent 4 }}
+  {{ end }}
+  template:
+    metadata:
+      labels:
+          app: notifications
+    spec:
+      containers:
+        - name: notifications
+          {{- if .Values.image.sha }}
+          image: "{{ .Values.image.repository }}:{{ .Values.image.tag }}@sha256:{{ .Values.image.sha }}"
+          {{- else }}
+          image: "{{ .Values.image.repository }}:{{ .Values.image.tag }}"
+          {{- end }}
+          imagePullPolicy: {{ .Values.image.pullPolicy }}
+          command: ["ocis"]
+          args: ["notifications", "server"]
+          env:
+            - name: MICRO_REGISTRY
+              value: kubernetes
+
+            - name: NOTIFICATIONS_LOG_COLOR
+              value: "{{ $.Values.logging.color }}"
+            - name: NOTIFICATIONS_LOG_LEVEL
+              value: "{{ $.Values.logging.level }}"
+            - name: NOTIFICATIONS_LOG_PRETTY
+              value: "{{ $.Values.logging.pretty }}"
+
+            - name: NOTIFICATIONS_EVENTS_ENDPOINT
+              value: nats:9233
+
+            - name: NOTIFICATIONS_SMTP_HOST
+              value: ""
+            - name: NOTIFICATIONS_SMTP_PORT
+              value: ""
+            - name: NOTIFICATIONS_SMTP_SENDER
+              value: ""
+            - name: NOTIFICATIONS_SMTP_PASSWORD
+              value: ""
+
+            - name: OCS_MACHINE_AUTH_API_KEY
+              value: "{{ $.Values.secrets.machineAuth }}"
+            - name: NOTIFICATIONS_REVA_GATEWAY
+              value: storage-gateway:9142
+          resources: {{ toYaml .Values.resources | nindent 12 }}

--- a/charts/ocis/templates/notifications/service.yaml
+++ b/charts/ocis/templates/notifications/service.yaml
@@ -1,0 +1,10 @@
+apiVersion: v1
+kind: Service
+metadata:
+  name: notifications
+  namespace: {{ $.Release.Namespace }}
+  labels:
+    {{- include "ocis.labels" . | nindent 4 }}
+spec:
+  selector:
+    app: notifications


### PR DESCRIPTION
adds audit and notifications service

# TODO:
- start notifications service only when a mail server is configured
- do we scale the audit service by default? currently we log to stdout, that means more service = split audit log