### PR TITLE
introduce OCDAV_MACHINE_AUTH_API_KEY

### DIFF
--- a/charts/ocis/templates/ocdav/deployment.yaml
+++ b/charts/ocis/templates/ocdav/deployment.yaml
@@ -64,6 +64,12 @@ spec:
                   name: {{ .Values.secretRefs.jwtSecretRef }}
                   key: jwt-secret
 
+            - name: OCDAV_MACHINE_AUTH_API_KEY
+              valueFrom:
+                secretKeyRef:
+                  name: {{ .Values.secretRefs.machineAuthApiKeySecretRef }}
+                  key: machine-auth-api-key
+
           resources: {{ toYaml .Values.resources | nindent 12 }}
           ports:
             - name: http


### PR DESCRIPTION
Was introduced by owncloud/ocis#4076 and is needed for 2.0.0-beta.5 (or any current master)