### PR TITLE
switch to jsoncs3 sharing drivers

### DIFF
--- a/charts/ocis/templates/sharing/deployment.yaml
+++ b/charts/ocis/templates/sharing/deployment.yaml
@@ -67,15 +67,15 @@ spec:
 
             # user sharing
             - name: SHARING_USER_DRIVER
-              value: cs3
-            - name: SHARING_USER_CS3_PROVIDER_ADDR
+              value: jsoncs3
+            - name: SHARING_USER_JSONCS3_PROVIDER_ADDR
               value: storage-system:9215
-            - name: SHARING_USER_CS3_SYSTEM_USER_API_KEY
+            - name: SHARING_USER_JSONCS3_SYSTEM_USER_API_KEY
               valueFrom:
                 secretKeyRef:
                   name: {{ .Values.secretRefs.storageSystemSecretRef }}
                   key: api-key
-            - name: SHARING_USER_CS3_SYSTEM_USER_ID
+            - name: SHARING_USER_JSONCS3_SYSTEM_USER_ID
               valueFrom:
                 secretKeyRef:
                   name: {{ .Values.secretRefs.storageSystemSecretRef }}
@@ -83,15 +83,15 @@ spec:
 
             # public sharing
             - name: SHARING_PUBLIC_DRIVER
-              value: cs3
-            - name: SHARING_PUBLIC_CS3_PROVIDER_ADDR
+              value: jsoncs3
+            - name: SHARING_PUBLIC_JSONCS3_PROVIDER_ADDR
               value: storage-system:9215
-            - name: SHARING_PUBLIC_CS3_SYSTEM_USER_API_KEY
+            - name: SHARING_PUBLIC_JSONCS3_SYSTEM_USER_API_KEY
               valueFrom:
                 secretKeyRef:
                   name: {{ .Values.secretRefs.storageSystemSecretRef }}
                   key: api-key
-            - name: SHARING_PUBLIC_CS3_SYSTEM_USER_ID
+            - name: SHARING_PUBLIC_JSONCS3_SYSTEM_USER_ID
               valueFrom:
                 secretKeyRef:
                   name: {{ .Values.secretRefs.storageSystemSecretRef }}


### PR DESCRIPTION
## Description
switches user and public sharing to the jsoncs3 driver.

## Related Issue
<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->
- Fixes https://github.com/owncloud/ocis-charts/issues/87
- Needs https://github.com/owncloud/ocis-charts/pull/105 first because of a known bug in oCIS 2.0.0-beta.8 regarding jsoncs3 / cs3 sharing configuration (fixed in https://github.com/owncloud/ocis/pull/4593)

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
- minikube

## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [x] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Technical debt
- [ ] Tests only (no source changes)

## Checklist:
<!-- Tick the checkboxes when done. -->
<!-- Raise documentation ticket in https://github.com/owncloud/docs-ocis/issues -->
<!-- or create documentation PR in https://github.com/owncloud/docs-ocis/tree/master/modules/ROOT/pages/deployment/container>
- [x] Code changes
- [ ] Unit tests added
- [ ] Acceptance tests added
- [ ] Documentation generated (`make docs`) and committed
- [ ] Documentation ticket raised: <link>
- [ ] Documentation PR created: <link>
