### PR TITLE
update ocis digest to a more recent version

### DIFF
--- a/charts/ocis/templates/storage-users/deployment.yaml
+++ b/charts/ocis/templates/storage-users/deployment.yaml
@@ -93,6 +93,10 @@ spec:
               value: "{{ $.Values.storageUsers.storageBackend.driverConfig.s3ng.bucket }}"
             {{- end }}
 
+            # events
+            - name: STORAGE_SHARING_EVENTS_ADDRESS
+              value: nats:9233
+
             # permissions middleware
             - name: STORAGE_PERMISSIONS_ENDPOINT
               value: "settings:9191"

--- a/charts/ocis/values.yaml
+++ b/charts/ocis/values.yaml
@@ -1,7 +1,7 @@
 image:
   repository: owncloud/ocis
   tag: "latest"
-  sha: "a49a106802ebe44e1cfdc04ca71661be104d87224f0e6fd8e2477bc3bb078b92"
+  sha: "84310ec566ad850086d9cc836e57e2306ca6c07ab47af5bf5475491afdb50086"
   pullPolicy: IfNotPresent
 
 logging:

--- a/charts/ocis/values.yaml
+++ b/charts/ocis/values.yaml
@@ -1,7 +1,7 @@
 image:
   repository: owncloud/ocis
-  tag: "latest"
-  sha: "84310ec566ad850086d9cc836e57e2306ca6c07ab47af5bf5475491afdb50086"
+  tag: "1.19.1"
+  sha: "3fdde158afabac6ec540756f651a59892baf2c9a2b2b03e82fddeb34fa83374b"
   pullPolicy: IfNotPresent
 
 logging:


### PR DESCRIPTION
updates oCIS digest to a more recent version (from https://github.com/owncloud/ocis/commit/c7b23e19 to [1.19.1](https://github.com/owncloud/ocis/tree/v1.19.1))