### PR TITLE
clean up expired uploads

### DIFF
--- a/charts/ocis/docs/values-desc-table.adoc
+++ b/charts/ocis/docs/values-desc-table.adoc
@@ -768,6 +768,18 @@ a| [subs=-attributes]
 a| [subs=-attributes]
 `nil`
 | Storage class to use. Uses the default storage class if not set.
+| services.storageUsers.maintenance.cleanUpExpiredUploads.enabled
+a| [subs=-attributes]
++bool+
+a| [subs=-attributes]
+`false`
+| Enables a job, that cleans up expired uploads. Requires persistence to be enabled and RWX storage.
+| services.storageUsers.maintenance.cleanUpExpiredUploads.schedule
+a| [subs=-attributes]
++string+
+a| [subs=-attributes]
+`"* * * * *"`
+| Cron pattern for the job to be run. Defaults to every minute.
 | services.storageUsers.persistence.accessModes
 a| [subs=-attributes]
 +list+

--- a/charts/ocis/docs/values.adoc.yaml
+++ b/charts/ocis/docs/values.adoc.yaml
@@ -397,6 +397,13 @@ services:
           accessKey: lorem-ipsum
           # -- S3 secret key to use for the S3NG driver. Only used if driver is set to "s3ng".
           secretKey: lorem-ipsum
+    maintenance:
+      # Expired uploads can be cleaned up automatically by enabling the clean up job.
+      cleanUpExpiredUploads:
+        # -- Enables a job, that cleans up expired uploads. Requires persistence to be enabled and RWX storage.
+        enabled: false
+        # -- Cron pattern for the job to be run. Defaults to every minute.
+        schedule: "* * * * *"
     persistence:
       # -- Enables persistence.
       # Needs to be enabled on production installations.

--- a/charts/ocis/templates/storage-users/jobs.yaml
+++ b/charts/ocis/templates/storage-users/jobs.yaml
@@ -1,0 +1,86 @@
+{{- if and .Values.services.storageUsers.persistence.enabled .Values.services.storageUsers.maintenance.cleanUpExpiredUploads.enabled }}
+apiVersion: batch/v1
+kind: CronJob
+metadata:
+  name: storage-users-clean-expired-uploads
+  namespace: {{ template "ocis.namespace" . }}
+  labels:
+    {{- include "ocis.labels" . | nindent 4 }}
+spec:
+  schedule: "{{ .Values.services.storageUsers.maintenance.cleanUpExpiredUploads.schedule }}"
+  successfulJobsHistoryLimit: 3
+  failedJobsHistoryLimit: 3
+  jobTemplate:
+    spec:
+      parallelism: 1
+      template:
+        metadata:
+          labels:
+            app: storage-users-clean-expired-uploads
+            {{- include "ocis.labels" . | nindent 12 }}
+
+        spec:
+          restartPolicy: Never
+          containers:
+            - name: storage-users-clean-expired-uploads
+              image: {{ template "ocis.image" $ }}
+              imagePullPolicy: {{ .Values.image.pullPolicy }}
+              command: ["ocis"]
+              args: ["storage-users", "uploads", "clean"]
+              securityContext:
+                runAsNonRoot: true
+                runAsUser: {{ .Values.securityContext.runAsUser }}
+                runAsGroup: {{ .Values.securityContext.runAsGroup }}
+                readOnlyRootFilesystem: true
+              env:
+                - name: MICRO_REGISTRY
+                  value: kubernetes
+
+                # logging
+                - name: STORAGE_USERS_LOG_COLOR
+                  value: "{{ .Values.logging.color }}"
+                - name: STORAGE_USERS_LOG_LEVEL
+                  value: "{{ .Values.logging.level }}"
+                - name: STORAGE_USERS_LOG_PRETTY
+                  value: "{{ .Values.logging.pretty }}"
+
+                # oCIS storage driver (decomposed filesystem)
+                {{- if  eq .Values.services.storageUsers.storageBackend.driver "ocis" }}
+                - name: STORAGE_USERS_DRIVER
+                  value: ocis
+                {{- end }}
+
+                # S3ng storage driver (decomposed filesystem)
+                {{- if  eq .Values.services.storageUsers.storageBackend.driver "s3ng" }}
+                - name: STORAGE_USERS_DRIVER
+                  value: s3ng
+                {{- end }}
+
+                - name: STORAGE_USERS_JWT_SECRET
+                  valueFrom:
+                    secretKeyRef:
+                      name: {{ .Values.secretRefs.jwtSecretRef }}
+                      key: jwt-secret
+
+                - name: STORAGE_TRANSFER_SECRET
+                  valueFrom:
+                    secretKeyRef:
+                      name: {{ .Values.secretRefs.transferSecretSecretRef }}
+                      key: transfer-secret
+
+              resources: {{ toYaml .Values.resources | nindent 16 }}
+
+              volumeMounts:
+                - name: tmp-volume
+                  mountPath: /tmp
+                - name: storage-users-data
+                  mountPath: /var/lib/ocis
+          volumes:
+            - name: tmp-volume
+              emptyDir:
+                medium: Memory
+                sizeLimit: 6Mi
+            - name: storage-users-data
+              persistentVolumeClaim:
+                claimName: storage-users-data
+{{ end }}

--- a/charts/ocis/values.yaml
+++ b/charts/ocis/values.yaml
@@ -396,6 +396,13 @@ services:
           accessKey: lorem-ipsum
           # -- S3 secret key to use for the S3NG driver. Only used if driver is set to "s3ng".
           secretKey: lorem-ipsum
+    maintenance:
+      # Expired uploads can be cleaned up automatically by enabling the clean up job.
+      cleanUpExpiredUploads:
+        # -- Enables a job, that cleans up expired uploads. Requires persistence to be enabled and RWX storage.
+        enabled: false
+        # -- Cron pattern for the job to be run. Defaults to every minute.
+        schedule: "* * * * *"
     persistence:
       # -- Enables persistence.
       # Needs to be enabled on production installations.


### PR DESCRIPTION
## Description
Add a job that cleans up expired uploads for the storage-users service

## Related Issue
- Fixes #80 

## Motivation and Context
Automatic maintenance

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
- minikube

## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Technical debt
- [ ] Tests only (no source changes)

## Checklist:
- [ ] Code changes
- [ ] Unit tests added
- [ ] Acceptance tests added
- [ ] Documentation generated (`make docs`) and committed
- [ ] Documentation ticket raised: <link>
- [ ] Documentation PR created: <link>
