### PR TITLE
don't warn about disabled persistence for the idm service when using external user managment

### DIFF
--- a/charts/ocis/templates/NOTES.txt
+++ b/charts/ocis/templates/NOTES.txt
@@ -30,7 +30,7 @@ kubectl -n <namespace> get secrets/admin-user --template='{{"{{"}}.data.password
 {{- if not .Values.services.storageSystem.persistence.enabled }}
 ######     - storage-system                                                 #####
 {{- end }}
-{{- if not .Values.services.idm.persistence.enabled }}
+{{- if and (not .Values.features.externalUserManagement.enabled) (not .Values.services.idm.persistence.enabled) }}
 ######     - idm                                                            #####
 {{- end }}
 {{- if not .Values.services.store.persistence.enabled }}


### PR DESCRIPTION
## Description
When the IDM isn't used because we're using an external user management, we shouldn't warn about missing persistence of the IDM service

## Related Issue
<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->
- Fixes confusing warning message

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
- have external user management enabled and not persistence enabled for the IDM, then you'll see a warning, that the IDM has no persistence.

## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Technical debt
- [ ] Tests only (no source changes)

## Checklist:
<!-- Tick the checkboxes when done. -->
<!-- Raise documentation ticket in https://github.com/owncloud/docs-ocis/issues -->
<!-- or create documentation PR in https://github.com/owncloud/docs-ocis/tree/master/modules/ROOT/pages/deployment/container>
- [ ] Code changes
- [ ] Unit tests added
- [ ] Acceptance tests added
- [ ] Documentation generated (`make docs`) and committed
- [ ] Documentation ticket raised: <link>
- [ ] Documentation PR created: <link>
