### PR TITLE
configure caches

### DIFF
--- a/charts/ocis/docs/values-desc-table.adoc
+++ b/charts/ocis/docs/values-desc-table.adoc
@@ -30,6 +30,18 @@ a| [subs=-attributes]
 a| [subs=-attributes]
 `3`
 | Sets minimum replicas for autoscaling.
+| cache.nodes
+a| [subs=-attributes]
++list+
+a| [subs=-attributes]
+`[]`
+| Nodes of the cache to use.
+| cache.type
+a| [subs=-attributes]
++string+
+a| [subs=-attributes]
+`"noop"`
+| Type of the cache to use. To disable the cache, set to "noop". Can be set to "redis", then the address of Redis nodes needs to be set to `cache.nodes`.
 | debug.profiling
 a| [subs=-attributes]
 +bool+

--- a/charts/ocis/docs/values.adoc.yaml
+++ b/charts/ocis/docs/values.adoc.yaml
@@ -47,6 +47,16 @@ insecure:
   # Not recommended for production installations.
   ocisHttpApiInsecure: false
 
+cache:
+  # -- Type of the cache to use. To disable the cache, set to "noop".
+  # Can be set to "redis", then the address of Redis nodes needs to be set to `cache.nodes`.
+  type: noop
+  # -- Nodes of the cache to use.
+  nodes: []
+  # nodes:
+  #   - redis-master-1.ocis-redis.svc.cluster.local:6379
+  #   - redis-master-2.ocis-redis.svc.cluster.local:6379
+
 # Feature options.
 # Enable or disable features of oCIS.
 features:

--- a/charts/ocis/templates/gateway/deployment.yaml
+++ b/charts/ocis/templates/gateway/deployment.yaml
@@ -88,6 +88,14 @@ spec:
             - name: GATEWAY_APP_REGISTRY_ENDPOINT
               value: app-registry:9242
 
+            # cache
+            - name: GATEWAY_CACHE_STORE
+              value: {{ .Values.cache.type }}
+            {{- if ne .Values.cache.type "noop" }}
+            - name: GATEWAY_CACHE_NODES
+              value: {{ join "," .Values.cache.nodes }}
+            {{- end }}
+
             - name: GATEWAY_JWT_SECRET
               valueFrom:
                 secretKeyRef:

--- a/charts/ocis/templates/storage-users/deployment.yaml
+++ b/charts/ocis/templates/storage-users/deployment.yaml
@@ -106,6 +106,14 @@ spec:
             - name: REVA_GATEWAY
               value: gateway:9142
 
+            # cache
+            - name: STORAGE_USERS_CACHE_STORE
+              value: {{ .Values.cache.type }}
+            {{- if ne .Values.cache.type "noop" }}
+            - name: STORAGE_USERS_CACHE_NODES
+              value: {{ join "," .Values.cache.nodes }}
+            {{- end }}
+
             - name: STORAGE_USERS_JWT_SECRET
               valueFrom:
                 secretKeyRef:

--- a/charts/ocis/values.yaml
+++ b/charts/ocis/values.yaml
@@ -46,6 +46,16 @@ insecure:
   # Not recommended for production installations.
   ocisHttpApiInsecure: false
 
+cache:
+  # -- Type of the cache to use. To disable the cache, set to "noop".
+  # Can be set to "redis", then the address of Redis nodes needs to be set to `cache.nodes`.
+  type: noop
+  # -- Nodes of the cache to use.
+  nodes: []
+  # nodes:
+  #   - redis-master-1.ocis-redis.svc.cluster.local:6379
+  #   - redis-master-2.ocis-redis.svc.cluster.local:6379
+
 # Feature options.
 # Enable or disable features of oCIS.
 features:


### PR DESCRIPTION
## Description
The gateway and storage-users service normally share a common in-memory cache. Since they use active invalidation mechanisms we need to disable the cache or use an external cache as sonn as those two services don't run in the same process.

## Related Issue
<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->
- Fixes cache invalidation issues when running gateway and storage-users in different pods

## Motivation and Context
Fixes cache invalidation issues when running gateway and storage-users in different pods and enable the usage of external caches.

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
- tested on experimental branch

## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Technical debt
- [ ] Tests only (no source changes)

## Checklist:
- [x] Code changes
- [ ] Unit tests added
- [ ] Acceptance tests added
- [x] Documentation generated (`make docs`) and committed
- [ ] Documentation ticket raised: <link>
- [ ] Documentation PR created: <link>
