### PR TITLE
fix settings service

### DIFF
--- a/charts/ocis/templates/settings/deployment.yaml
+++ b/charts/ocis/templates/settings/deployment.yaml
@@ -56,7 +56,7 @@ spec:
               value: storage-gateway:9142
             - name: STORAGE_GRPC_ADDR
               value: storage-metadata:9215
-            - name: METADATA_SERVICE_USER_IDP
+            - name: METADATA_SERVICE_USER_IDP # TODO: https://github.com/owncloud/ocis-charts/issues/35
               value: "https://{{ $.Values.externalDomain }}"
           envFrom:
             - secretRef:

--- a/charts/ocis/templates/settings/deployment.yaml
+++ b/charts/ocis/templates/settings/deployment.yaml
@@ -56,6 +56,8 @@ spec:
               value: storage-gateway:9142
             - name: STORAGE_GRPC_ADDR
               value: storage-metadata:9215
+            - name: METADATA_SERVICE_USER_IDP
+              value: "https://{{ $.Values.externalDomain }}"
           envFrom:
             - secretRef:
                 name: jwt-secret


### PR DESCRIPTION
fixes the settings service's connection to the metadata service which failed before with:

`{"level":"error","service":"ocis","error":"error: not found: stat: error: not found: f1bdd61a-da7c-49fc-8203-0558109d1b4f/settings","time":"2022-03-22T18:10:53.540848549Z","message":"error initializing metadata client"}`