### PR TITLE
configure audit to log to stdout

### DIFF
--- a/charts/ocis/templates/audit/deployment.yaml
+++ b/charts/ocis/templates/audit/deployment.yaml
@@ -10,7 +10,7 @@ spec:
     matchLabels:
       app: audit
   {{- if and (not .Values.autoscaling.enabled) (.Values.replicas) }}
-  replicas: {{ .Values.replicas }} #TODO: how to scale audit?
+  replicas: {{ .Values.replicas }}
   {{- end }}
   {{- if .Values.deploymentStrategy }}
   strategy: {{ toYaml .Values.deploymentStrategy | nindent 4 }}
@@ -49,8 +49,7 @@ spec:
             - name: AUDIT_EVENTS_ENDPOINT
               value: nats:9233
 
-            # TODO: log to file or stdout?
-            #- name: AUDIT_FILEPATH
-            #  value:
+            - name: AUDIT_LOG_TO_CONSOLE
+              value: "true"
 
           resources: {{ toYaml .Values.resources | nindent 12 }}


### PR DESCRIPTION
## Description
the audit service now logs to stdout from where kubernetes will pick up the audit logs (and rotates it).
Depending on the deployment, there may also be an logging system that picks up the audit logs from Kubernetes and
persists it / makes it searchable / accessible to X.

## Related Issue
<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->
- fixes https://github.com/owncloud/ocis-charts/issues/17

## Motivation and Context
- Provide easy access to audit logs

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
- run `kubectl logs` on a audit service pod

## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Technical debt
- [ ] Tests only (no source changes)

## Checklist:
<!-- Tick the checkboxes when done. -->
<!-- Raise documentation ticket in https://github.com/owncloud/docs-ocis/issues -->
<!-- or create documentation PR in https://github.com/owncloud/docs-ocis/tree/master/modules/ROOT/pages/deployment/container>
- [x] Code changes
- [ ] Unit tests added
- [ ] Acceptance tests added
- [ ] Documentation generated (`make docs`) and committed
- [ ] Documentation ticket raised: <link>
- [ ] Documentation PR created: <link>
