### PR TITLE
bring back the chownInitContainer and introduce fsGroupChangePolicy option

### DIFF
--- a/charts/ocis/README.md
+++ b/charts/ocis/README.md
@@ -160,10 +160,12 @@ This chart only supports following oCIS versions:
 | secretRefs.thumbnailsSecretRef | string | `"thumbnails-transfer-secret"` | Reference to an existing thumbnails transfer secret (see [Secrets](#secrets)) |
 | secretRefs.transferSecretSecretRef | string | `"transfer-secret"` | Reference to an existing transfer secret (see [Secrets](#secrets)) |
 | securityContext.fsGroup | int | `1000` | File system group for all volumes. |
+| securityContext.fsGroupChangePolicy | string | `"OnRootMismatch"` | File system group change policy for all volumes. Possible values "Always" and "OnRootMismatch". |
 | securityContext.runAsGroup | int | `1000` | Group ID that all processes within any containers will run with. |
 | securityContext.runAsUser | int | `1000` | User ID that all processes within any containers will run with. |
 | services.idm.persistence.accessModes | list | `["ReadWriteMany"]` | Persistent volume access modes. Needs to be `["ReadWriteMany"]` when scaling this service beyond one instance. |
 | services.idm.persistence.annotations | object | `{}` | Persistent volume annotations. |
+| services.idm.persistence.chownInitContainer | bool | `false` | Enables a initContainer to chown the volume. The initContainer is run as root. This is not needed if the driver applies the fsGroup from the securityContext. |
 | services.idm.persistence.enabled | bool | `false` | Enables persistence. Needs to be enabled on production installations. If not enabled, pod restarts will lead to data loss. Also scaling this service beyond one instance is not possible if the service instances don't share the same storage. |
 | services.idm.persistence.existingClaim | string | `nil` | Use an existing PersistentVolumeClaim for persistence. |
 | services.idm.persistence.finalizers | list | `["kubernetes.io/pvc-protection"]` | Persistent volume finalizers. |
@@ -172,6 +174,7 @@ This chart only supports following oCIS versions:
 | services.idm.persistence.storageClassName | string | `nil` | Storage class to use. Uses the default storage class if not set. |
 | services.nats.persistence.accessModes | list | `["ReadWriteMany"]` | Persistent volume access modes. Needs to be `["ReadWriteMany"]` when scaling this service beyond one instance. |
 | services.nats.persistence.annotations | object | `{}` | Persistent volume annotations. |
+| services.nats.persistence.chownInitContainer | bool | `false` | Enables a initContainer to chown the volume. The initContainer is run as root. This is not needed if the driver applies the fsGroup from the securityContext. |
 | services.nats.persistence.enabled | bool | `false` | Enables persistence. Needs to be enabled on production installations. If not enabled, pod restarts will lead to data loss. Also scaling this service beyond one instance is not possible if the service instances don't share the same storage. |
 | services.nats.persistence.existingClaim | string | `nil` | Use an existing PersistentVolumeClaim for persistence. |
 | services.nats.persistence.finalizers | list | `["kubernetes.io/pvc-protection"]` | Persistent volume finalizers. |
@@ -180,6 +183,7 @@ This chart only supports following oCIS versions:
 | services.nats.persistence.storageClassName | string | `nil` | Storage class to use. Uses the default storage class if not set. |
 | services.search.persistence.accessModes | list | `["ReadWriteMany"]` | Persistent volume access modes. Needs to be `["ReadWriteMany"]` when scaling this service beyond one instance. |
 | services.search.persistence.annotations | object | `{}` | Persistent volume annotations. |
+| services.search.persistence.chownInitContainer | bool | `false` | Enables a initContainer to chown the volume. The initContainer is run as root. This is not needed if the driver applies the fsGroup from the securityContext. |
 | services.search.persistence.enabled | bool | `false` | Enables persistence. Needs to be enabled on production installations. If not enabled, pod restarts will lead to data loss. Also scaling this service beyond one instance is not possible if the service instances don't share the same storage. |
 | services.search.persistence.existingClaim | string | `nil` | Use an existing PersistentVolumeClaim for persistence. |
 | services.search.persistence.finalizers | list | `["kubernetes.io/pvc-protection"]` | Persistent volume finalizers. |
@@ -188,6 +192,7 @@ This chart only supports following oCIS versions:
 | services.search.persistence.storageClassName | string | `nil` | Storage class to use. Uses the default storage class if not set. |
 | services.storageSystem.persistence.accessModes | list | `["ReadWriteMany"]` | Persistent volume access modes. Needs to be `["ReadWriteMany"]` when scaling this service beyond one instance. |
 | services.storageSystem.persistence.annotations | object | `{}` | Persistent volume annotations. |
+| services.storageSystem.persistence.chownInitContainer | bool | `false` | Enables a initContainer to chown the volume. The initContainer is run as root. This is not needed if the driver applies the fsGroup from the securityContext. |
 | services.storageSystem.persistence.enabled | bool | `false` | Enables persistence. Needs to be enabled on production installations. If not enabled, pod restarts will lead to data loss. Also scaling this service beyond one instance is not possible if the service instances don't share the same storage. |
 | services.storageSystem.persistence.existingClaim | string | `nil` | Use an existing PersistentVolumeClaim for persistence. |
 | services.storageSystem.persistence.finalizers | list | `["kubernetes.io/pvc-protection"]` | Persistent volume finalizers. |
@@ -196,6 +201,7 @@ This chart only supports following oCIS versions:
 | services.storageSystem.persistence.storageClassName | string | `nil` | Storage class to use. Uses the default storage class if not set. |
 | services.storageUsers.persistence.accessModes | list | `["ReadWriteMany"]` | Persistent volume access modes. Needs to be `["ReadWriteMany"]` when scaling this service beyond one instance. |
 | services.storageUsers.persistence.annotations | object | `{}` | Persistent volume annotations. |
+| services.storageUsers.persistence.chownInitContainer | bool | `false` | Enables a initContainer to chown the volume. The initContainer is run as root. This is not needed if the driver applies the fsGroup from the securityContext. |
 | services.storageUsers.persistence.enabled | bool | `false` | Enables persistence. Needs to be enabled on production installations. If not enabled, pod restarts will lead to data loss. Also scaling this service beyond one instance is not possible if the service instances don't share the same storage. |
 | services.storageUsers.persistence.existingClaim | string | `nil` | Use an existing PersistentVolumeClaim for persistence. |
 | services.storageUsers.persistence.finalizers | list | `["kubernetes.io/pvc-protection"]` | Persistent volume finalizers. |
@@ -210,6 +216,7 @@ This chart only supports following oCIS versions:
 | services.storageUsers.storageBackend.driverConfig.s3ng.secretKey | string | `"lorem-ipsum"` | S3 secret key to use for the S3NG driver. Only used if driver is set to "s3ng". |
 | services.store.persistence.accessModes | list | `["ReadWriteMany"]` | Persistent volume access modes. Needs to be `["ReadWriteMany"]` when scaling this service beyond one instance. |
 | services.store.persistence.annotations | object | `{}` | Persistent volume annotations. |
+| services.store.persistence.chownInitContainer | bool | `false` | Enables a initContainer to chown the volume. The initContainer is run as root. This is not needed if the driver applies the fsGroup from the securityContext. |
 | services.store.persistence.enabled | bool | `false` | Enables persistence. Needs to be enabled on production installations. If not enabled, pod restarts will lead to data loss. Also scaling this service beyond one instance is not possible if the service instances don't share the same storage. |
 | services.store.persistence.existingClaim | string | `nil` | Use an existing PersistentVolumeClaim for persistence. |
 | services.store.persistence.finalizers | list | `["kubernetes.io/pvc-protection"]` | Persistent volume finalizers. |
@@ -218,6 +225,7 @@ This chart only supports following oCIS versions:
 | services.store.persistence.storageClassName | string | `nil` | Storage class to use. Uses the default storage class if not set. |
 | services.thumbnails.persistence.accessModes | list | `["ReadWriteMany"]` | Persistent volume access modes. Needs to be `["ReadWriteMany"]` when scaling this service beyond one instance or persistence needs to be disabled. |
 | services.thumbnails.persistence.annotations | object | `{}` | Persistent volume annotations. |
+| services.thumbnails.persistence.chownInitContainer | bool | `false` | Enables a initContainer to chown the volume. The initContainer is run as root. This is not needed if the driver applies the fsGroup from the securityContext. |
 | services.thumbnails.persistence.enabled | bool | `false` | Enables persistence. Is recommended to be enabled on production installations. If enabled, generated thumbnails are cached on this volume and available across pod restarts and service instances. If not enabled, thumbnail generation might lead to higher CPU usage. |
 | services.thumbnails.persistence.existingClaim | string | `nil` | Use an existing PersistentVolumeClaim for persistence. |
 | services.thumbnails.persistence.finalizers | list | `[]` | Persistent volume finalizers. |

--- a/charts/ocis/docs/values-desc-table.adoc
+++ b/charts/ocis/docs/values-desc-table.adoc
@@ -324,6 +324,12 @@ a| [subs=-attributes]
 a| [subs=-attributes]
 `1000`
 | File system group for all volumes.
+| securityContext.fsGroupChangePolicy
+a| [subs=-attributes]
++string+
+a| [subs=-attributes]
+`"OnRootMismatch"`
+| File system group change policy for all volumes. Possible values "Always" and "OnRootMismatch".
 | securityContext.runAsGroup
 a| [subs=-attributes]
 +int+
@@ -348,6 +354,12 @@ a| [subs=-attributes]
 a| [subs=-attributes]
 `{}`
 | Persistent volume annotations.
+| services.idm.persistence.chownInitContainer
+a| [subs=-attributes]
++bool+
+a| [subs=-attributes]
+`false`
+| Enables a initContainer to chown the volume. The initContainer is run as root. This is not needed if the driver applies the fsGroup from the securityContext.
 | services.idm.persistence.enabled
 a| [subs=-attributes]
 +bool+
@@ -396,6 +408,12 @@ a| [subs=-attributes]
 a| [subs=-attributes]
 `{}`
 | Persistent volume annotations.
+| services.nats.persistence.chownInitContainer
+a| [subs=-attributes]
++bool+
+a| [subs=-attributes]
+`false`
+| Enables a initContainer to chown the volume. The initContainer is run as root. This is not needed if the driver applies the fsGroup from the securityContext.
 | services.nats.persistence.enabled
 a| [subs=-attributes]
 +bool+
@@ -444,6 +462,12 @@ a| [subs=-attributes]
 a| [subs=-attributes]
 `{}`
 | Persistent volume annotations.
+| services.search.persistence.chownInitContainer
+a| [subs=-attributes]
++bool+
+a| [subs=-attributes]
+`false`
+| Enables a initContainer to chown the volume. The initContainer is run as root. This is not needed if the driver applies the fsGroup from the securityContext.
 | services.search.persistence.enabled
 a| [subs=-attributes]
 +bool+
@@ -492,6 +516,12 @@ a| [subs=-attributes]
 a| [subs=-attributes]
 `{}`
 | Persistent volume annotations.
+| services.storageSystem.persistence.chownInitContainer
+a| [subs=-attributes]
++bool+
+a| [subs=-attributes]
+`false`
+| Enables a initContainer to chown the volume. The initContainer is run as root. This is not needed if the driver applies the fsGroup from the securityContext.
 | services.storageSystem.persistence.enabled
 a| [subs=-attributes]
 +bool+
@@ -540,6 +570,12 @@ a| [subs=-attributes]
 a| [subs=-attributes]
 `{}`
 | Persistent volume annotations.
+| services.storageUsers.persistence.chownInitContainer
+a| [subs=-attributes]
++bool+
+a| [subs=-attributes]
+`false`
+| Enables a initContainer to chown the volume. The initContainer is run as root. This is not needed if the driver applies the fsGroup from the securityContext.
 | services.storageUsers.persistence.enabled
 a| [subs=-attributes]
 +bool+
@@ -624,6 +660,12 @@ a| [subs=-attributes]
 a| [subs=-attributes]
 `{}`
 | Persistent volume annotations.
+| services.store.persistence.chownInitContainer
+a| [subs=-attributes]
++bool+
+a| [subs=-attributes]
+`false`
+| Enables a initContainer to chown the volume. The initContainer is run as root. This is not needed if the driver applies the fsGroup from the securityContext.
 | services.store.persistence.enabled
 a| [subs=-attributes]
 +bool+
@@ -672,6 +714,12 @@ a| [subs=-attributes]
 a| [subs=-attributes]
 `{}`
 | Persistent volume annotations.
+| services.thumbnails.persistence.chownInitContainer
+a| [subs=-attributes]
++bool+
+a| [subs=-attributes]
+`false`
+| Enables a initContainer to chown the volume. The initContainer is run as root. This is not needed if the driver applies the fsGroup from the securityContext.
 | services.thumbnails.persistence.enabled
 a| [subs=-attributes]
 +bool+

--- a/charts/ocis/docs/values.adoc.yaml
+++ b/charts/ocis/docs/values.adoc.yaml
@@ -135,6 +135,9 @@ secretRefs:
 securityContext:
   # -- File system group for all volumes.
   fsGroup: 1000
+  # -- File system group change policy for all volumes.
+  # Possible values "Always" and "OnRootMismatch".
+  fsGroupChangePolicy: "OnRootMismatch"
   # -- User ID that all processes within any containers will run with.
   runAsUser: 1000
   # -- Group ID that all processes within any containers will run with.
@@ -211,6 +214,10 @@ services:
       # If not enabled, pod restarts will lead to data loss.
       # Also scaling this service beyond one instance is not possible if the service instances don't share the same storage.
       enabled: false
+      # -- Enables a initContainer to chown the volume.
+      # The initContainer is run as root.
+      # This is not needed if the driver applies the fsGroup from the securityContext.
+      chownInitContainer: false
       # -- Storage class to use.
       # Uses the default storage class if not set.
       storageClassName:
@@ -254,6 +261,10 @@ services:
       # If not enabled, pod restarts will lead to data loss.
       # Also scaling this service beyond one instance is not possible if the service instances don't share the same storage.
       enabled: false
+      # -- Enables a initContainer to chown the volume.
+      # The initContainer is run as root.
+      # This is not needed if the driver applies the fsGroup from the securityContext.
+      chownInitContainer: false
       # -- Storage class to use.
       # Uses the default storage class if not set.
       storageClassName:
@@ -280,6 +291,10 @@ services:
       # If not enabled, pod restarts will lead to data loss.
       # Also scaling this service beyond one instance is not possible if the service instances don't share the same storage.
       enabled: false
+      # -- Enables a initContainer to chown the volume.
+      # The initContainer is run as root.
+      # This is not needed if the driver applies the fsGroup from the securityContext.
+      chownInitContainer: false
       # -- Storage class to use.
       # Uses the default storage class if not set.
       storageClassName:
@@ -306,6 +321,10 @@ services:
       # If enabled, generated thumbnails are cached on this volume and available across pod restarts and service instances.
       # If not enabled, thumbnail generation might lead to higher CPU usage.
       enabled: false
+      # -- Enables a initContainer to chown the volume.
+      # The initContainer is run as root.
+      # This is not needed if the driver applies the fsGroup from the securityContext.
+      chownInitContainer: false
       # -- Storage class to use.
       # Uses the default storage class if not set.
       storageClassName:
@@ -331,6 +350,10 @@ services:
       # If not enabled, pod restarts will lead to data loss.
       # Also scaling this service beyond one instance is not possible if the service instances don't share the same storage.
       enabled: false
+      # -- Enables a initContainer to chown the volume.
+      # The initContainer is run as root.
+      # This is not needed if the driver applies the fsGroup from the securityContext.
+      chownInitContainer: false
       # -- Storage class to use.
       # Uses the default storage class if not set.
       storageClassName:
@@ -357,6 +380,10 @@ services:
       # If not enabled, pod restarts will lead to data loss.
       # Also scaling this service beyond one instance is not possible if the service instances don't share the same storage.
       enabled: false
+      # -- Enables a initContainer to chown the volume.
+      # The initContainer is run as root.
+      # This is not needed if the driver applies the fsGroup from the securityContext.
+      chownInitContainer: false
       # -- Storage class to use.
       # Uses the default storage class if not set.
       storageClassName:
@@ -383,6 +410,10 @@ services:
       # If not enabled, pod restarts will lead to data loss.
       # Also scaling this service beyond one instance is not possible if the service instances don't share the same storage.
       enabled: false
+      # -- Enables a initContainer to chown the volume.
+      # The initContainer is run as root.
+      # This is not needed if the driver applies the fsGroup from the securityContext.
+      chownInitContainer: false
       # -- Storage class to use.
       # Uses the default storage class if not set.
       storageClassName:

--- a/charts/ocis/templates/app-provider/deployment.yaml
+++ b/charts/ocis/templates/app-provider/deployment.yaml
@@ -25,6 +25,7 @@ spec:
     spec:
       securityContext:
           fsGroup: {{ $.Values.securityContext.fsGroup }}
+          fsGroupChangePolicy: {{ $.Values.securityContext.fsGroupChangePolicy }}
       containers:
         - name:  app-provider-{{ regexReplaceAll "\\W+" (lower $officeSuite.name) "_" }}
           {{- if $.Values.image.sha }}

--- a/charts/ocis/templates/app-registry/deployment.yaml
+++ b/charts/ocis/templates/app-registry/deployment.yaml
@@ -22,6 +22,7 @@ spec:
     spec:
       securityContext:
           fsGroup: {{ .Values.securityContext.fsGroup }}
+          fsGroupChangePolicy: {{ .Values.securityContext.fsGroupChangePolicy }}
       containers:
         - name: app-registry
           {{- if .Values.image.sha }}

--- a/charts/ocis/templates/audit/deployment.yaml
+++ b/charts/ocis/templates/audit/deployment.yaml
@@ -23,6 +23,7 @@ spec:
     spec:
       securityContext:
           fsGroup: {{ .Values.securityContext.fsGroup }}
+          fsGroupChangePolicy: {{ .Values.securityContext.fsGroupChangePolicy }}
       containers:
         - name: audit
           {{- if .Values.image.sha }}

--- a/charts/ocis/templates/auth-basic/deployment.yaml
+++ b/charts/ocis/templates/auth-basic/deployment.yaml
@@ -23,6 +23,7 @@ spec:
     spec:
       securityContext:
           fsGroup: {{ .Values.securityContext.fsGroup }}
+          fsGroupChangePolicy: {{ .Values.securityContext.fsGroupChangePolicy }}
       containers:
         - name: auth-basic
           {{- if .Values.image.sha }}

--- a/charts/ocis/templates/auth-bearer/deployment.yaml
+++ b/charts/ocis/templates/auth-bearer/deployment.yaml
@@ -23,6 +23,7 @@ spec:
     spec:
       securityContext:
           fsGroup: {{ .Values.securityContext.fsGroup }}
+          fsGroupChangePolicy: {{ .Values.securityContext.fsGroupChangePolicy }}
       containers:
         - name: auth-bearer
           {{- if .Values.image.sha }}

--- a/charts/ocis/templates/auth-machine/deployment.yaml
+++ b/charts/ocis/templates/auth-machine/deployment.yaml
@@ -23,6 +23,7 @@ spec:
     spec:
       securityContext:
           fsGroup: {{ .Values.securityContext.fsGroup }}
+          fsGroupChangePolicy: {{ .Values.securityContext.fsGroupChangePolicy }}
       containers:
         - name: auth-machine
           {{- if .Values.image.sha }}

--- a/charts/ocis/templates/frontend/deployment.yaml
+++ b/charts/ocis/templates/frontend/deployment.yaml
@@ -23,6 +23,7 @@ spec:
     spec:
       securityContext:
           fsGroup: {{ .Values.securityContext.fsGroup }}
+          fsGroupChangePolicy: {{ .Values.securityContext.fsGroupChangePolicy }}
       containers:
         - name: frontend
           {{- if .Values.image.sha }}

--- a/charts/ocis/templates/gateway/deployment.yaml
+++ b/charts/ocis/templates/gateway/deployment.yaml
@@ -23,6 +23,7 @@ spec:
     spec:
       securityContext:
           fsGroup: {{ .Values.securityContext.fsGroup }}
+          fsGroupChangePolicy: {{ .Values.securityContext.fsGroupChangePolicy }}
       containers:
         - name: gateway
           {{- if .Values.image.sha }}

--- a/charts/ocis/templates/graph-explorer/deployment.yaml
+++ b/charts/ocis/templates/graph-explorer/deployment.yaml
@@ -23,6 +23,7 @@ spec:
     spec:
       securityContext:
           fsGroup: {{ .Values.securityContext.fsGroup }}
+          fsGroupChangePolicy: {{ .Values.securityContext.fsGroupChangePolicy }}
       containers:
         - name: graph-explorer
           {{- if .Values.image.sha }}

--- a/charts/ocis/templates/graph/deployment.yaml
+++ b/charts/ocis/templates/graph/deployment.yaml
@@ -23,6 +23,7 @@ spec:
     spec:
       securityContext:
           fsGroup: {{ .Values.securityContext.fsGroup }}
+          fsGroupChangePolicy: {{ .Values.securityContext.fsGroupChangePolicy }}
       containers:
         - name: graph
           {{- if .Values.image.sha }}

--- a/charts/ocis/templates/groups/deployment.yaml
+++ b/charts/ocis/templates/groups/deployment.yaml
@@ -23,6 +23,7 @@ spec:
     spec:
       securityContext:
           fsGroup: {{ .Values.securityContext.fsGroup }}
+          fsGroupChangePolicy: {{ .Values.securityContext.fsGroupChangePolicy }}
       containers:
         - name: groups
           {{- if .Values.image.sha }}

--- a/charts/ocis/templates/idm/deployment.yaml
+++ b/charts/ocis/templates/idm/deployment.yaml
@@ -20,7 +20,19 @@ spec:
     spec:
       securityContext:
           fsGroup: {{ .Values.securityContext.fsGroup }}
+          fsGroupChangePolicy: {{ .Values.securityContext.fsGroupChangePolicy }}
       initContainers:
+      {{- if and $.Values.services.idm.persistence.enabled $.Values.services.idm.persistence.chownInitContainer }}
+        - name: init-chown-data
+          image: busybox
+          securityContext:
+            runAsNonRoot: false
+            runAsUser: 0
+          command: ["chown", "-R", "{{ .Values.securityContext.runAsUser }}:{{ .Values.securityContext.runAsGroup }}", "/var/lib/ocis"]
+          volumeMounts:
+          - name: idm-data
+            mountPath: /var/lib/ocis
+      {{ end }}
         - name: init-dir #TODO: that should not be needed, needs fix in the idm service
           image: busybox:stable
           securityContext:

--- a/charts/ocis/templates/idp/deployment.yaml
+++ b/charts/ocis/templates/idp/deployment.yaml
@@ -25,6 +25,7 @@ spec:
     spec:
       securityContext:
           fsGroup: {{ .Values.securityContext.fsGroup }}
+          fsGroupChangePolicy: {{ .Values.securityContext.fsGroupChangePolicy }}
       containers:
         - name: idp
           {{- if .Values.image.sha }}

--- a/charts/ocis/templates/nats/deployment.yaml
+++ b/charts/ocis/templates/nats/deployment.yaml
@@ -20,6 +20,19 @@ spec:
     spec:
       securityContext:
           fsGroup: {{ .Values.securityContext.fsGroup }}
+          fsGroupChangePolicy: {{ .Values.securityContext.fsGroupChangePolicy }}
+      {{- if and $.Values.services.nats.persistence.enabled $.Values.services.nats.persistence.chownInitContainer }}
+      initContainers:
+        - name: init-chown-data
+          image: busybox
+          securityContext:
+            runAsNonRoot: false
+            runAsUser: 0
+          command: ["chown", "-R", "{{ .Values.securityContext.runAsUser }}:{{ .Values.securityContext.runAsGroup }}", "/var/lib/ocis"]
+          volumeMounts:
+          - name: nats-data
+            mountPath: /var/lib/ocis
+      {{ end }}
       containers:
         - name: nats
           {{- if .Values.image.sha }}

--- a/charts/ocis/templates/notifications/deployment.yaml
+++ b/charts/ocis/templates/notifications/deployment.yaml
@@ -24,6 +24,7 @@ spec:
     spec:
       securityContext:
           fsGroup: {{ .Values.securityContext.fsGroup }}
+          fsGroupChangePolicy: {{ .Values.securityContext.fsGroupChangePolicy }}
       containers:
         - name: notifications
           {{- if .Values.image.sha }}

--- a/charts/ocis/templates/ocdav/deployment.yaml
+++ b/charts/ocis/templates/ocdav/deployment.yaml
@@ -23,6 +23,7 @@ spec:
     spec:
       securityContext:
           fsGroup: {{ .Values.securityContext.fsGroup }}
+          fsGroupChangePolicy: {{ .Values.securityContext.fsGroupChangePolicy }}
       containers:
         - name: ocdav
           {{- if .Values.image.sha }}

--- a/charts/ocis/templates/ocs/deployment.yaml
+++ b/charts/ocis/templates/ocs/deployment.yaml
@@ -23,6 +23,7 @@ spec:
     spec:
       securityContext:
           fsGroup: {{ .Values.securityContext.fsGroup }}
+          fsGroupChangePolicy: {{ .Values.securityContext.fsGroupChangePolicy }}
       containers:
         - name: ocs
           {{- if .Values.image.sha }}

--- a/charts/ocis/templates/proxy/deployment.yaml
+++ b/charts/ocis/templates/proxy/deployment.yaml
@@ -25,6 +25,7 @@ spec:
     spec:
       securityContext:
           fsGroup: {{ .Values.securityContext.fsGroup }}
+          fsGroupChangePolicy: {{ .Values.securityContext.fsGroupChangePolicy }}
       containers:
         - name: proxy
           {{- if .Values.image.sha }}

--- a/charts/ocis/templates/search/deployment.yaml
+++ b/charts/ocis/templates/search/deployment.yaml
@@ -23,6 +23,19 @@ spec:
     spec:
       securityContext:
           fsGroup: {{ .Values.securityContext.fsGroup }}
+          fsGroupChangePolicy: {{ .Values.securityContext.fsGroupChangePolicy }}
+      {{- if and $.Values.services.search.persistence.enabled $.Values.services.search.persistence.chownInitContainer }}
+      initContainers:
+        - name: init-chown-data
+          image: busybox
+          securityContext:
+            runAsNonRoot: false
+            runAsUser: 0
+          command: ["chown", "-R", "{{ .Values.securityContext.runAsUser }}:{{ .Values.securityContext.runAsGroup }}", "/var/lib/ocis"]
+          volumeMounts:
+          - name: search-data
+            mountPath: /var/lib/ocis
+      {{ end }}
       containers:
         - name: search
           {{- if .Values.image.sha }}

--- a/charts/ocis/templates/settings/deployment.yaml
+++ b/charts/ocis/templates/settings/deployment.yaml
@@ -23,6 +23,7 @@ spec:
     spec:
       securityContext:
           fsGroup: {{ .Values.securityContext.fsGroup }}
+          fsGroupChangePolicy: {{ .Values.securityContext.fsGroupChangePolicy }}
       containers:
         - name: settings
           {{- if .Values.image.sha }}

--- a/charts/ocis/templates/sharing/deployment.yaml
+++ b/charts/ocis/templates/sharing/deployment.yaml
@@ -23,6 +23,7 @@ spec:
     spec:
       securityContext:
           fsGroup: {{ .Values.securityContext.fsGroup }}
+          fsGroupChangePolicy: {{ .Values.securityContext.fsGroupChangePolicy }}
       containers:
         - name: sharing
           {{- if .Values.image.sha }}

--- a/charts/ocis/templates/storage-publiclink/deployment.yaml
+++ b/charts/ocis/templates/storage-publiclink/deployment.yaml
@@ -23,6 +23,7 @@ spec:
     spec:
       securityContext:
           fsGroup: {{ .Values.securityContext.fsGroup }}
+          fsGroupChangePolicy: {{ .Values.securityContext.fsGroupChangePolicy }}
       containers:
         - name: storage-publiclink
           {{- if .Values.image.sha }}

--- a/charts/ocis/templates/storage-shares/deployment.yaml
+++ b/charts/ocis/templates/storage-shares/deployment.yaml
@@ -23,6 +23,7 @@ spec:
     spec:
       securityContext:
           fsGroup: {{ .Values.securityContext.fsGroup }}
+          fsGroupChangePolicy: {{ .Values.securityContext.fsGroupChangePolicy }}
       containers:
         - name: storage-shares
           {{- if .Values.image.sha }}

--- a/charts/ocis/templates/storage-system/deployment.yaml
+++ b/charts/ocis/templates/storage-system/deployment.yaml
@@ -23,6 +23,19 @@ spec:
     spec:
       securityContext:
           fsGroup: {{ .Values.securityContext.fsGroup }}
+          fsGroupChangePolicy: {{ .Values.securityContext.fsGroupChangePolicy }}
+      {{- if and $.Values.services.storageSystem.persistence.enabled $.Values.services.storageSystem.persistence.chownInitContainer }}
+      initContainers:
+        - name: init-chown-data
+          image: busybox
+          securityContext:
+            runAsNonRoot: false
+            runAsUser: 0
+          command: ["chown", "-R", "{{ .Values.securityContext.runAsUser }}:{{ .Values.securityContext.runAsGroup }}", "/var/lib/ocis"]
+          volumeMounts:
+          - name: storage-system-data
+            mountPath: /var/lib/ocis
+      {{ end }}
       containers:
         - name: storage-system
           {{- if .Values.image.sha }}

--- a/charts/ocis/templates/storage-users/deployment.yaml
+++ b/charts/ocis/templates/storage-users/deployment.yaml
@@ -23,6 +23,19 @@ spec:
     spec:
       securityContext:
           fsGroup: {{ .Values.securityContext.fsGroup }}
+          fsGroupChangePolicy: {{ .Values.securityContext.fsGroupChangePolicy }}
+      {{- if and $.Values.services.storageUsers.persistence.enabled $.Values.services.storageUsers.persistence.chownInitContainer }}
+      initContainers:
+        - name: init-chown-data
+          image: busybox
+          securityContext:
+            runAsNonRoot: false
+            runAsUser: 0
+          command: ["chown", "-R", "{{ .Values.securityContext.runAsUser }}:{{ .Values.securityContext.runAsGroup }}", "/var/lib/ocis"]
+          volumeMounts:
+          - name: storage-users-data
+            mountPath: /var/lib/ocis
+      {{ end }}
       containers:
         - name: storage-users
           {{- if .Values.image.sha }}

--- a/charts/ocis/templates/store/deployment.yaml
+++ b/charts/ocis/templates/store/deployment.yaml
@@ -25,6 +25,19 @@ spec:
     spec:
       securityContext:
           fsGroup: {{ .Values.securityContext.fsGroup }}
+          fsGroupChangePolicy: {{ .Values.securityContext.fsGroupChangePolicy }}
+      {{- if and $.Values.services.store.persistence.enabled $.Values.services.store.persistence.chownInitContainer }}
+      initContainers:
+        - name: init-chown-data
+          image: busybox
+          securityContext:
+            runAsNonRoot: false
+            runAsUser: 0
+          command: ["chown", "-R", "{{ .Values.securityContext.runAsUser }}:{{ .Values.securityContext.runAsGroup }}", "/var/lib/ocis"]
+          volumeMounts:
+          - name: store-data
+            mountPath: /var/lib/ocis
+      {{ end }}
       containers:
         - name: store
           {{- if .Values.image.sha }}

--- a/charts/ocis/templates/thumbnails/deployment.yaml
+++ b/charts/ocis/templates/thumbnails/deployment.yaml
@@ -23,6 +23,19 @@ spec:
     spec:
       securityContext:
           fsGroup: {{ .Values.securityContext.fsGroup }}
+          fsGroupChangePolicy: {{ .Values.securityContext.fsGroupChangePolicy }}
+      {{- if and $.Values.services.thumbnails.persistence.enabled $.Values.services.thumbnails.persistence.chownInitContainer }}
+      initContainers:
+        - name: init-chown-data
+          image: busybox
+          securityContext:
+            runAsNonRoot: false
+            runAsUser: 0
+          command: ["chown", "-R", "{{ .Values.securityContext.runAsUser }}:{{ .Values.securityContext.runAsGroup }}", "/var/lib/ocis"]
+          volumeMounts:
+          - name: thumbnails-data
+            mountPath: /var/lib/ocis
+      {{ end }}
       containers:
         - name: thumbnails
           {{- if .Values.image.sha }}

--- a/charts/ocis/templates/users/deployment.yaml
+++ b/charts/ocis/templates/users/deployment.yaml
@@ -23,6 +23,7 @@ spec:
     spec:
       securityContext:
           fsGroup: {{ .Values.securityContext.fsGroup }}
+          fsGroupChangePolicy: {{ .Values.securityContext.fsGroupChangePolicy }}
       containers:
         - name: users
           {{- if .Values.image.sha }}

--- a/charts/ocis/templates/web/deployment.yaml
+++ b/charts/ocis/templates/web/deployment.yaml
@@ -23,6 +23,7 @@ spec:
     spec:
       securityContext:
           fsGroup: {{ .Values.securityContext.fsGroup }}
+          fsGroupChangePolicy: {{ .Values.securityContext.fsGroupChangePolicy }}
       containers:
         - name: web
           {{- if .Values.image.sha }}

--- a/charts/ocis/templates/webdav/deployment.yaml
+++ b/charts/ocis/templates/webdav/deployment.yaml
@@ -23,6 +23,7 @@ spec:
     spec:
       securityContext:
           fsGroup: {{ .Values.securityContext.fsGroup }}
+          fsGroupChangePolicy: {{ .Values.securityContext.fsGroupChangePolicy }}
       containers:
         - name: webdav
           {{- if .Values.image.sha }}

--- a/charts/ocis/values.yaml
+++ b/charts/ocis/values.yaml
@@ -134,6 +134,9 @@ secretRefs:
 securityContext:
   # -- File system group for all volumes.
   fsGroup: 1000
+  # -- File system group change policy for all volumes.
+  # Possible values "Always" and "OnRootMismatch".
+  fsGroupChangePolicy: "OnRootMismatch"
   # -- User ID that all processes within any containers will run with.
   runAsUser: 1000
   # -- Group ID that all processes within any containers will run with.
@@ -210,6 +213,10 @@ services:
       # If not enabled, pod restarts will lead to data loss.
       # Also scaling this service beyond one instance is not possible if the service instances don't share the same storage.
       enabled: false
+      # -- Enables a initContainer to chown the volume.
+      # The initContainer is run as root.
+      # This is not needed if the driver applies the fsGroup from the securityContext.
+      chownInitContainer: false
       # -- Storage class to use.
       # Uses the default storage class if not set.
       storageClassName:
@@ -253,6 +260,10 @@ services:
       # If not enabled, pod restarts will lead to data loss.
       # Also scaling this service beyond one instance is not possible if the service instances don't share the same storage.
       enabled: false
+      # -- Enables a initContainer to chown the volume.
+      # The initContainer is run as root.
+      # This is not needed if the driver applies the fsGroup from the securityContext.
+      chownInitContainer: false
       # -- Storage class to use.
       # Uses the default storage class if not set.
       storageClassName:
@@ -279,6 +290,10 @@ services:
       # If not enabled, pod restarts will lead to data loss.
       # Also scaling this service beyond one instance is not possible if the service instances don't share the same storage.
       enabled: false
+      # -- Enables a initContainer to chown the volume.
+      # The initContainer is run as root.
+      # This is not needed if the driver applies the fsGroup from the securityContext.
+      chownInitContainer: false
       # -- Storage class to use.
       # Uses the default storage class if not set.
       storageClassName:
@@ -305,6 +320,10 @@ services:
       # If enabled, generated thumbnails are cached on this volume and available across pod restarts and service instances.
       # If not enabled, thumbnail generation might lead to higher CPU usage.
       enabled: false
+      # -- Enables a initContainer to chown the volume.
+      # The initContainer is run as root.
+      # This is not needed if the driver applies the fsGroup from the securityContext.
+      chownInitContainer: false
       # -- Storage class to use.
       # Uses the default storage class if not set.
       storageClassName:
@@ -330,6 +349,10 @@ services:
       # If not enabled, pod restarts will lead to data loss.
       # Also scaling this service beyond one instance is not possible if the service instances don't share the same storage.
       enabled: false
+      # -- Enables a initContainer to chown the volume.
+      # The initContainer is run as root.
+      # This is not needed if the driver applies the fsGroup from the securityContext.
+      chownInitContainer: false
       # -- Storage class to use.
       # Uses the default storage class if not set.
       storageClassName:
@@ -356,6 +379,10 @@ services:
       # If not enabled, pod restarts will lead to data loss.
       # Also scaling this service beyond one instance is not possible if the service instances don't share the same storage.
       enabled: false
+      # -- Enables a initContainer to chown the volume.
+      # The initContainer is run as root.
+      # This is not needed if the driver applies the fsGroup from the securityContext.
+      chownInitContainer: false
       # -- Storage class to use.
       # Uses the default storage class if not set.
       storageClassName:
@@ -382,6 +409,10 @@ services:
       # If not enabled, pod restarts will lead to data loss.
       # Also scaling this service beyond one instance is not possible if the service instances don't share the same storage.
       enabled: false
+      # -- Enables a initContainer to chown the volume.
+      # The initContainer is run as root.
+      # This is not needed if the driver applies the fsGroup from the securityContext.
+      chownInitContainer: false
       # -- Storage class to use.
       # Uses the default storage class if not set.
       storageClassName:


### PR DESCRIPTION
some storage drives do not apply the fsGroup (see eg. https://github.com/kubernetes/examples/issues/260) therefore we need to have the initContainer with chown at hand.

For other cases it also might be handy to switch the fsGroupChangePolicy 
