### PR TITLE
Update adoc xref output

### DIFF
--- a/charts/ocis/docs/templates/values-desc-table.adoc.gotmpl
+++ b/charts/ocis/docs/templates/values-desc-table.adoc.gotmpl
@@ -13,8 +13,7 @@ a| [subs=-attributes]
 +{{ $value.Type }}+
 a| [subs=-attributes]
 {{default $value.Default $value.AutoDefault}}
-a| [subs=-attributes]
-{{ regexReplaceAll "ref:([a-zA-Z0-9 ]*)#([a-zA-Z0-9-]*)" (default $value.Description $value.AutoDescription) "xref:${2}[${1}]" }}
+| {{ regexReplaceAll "ref:([a-zA-Z0-9 ]*)#([a-zA-Z0-9-]*)" (default $value.Description $value.AutoDescription) "xref:{${2}}[${1}]" }}
 
 {{- end }}
 |===

--- a/charts/ocis/docs/templates/values.adoc.yaml.gotmpl
+++ b/charts/ocis/docs/templates/values.adoc.yaml.gotmpl
@@ -1,3 +1,3 @@
 {{- range (file.Read "charts/ocis/values.yaml" | strings.Split "\n") }}
-{{ regexp.Replace "ref:([a-zA-Z0-9 ]*)#([a-zA-Z0-9-]*)" "xref:${2}[${1}]" . }}
+{{ regexp.Replace "ref:([a-zA-Z0-9 ]*)#([a-zA-Z0-9-]*)" "xref:{${2}}[${1}]" . }}
 {{- end }}


### PR DESCRIPTION
During writing the Kubernetes/Helm Chart documentation, I needed to "virtualize" the `xref` target.

* The old hardcoded result string was `xref:secrets[Secrets]`
* The new virualized result string is `xref:{secrets}[Secrets]`

As a consequence, the documentation needs a attribute set which defines the final target for `secrets`. This is already implemented and looks like: 
`secrets: deployment/container/orchestration/orchestration.adoc#secrets`

Another consequence is, that the table definition for that cell needs to allow attributes.

**NOTE:** if in the source `values.yaml` file in field description a content like `{text}` is needed, this text element needs to be either written as `{ text }` or escaped `\{text}`.

Background: the source files are quite long and make the document hard to read. Therefore an own page is greated that includes the source file, gets linked and is opened in a new window when clicked. Now, when clicking on the link in the description, this link needs to be resolved properly.

Request for help, pls check if the added curly braces are properly used.