### PR TITLE
Add drone-ci for helm linting

### DIFF
--- a/.drone.star
+++ b/.drone.star
@@ -1,0 +1,40 @@
+config = {
+    "branches": [
+        "master",
+    ],
+}
+
+def main(ctx):
+    return linting(ctx)
+
+def linting(ctx):
+    pipelines = []
+
+    result = {
+        "kind": "pipeline",
+        "type": "docker",
+        "name": "lint",
+        "steps": [
+            {
+                "name": "lint chart",
+                "image": "alpine/helm:latest",
+                "commands": [
+                    "helm lint charts/**",
+                ],
+            },
+        ],
+        "depends_on": [],
+        "trigger": {
+            "ref": [
+                "refs/pull/**",
+                "refs/tags/**",
+            ],
+        },
+    }
+
+    for branch in config["branches"]:
+        result["trigger"]["ref"].append("refs/heads/%s" % branch)
+
+    pipelines.append(result)
+
+    return pipelines

--- a/.drone.star
+++ b/.drone.star
@@ -24,11 +24,11 @@ def linting(ctx):
             },
             {
                 "name": "kube-linter",
-                "image": "archlinux:latest",
-                "commands": [
-                    "pacman -Sy",
-                    "pacman --noconfirm -S kube-linter",
-                    "kube-linter lint charts/**",
+                "image": "stackrox/kube-linter:latest",
+                "entrypoint": [
+                    "/kube-linter",
+                    "lint",
+                    "/drone/src/charts/",
                 ],
             },
         ],

--- a/.drone.star
+++ b/.drone.star
@@ -16,10 +16,19 @@ def linting(ctx):
         "name": "lint",
         "steps": [
             {
-                "name": "lint chart",
+                "name": "helm lint",
                 "image": "alpine/helm:latest",
                 "commands": [
                     "helm lint charts/**",
+                ],
+            },
+            {
+                "name": "kube-linter",
+                "image": "archlinux:latest",
+                "commands": [
+                    "pacman -Sy",
+                    "pacman --noconfirm -S kube-linter",
+                    "kube-linter lint charts/**",
                 ],
             },
         ],

--- a/.gitignore
+++ b/.gitignore
@@ -4,3 +4,5 @@
 .project
 .settings
 .DS_Store
+helmfile.yaml
+.drone.yml

--- a/charts/ocis/templates/_secrets/jwtsecret.yaml
+++ b/charts/ocis/templates/_secrets/jwtsecret.yaml
@@ -1,0 +1,9 @@
+---
+apiVersion: v1
+kind: Secret
+metadata:
+  name: jwtsecret
+type: Opaque
+data:
+    # TODO: create random default value when no value is set in values.yaml https://github.com/owncloud/ocis-charts/issues/9
+    password: "{{ b64enc $.Values.secrets.jwt }}"

--- a/charts/ocis/templates/_secrets/transfersecret.yaml
+++ b/charts/ocis/templates/_secrets/transfersecret.yaml
@@ -1,0 +1,9 @@
+---
+apiVersion: v1
+kind: Secret
+metadata:
+  name: jwtsecret
+type: Opaque
+data:
+    # TODO: create random default value when no value is set in values.yaml https://github.com/owncloud/ocis-charts/issues/9
+    password: "{{ b64enc $.Values.secrets.transfer }}"

--- a/charts/ocis/templates/accounts/deployment.yaml
+++ b/charts/ocis/templates/accounts/deployment.yaml
@@ -54,9 +54,9 @@ spec:
               value: storage-metadata:9215
 
             - name: ACCOUNTS_JWT_SECRET
-              value: "{{ $.Values.secrets.jwt }}"
+              secretRef: jwtsecret
             - name: ACCOUNTS_STORAGE_CS3_JWT_SECRET
-              value: "{{ $.Values.secrets.jwt }}"
+              secretRef: jwtsecret
           resources: {{ toYaml .Values.resources | nindent 12 }}
           ports:
           - name: grpc

--- a/charts/ocis/templates/accounts/deployment.yaml
+++ b/charts/ocis/templates/accounts/deployment.yaml
@@ -28,6 +28,10 @@ spec:
           imagePullPolicy: {{ .Values.image.pullPolicy }}
           command: ["ocis"]
           args: ["accounts", "server"]
+          securityContext:
+            runAsNonRoot: true
+            runAsUser: 1000
+            readOnlyRootFilesystem: true
           env:
             - name: MICRO_REGISTRY
               value: kubernetes

--- a/charts/ocis/templates/glauth/deployment.yaml
+++ b/charts/ocis/templates/glauth/deployment.yaml
@@ -30,6 +30,10 @@ spec:
           imagePullPolicy: {{ .Values.image.pullPolicy }}
           command: ["ocis"]
           args: ["glauth", "server"]
+          securityContext:
+            runAsNonRoot: true
+            runAsUser: 1000
+            readOnlyRootFilesystem: true
           env:
             - name: MICRO_REGISTRY
               value: kubernetes

--- a/charts/ocis/templates/graph/deployment.yaml
+++ b/charts/ocis/templates/graph/deployment.yaml
@@ -30,6 +30,10 @@ spec:
           imagePullPolicy: {{ .Values.image.pullPolicy }}
           command: ["ocis"]
           args: ["graph", "server"]
+          securityContext:
+            runAsNonRoot: true
+            runAsUser: 1000
+            readOnlyRootFilesystem: true
           env:
             - name: MICRO_REGISTRY
               value: kubernetes

--- a/charts/ocis/templates/graph/deployment.yaml
+++ b/charts/ocis/templates/graph/deployment.yaml
@@ -55,7 +55,7 @@ spec:
               value: "storage-gateway:9142"
 
             - name: GRAPH_JWT_SECRET
-              value: "{{ $.Values.secrets.jwt }}"
+              secretRef: jwtsecret
 
             - name: GRAPH_LDAP_URI
               value: ldap://glauth:9125

--- a/charts/ocis/templates/idp/deployment.yaml
+++ b/charts/ocis/templates/idp/deployment.yaml
@@ -28,6 +28,10 @@ spec:
           imagePullPolicy: {{ .Values.image.pullPolicy }}
           command: ["ocis"]
           args: ["idp", "server"]
+          securityContext:
+            runAsNonRoot: true
+            runAsUser: 1000
+            readOnlyRootFilesystem: true
           env:
             - name: MICRO_REGISTRY
               value: kubernetes

--- a/charts/ocis/templates/nats/deployment.yaml
+++ b/charts/ocis/templates/nats/deployment.yaml
@@ -28,6 +28,10 @@ spec:
           imagePullPolicy: {{ .Values.image.pullPolicy }}
           command: ["ocis"]
           args: ["nats-server", "server"]
+          securityContext:
+            runAsNonRoot: true
+            runAsUser: 1000
+            readOnlyRootFilesystem: true
           env:
             - name: NATS_LOG_COLOR
               value: "{{ $.Values.logging.color }}"

--- a/charts/ocis/templates/ocs/deployment.yaml
+++ b/charts/ocis/templates/ocs/deployment.yaml
@@ -53,9 +53,9 @@ spec:
             - name: OCS_IDM_ADDRESS
               value: "https://{{ $.Values.externalDomain }}"
 
-            - name: OCS_JWT_SECRET
-              value: "{{ $.Values.secrets.jwt }}"
             - name: OCS_MACHINE_AUTH_API_KEY
+              secretRef: jwtsecret
+            - name: PROXY_MACHINE_AUTH_API_KEY
               value: "{{ $.Values.secrets.machineAuth }}"
 
             - name: REVA_GATEWAY

--- a/charts/ocis/templates/ocs/deployment.yaml
+++ b/charts/ocis/templates/ocs/deployment.yaml
@@ -30,6 +30,10 @@ spec:
           imagePullPolicy: {{ .Values.image.pullPolicy }}
           command: ["ocis"]
           args: ["ocs", "server"]
+          securityContext:
+            runAsNonRoot: true
+            runAsUser: 1000
+            readOnlyRootFilesystem: true
           env:
             - name: MICRO_REGISTRY
               value: kubernetes

--- a/charts/ocis/templates/proxy/deployment.yaml
+++ b/charts/ocis/templates/proxy/deployment.yaml
@@ -37,6 +37,10 @@ spec:
           imagePullPolicy: {{ .Values.image.pullPolicy }}
           command: ["ocis"]
           args: ["proxy", "server"]
+          securityContext:
+            runAsNonRoot: true
+            runAsUser: 1000
+            readOnlyRootFilesystem: true
           env:
             - name: MICRO_REGISTRY
               value: kubernetes

--- a/charts/ocis/templates/proxy/deployment.yaml
+++ b/charts/ocis/templates/proxy/deployment.yaml
@@ -64,7 +64,7 @@ spec:
               value: "false"
 
             - name: PROXY_JWT_SECRET
-              value: "{{ $.Values.secrets.jwt }}"
+              secretRef: jwtsecret
             - name: PROXY_MACHINE_AUTH_API_KEY
               value: "{{ $.Values.secrets.machineAuth }}"
 

--- a/charts/ocis/templates/settings/deployment.yaml
+++ b/charts/ocis/templates/settings/deployment.yaml
@@ -30,6 +30,10 @@ spec:
           imagePullPolicy: {{ .Values.image.pullPolicy }}
           command: ["ocis"]
           args: ["settings", "server"]
+          securityContext:
+            runAsNonRoot: true
+            runAsUser: 1000
+            readOnlyRootFilesystem: true
           env:
             - name: MICRO_REGISTRY
               value: kubernetes

--- a/charts/ocis/templates/settings/deployment.yaml
+++ b/charts/ocis/templates/settings/deployment.yaml
@@ -61,7 +61,7 @@ spec:
               value: "{{ $.Values.secrets.machineAuth }}"
 
             - name: SETTINGS_JWT_SECRET
-              value: "{{ $.Values.secrets.jwt }}"
+              secretRef: jwtsecret
           resources: {{ toYaml .Values.resources | nindent 12 }}
           ports:
           - name: http

--- a/charts/ocis/templates/storage-authbasic/deployment.yaml
+++ b/charts/ocis/templates/storage-authbasic/deployment.yaml
@@ -51,7 +51,7 @@ spec:
               value: "storage-authbasic:9146"
 
             - name: STORAGE_JWT_SECRET
-              value: "{{ $.Values.secrets.jwt }}"
+              secretRef: jwtsecret
 
             - name: REVA_GATEWAY
               value: storage-gateway:9142

--- a/charts/ocis/templates/storage-authbasic/deployment.yaml
+++ b/charts/ocis/templates/storage-authbasic/deployment.yaml
@@ -30,6 +30,10 @@ spec:
           imagePullPolicy: {{ .Values.image.pullPolicy }}
           command: ["ocis"]
           args: ["storage-auth-basic", "server"]
+          securityContext:
+            runAsNonRoot: true
+            runAsUser: 1000
+            readOnlyRootFilesystem: true
           env:
             - name: MICRO_REGISTRY
               value: kubernetes

--- a/charts/ocis/templates/storage-authbearer/deployment.yaml
+++ b/charts/ocis/templates/storage-authbearer/deployment.yaml
@@ -30,6 +30,10 @@ spec:
           imagePullPolicy: {{ .Values.image.pullPolicy }}
           command: ["ocis"]
           args: ["storage-auth-bearer", "server"]
+          securityContext:
+            runAsNonRoot: true
+            runAsUser: 1000
+            readOnlyRootFilesystem: true
           env:
             - name: MICRO_REGISTRY
               value: kubernetes

--- a/charts/ocis/templates/storage-authbearer/deployment.yaml
+++ b/charts/ocis/templates/storage-authbearer/deployment.yaml
@@ -51,7 +51,7 @@ spec:
               value: "storage-authbearer:9166"
 
             - name: STORAGE_JWT_SECRET
-              value: "{{ $.Values.secrets.jwt }}"
+              secretRef: jwtsecret
 
             - name: REVA_GATEWAY
               value: storage-gateway:9142

--- a/charts/ocis/templates/storage-authmachine/deployment.yaml
+++ b/charts/ocis/templates/storage-authmachine/deployment.yaml
@@ -53,7 +53,7 @@ spec:
             - name: STORAGE_AUTH_MACHINE_AUTH_API_KEY
               value: "{{ $.Values.secrets.machineAuth }}"
             - name: STORAGE_JWT_SECRET
-              value: "{{ $.Values.secrets.jwt }}"
+              secretRef: jwtsecret
 
             - name: REVA_GATEWAY
               value: storage-gateway:9142

--- a/charts/ocis/templates/storage-authmachine/deployment.yaml
+++ b/charts/ocis/templates/storage-authmachine/deployment.yaml
@@ -30,6 +30,10 @@ spec:
           imagePullPolicy: {{ .Values.image.pullPolicy }}
           command: ["ocis"]
           args: ["storage-auth-machine", "server"]
+          securityContext:
+            runAsNonRoot: true
+            runAsUser: 1000
+            readOnlyRootFilesystem: true
           env:
             - name: MICRO_REGISTRY
               value: kubernetes

--- a/charts/ocis/templates/storage-frontend/deployment.yaml
+++ b/charts/ocis/templates/storage-frontend/deployment.yaml
@@ -61,9 +61,9 @@ spec:
               value: "storage-sharing:9150"
 
             - name: STORAGE_JWT_SECRET
-              value: "{{ $.Values.secrets.jwt }}"
+              secretRef: jwtsecret
             - name: STORAGE_TRANSFER_SECRET
-              value: "{{ $.Values.secrets.transfer }}"
+              secretRef: transfersecret
 
             - name: STORAGE_AUTH_MACHINE_AUTH_API_KEY
               value: "{{ $.Values.secrets.machineAuth }}"

--- a/charts/ocis/templates/storage-frontend/deployment.yaml
+++ b/charts/ocis/templates/storage-frontend/deployment.yaml
@@ -30,6 +30,10 @@ spec:
           imagePullPolicy: {{ .Values.image.pullPolicy }}
           command: ["ocis"]
           args: ["storage-frontend", "server"]
+          securityContext:
+            runAsNonRoot: true
+            runAsUser: 1000
+            readOnlyRootFilesystem: true
           env:
             - name: MICRO_REGISTRY
               value: kubernetes

--- a/charts/ocis/templates/storage-gateway/deployment.yaml
+++ b/charts/ocis/templates/storage-gateway/deployment.yaml
@@ -30,6 +30,10 @@ spec:
           imagePullPolicy: {{ .Values.image.pullPolicy }}
           command: ["ocis"]
           args: ["storage-gateway", "server"]
+          securityContext:
+            runAsNonRoot: true
+            runAsUser: 1000
+            readOnlyRootFilesystem: true
           env:
             - name: MICRO_REGISTRY
               value: kubernetes

--- a/charts/ocis/templates/storage-gateway/deployment.yaml
+++ b/charts/ocis/templates/storage-gateway/deployment.yaml
@@ -79,9 +79,10 @@ spec:
               value: "settings:9191"
 
             - name: STORAGE_JWT_SECRET
-              value: "{{ $.Values.secrets.jwt }}"
+              secretRef: jwtsecret
             - name: STORAGE_TRANSFER_SECRET
-              value: "{{ $.Values.secrets.transfer }}"
+              secretRef: transfersecret
+
           resources: {{ toYaml .Values.resources | nindent 12 }}
           ports:
             - name: grpc

--- a/charts/ocis/templates/storage-groupprovider/deployment.yaml
+++ b/charts/ocis/templates/storage-groupprovider/deployment.yaml
@@ -30,6 +30,10 @@ spec:
           imagePullPolicy: {{ .Values.image.pullPolicy }}
           command: ["ocis"]
           args: ["storage-groupprovider", "server"]
+          securityContext:
+            runAsNonRoot: true
+            runAsUser: 1000
+            readOnlyRootFilesystem: true
           env:
             - name: MICRO_REGISTRY
               value: kubernetes

--- a/charts/ocis/templates/storage-groupprovider/deployment.yaml
+++ b/charts/ocis/templates/storage-groupprovider/deployment.yaml
@@ -63,7 +63,7 @@ spec:
               value: "https://{{ $.Values.externalDomain }}"
 
             - name: STORAGE_JWT_SECRET
-              value: "{{ $.Values.secrets.jwt }}"
+              secretRef: jwtsecret
 
             - name: REVA_GATEWAY
               value: storage-gateway:9142

--- a/charts/ocis/templates/storage-metadata/deployment.yaml
+++ b/charts/ocis/templates/storage-metadata/deployment.yaml
@@ -65,9 +65,9 @@ spec:
               value: "http://storage-metadata:9216/data"
 
             - name: OCIS_JWT_SECRET
-              value: "{{ $.Values.secrets.jwt }}"
+              secretRef: jwtsecret
             - name: STORAGE_TRANSFER_SECRET
-              value: "{{ $.Values.secrets.transfer }}"
+              secretRef: transfersecret
 
             - name: STORAGE_PERMISSIONS_ENDPOINT
               value: "settings:9191"

--- a/charts/ocis/templates/storage-metadata/deployment.yaml
+++ b/charts/ocis/templates/storage-metadata/deployment.yaml
@@ -40,6 +40,10 @@ spec:
           imagePullPolicy: {{ .Values.image.pullPolicy }}
           command: ["ocis"]
           args: ["storage-metadata", "server"]
+          securityContext:
+            runAsNonRoot: true
+            runAsUser: 1000
+            readOnlyRootFilesystem: true
           env:
             - name: MICRO_REGISTRY
               value: kubernetes

--- a/charts/ocis/templates/storage-publiclink/deployment.yaml
+++ b/charts/ocis/templates/storage-publiclink/deployment.yaml
@@ -51,7 +51,7 @@ spec:
               value: "storage-shares:9178"
 
             - name: STORAGE_JWT_SECRET
-              value: "{{ $.Values.secrets.jwt }}"
+              secretRef: jwtsecret
 
             - name: REVA_GATEWAY
               value: storage-gateway:9142

--- a/charts/ocis/templates/storage-publiclink/deployment.yaml
+++ b/charts/ocis/templates/storage-publiclink/deployment.yaml
@@ -30,6 +30,10 @@ spec:
           imagePullPolicy: {{ .Values.image.pullPolicy }}
           command: ["ocis"]
           args: ["storage-public-link", "server"]
+          securityContext:
+            runAsNonRoot: true
+            runAsUser: 1000
+            readOnlyRootFilesystem: true
           env:
             - name: MICRO_REGISTRY
               value: kubernetes

--- a/charts/ocis/templates/storage-shares/deployment.yaml
+++ b/charts/ocis/templates/storage-shares/deployment.yaml
@@ -54,9 +54,9 @@ spec:
               value: "storage-sharing:9150"
 
             - name: STORAGE_JWT_SECRET
-              value: "{{ $.Values.secrets.jwt }}"
+              secretRef: jwtsecret
             - name: STORAGE_TRANSFER_SECRET
-              value: "{{ $.Values.secrets.transfer }}"
+              secretRef: transfersecret
 
             - name: REVA_GATEWAY
               value: storage-gateway:9142

--- a/charts/ocis/templates/storage-shares/deployment.yaml
+++ b/charts/ocis/templates/storage-shares/deployment.yaml
@@ -30,6 +30,10 @@ spec:
           imagePullPolicy: {{ .Values.image.pullPolicy }}
           command: ["ocis"]
           args: ["storage-shares", "server"]
+          securityContext:
+            runAsNonRoot: true
+            runAsUser: 1000
+            readOnlyRootFilesystem: true
           env:
             - name: MICRO_REGISTRY
               value: kubernetes

--- a/charts/ocis/templates/storage-sharing/deployment.yaml
+++ b/charts/ocis/templates/storage-sharing/deployment.yaml
@@ -40,6 +40,10 @@ spec:
           imagePullPolicy: {{ .Values.image.pullPolicy }}
           command: ["ocis"]
           args: ["storage-sharing", "server"]
+          securityContext:
+            runAsNonRoot: true
+            runAsUser: 1000
+            readOnlyRootFilesystem: true
           env:
             - name: MICRO_REGISTRY
               value: kubernetes

--- a/charts/ocis/templates/storage-sharing/deployment.yaml
+++ b/charts/ocis/templates/storage-sharing/deployment.yaml
@@ -74,7 +74,7 @@ spec:
               value: nats:9233
 
             - name: STORAGE_JWT_SECRET
-              value: "{{ $.Values.secrets.jwt }}"
+              secretRef: jwtsecret
             - name: REVA_GATEWAY
               value: "storage-gateway:9142"
           resources: {{ toYaml .Values.resources | nindent 12 }}

--- a/charts/ocis/templates/storage-userprovider/deployment.yaml
+++ b/charts/ocis/templates/storage-userprovider/deployment.yaml
@@ -63,7 +63,7 @@ spec:
               value: "https://{{ $.Values.externalDomain }}"
 
             - name: STORAGE_JWT_SECRET
-              value: "{{ $.Values.secrets.jwt }}"
+              secretRef: jwtsecret
 
             - name: REVA_GATEWAY
               value: storage-gateway:9142

--- a/charts/ocis/templates/storage-userprovider/deployment.yaml
+++ b/charts/ocis/templates/storage-userprovider/deployment.yaml
@@ -30,6 +30,10 @@ spec:
           imagePullPolicy: {{ .Values.image.pullPolicy }}
           command: ["ocis"]
           args: ["storage-userprovider", "server"]
+          securityContext:
+            runAsNonRoot: true
+            runAsUser: 1000
+            readOnlyRootFilesystem: true
           env:
             - name: MICRO_REGISTRY
               value: kubernetes

--- a/charts/ocis/templates/storage-users/deployment.yaml
+++ b/charts/ocis/templates/storage-users/deployment.yaml
@@ -40,6 +40,10 @@ spec:
           imagePullPolicy: {{ .Values.image.pullPolicy }}
           command: ["ocis"]
           args: ["storage-users", "server"]
+          securityContext:
+            runAsNonRoot: true
+            runAsUser: 1000
+            readOnlyRootFilesystem: true
           env:
             - name: MICRO_REGISTRY
               value: kubernetes

--- a/charts/ocis/templates/storage-users/deployment.yaml
+++ b/charts/ocis/templates/storage-users/deployment.yaml
@@ -92,9 +92,9 @@ spec:
               value: "settings:9191"
 
             - name: STORAGE_JWT_SECRET
-              value: "{{ $.Values.secrets.jwt }}"
+              secretRef: jwtsecret
             - name: STORAGE_TRANSFER_SECRET
-              value: "{{ $.Values.secrets.transfer }}"
+              secretRef: transfersecret
 
             - name: REVA_GATEWAY
               value: "storage-gateway:9142"

--- a/charts/ocis/templates/store/deployment.yaml
+++ b/charts/ocis/templates/store/deployment.yaml
@@ -44,6 +44,10 @@ spec:
           imagePullPolicy: {{ .Values.image.pullPolicy }}
           command: ["ocis"]
           args: ["store", "server"]
+          securityContext:
+            runAsNonRoot: true
+            runAsUser: 1000
+            readOnlyRootFilesystem: true
           env:
             - name: MICRO_REGISTRY
               value: kubernetes

--- a/charts/ocis/templates/thumbnails/deployment.yaml
+++ b/charts/ocis/templates/thumbnails/deployment.yaml
@@ -42,6 +42,10 @@ spec:
           imagePullPolicy: {{ .Values.image.pullPolicy }}
           command: ["ocis"]
           args: ["thumbnails", "server"]
+          securityContext:
+            runAsNonRoot: true
+            runAsUser: 1000
+            readOnlyRootFilesystem: true
           env:
             - name: MICRO_REGISTRY
               value: kubernetes

--- a/charts/ocis/templates/web/deployment.yaml
+++ b/charts/ocis/templates/web/deployment.yaml
@@ -30,6 +30,10 @@ spec:
           imagePullPolicy: {{ .Values.image.pullPolicy }}
           command: ["ocis"]
           args: ["web", "server"]
+          securityContext:
+            runAsNonRoot: true
+            runAsUser: 1000
+            readOnlyRootFilesystem: true
           env:
             - name: MICRO_REGISTRY
               value: kubernetes

--- a/charts/ocis/templates/webdav/deployment.yaml
+++ b/charts/ocis/templates/webdav/deployment.yaml
@@ -30,6 +30,10 @@ spec:
           imagePullPolicy: {{ .Values.image.pullPolicy }}
           command: ["ocis"]
           args: ["webdav", "server"]
+          securityContext:
+            runAsNonRoot: true
+            runAsUser: 1000
+            readOnlyRootFilesystem: true
           env:
             - name: MICRO_REGISTRY
               value: kubernetes

--- a/charts/ocis/values.yaml
+++ b/charts/ocis/values.yaml
@@ -134,14 +134,13 @@ autoscaling:
 
 # currently resources are globally applied to all services if
 
-resources: {}
-#  limits:
-#    cpu: 100m
-#    memory: 128Mi
-#  requests:
-#    cpu: 100m
-#    memory: 128Mi
-
+resources: 
+  limits:
+    cpu: 100m
+    memory: 128Mi
+  requests:
+    cpu: 100m
+    memory: 128Mi
 
 # Include arbitrary resources, eg. config maps or a cer-manager issuer (see example below)
 extraResources: []


### PR DESCRIPTION
This PR adds a rudimentary ci to the repo which enables linting and validation of the contained helm-charts. 
As a result the ocis chart needed to be refactored.