### PR TITLE
fix persistence notes

### DIFF
--- a/charts/ocis/templates/NOTES.txt
+++ b/charts/ocis/templates/NOTES.txt
@@ -1,3 +1,10 @@
+{{- $idm := and (not .Values.features.externalUserManagement.enabled) (not .Values.services.idm.persistence.enabled) -}}
+{{- $nats := not .Values.services.nats.persistence.enabled -}}
+{{- $search := not .Values.services.search.persistence.enabled -}}
+{{- $storageSystem := not .Values.services.storageSystem.persistence.enabled -}}
+{{- $storageUsers := not .Values.services.storageUsers.persistence.enabled -}}
+{{- $store := not .Values.services.store.persistence.enabled -}}
+
 You're now running
                  ,----..      ,---,   .--.--.
                 /   /   \  ,`--.' |  /  /    '.
@@ -18,28 +25,28 @@ You can get the initial "admin" administrator user password by running:
 
 kubectl -n <namespace> get secrets/admin-user --template='{{"{{"}}.data.password | base64decode{{"}}"}}'
 
-{{ if  or (not .Values.services.storageSystem.persistence.enabled) (not .Values.services.storageUsers.persistence.enabled) (not .Values.services.store.persistence.enabled) (not .Values.services.idm.persistence.enabled) (not .Values.services.search.persistence.enabled) (not .Values.services.nats.persistence.enabled) }}
+{{ if or $storageSystem $storageUsers $store $idm $search $nats }}
 #################################################################################
 ######   WARNING: Persistence is disabled for some services.                #####
 ######   You will lose your data when a service's pod is terminated.        #####
 ######                                                                      #####
 ######   Following services don't use persistence:                          #####
-{{- if not .Values.services.storageUsers.persistence.enabled }}
+{{- if $storageUsers }}
 ######     - storage-users                                                  #####
 {{- end }}
-{{- if not .Values.services.storageSystem.persistence.enabled }}
+{{- if $storageSystem }}
 ######     - storage-system                                                 #####
 {{- end }}
-{{- if and (not .Values.features.externalUserManagement.enabled) (not .Values.services.idm.persistence.enabled) }}
+{{- if $idm }}
 ######     - idm                                                            #####
 {{- end }}
-{{- if not .Values.services.store.persistence.enabled }}
+{{- if $store }}
 ######     - store                                                          #####
 {{- end }}
-{{- if not .Values.services.search.persistence.enabled }}
+{{- if $search }}
 ######     - search                                                         #####
 {{- end }}
-{{- if not .Values.services.nats.persistence.enabled }}
+{{- if $nats }}
 ######     - nats                                                           #####
 {{- end }}
 #################################################################################


### PR DESCRIPTION

## Description
previously the persistence notes head was printed if external usermanagement was enabled and the idm had no persistence configured

## Related Issue
<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->
- Fixes <issue_link>

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
- minikube

## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Technical debt
- [ ] Tests only (no source changes)

## Checklist:
<!-- Tick the checkboxes when done. -->
<!-- Raise documentation ticket in https://github.com/owncloud/docs-ocis/issues -->
<!-- or create documentation PR in https://github.com/owncloud/docs-ocis/tree/master/modules/ROOT/pages/deployment/container>
- [x] Code changes
- [ ] Unit tests added
- [ ] Acceptance tests added
- [ ] Documentation generated (`make docs`) and committed
- [ ] Documentation ticket raised: <link>
- [ ] Documentation PR created: <link>
