### PR TITLE
add option to configure external nats

### DIFF
--- a/charts/ocis/docs/values-desc-table.adoc
+++ b/charts/ocis/docs/values-desc-table.adoc
@@ -462,6 +462,42 @@ a| [subs=-attributes]
 a| [subs=-attributes]
 `"false"`
 | Activates pretty log output. Not recommended for production installations.
+| messagingSystem.external.cluster
+a| [subs=-attributes]
++string+
+a| [subs=-attributes]
+`"ocis-cluster"`
+| Cluster name to use with the messaging system.
+| messagingSystem.external.enabled
+a| [subs=-attributes]
++bool+
+a| [subs=-attributes]
+`true`
+| Use an external NATS messaging system instead of the internal one. Recommended for all production instances. Needs to be used if HighAvailability is needed. Needs to be used if oCIS shall be used by more than a 2-digit user count.
+| messagingSystem.external.endpoint
+a| [subs=-attributes]
++string+
+a| [subs=-attributes]
+`"nats.ocis-nats.svc.cluster.local:4222"`
+| Endpoint of the messaging system.
+| messagingSystem.external.tls.certTrusted
+a| [subs=-attributes]
++bool+
+a| [subs=-attributes]
+`true`
+| Set only to false, if the certificate of your messaging system service is not trusted. If set to false, you need to put the CA cert of the messaging system server into the secret referenced by "messagingSystemCaRef"
+| messagingSystem.external.tls.enabled
+a| [subs=-attributes]
++bool+
+a| [subs=-attributes]
+`true`
+| Enables TLS encrypted communication with the messaging system. Recommended for production installations.
+| messagingSystem.external.tls.insecure
+a| [subs=-attributes]
++bool+
+a| [subs=-attributes]
+`false`
+| For self signed certificates, consider to put the CA cert of the messaging system secure server into the secret referenced by "messagingSystemCaRef" Not recommended for production installations.
 | namespaceOverride
 a| [subs=-attributes]
 +string+
@@ -522,6 +558,12 @@ a| [subs=-attributes]
 a| [subs=-attributes]
 `"machine-auth-api-key"`
 | Reference to an existing machine auth api key secret (see xref:{secrets}[Secrets])
+| secretRefs.messagingSystemCaRef
+a| [subs=-attributes]
++string+
+a| [subs=-attributes]
+`"messaging-system-ca"`
+| Reference to an existing messaging system certificate authority secret (see xref:{secrets}[Secrets])
 | secretRefs.notificationsSmtpSecretRef
 a| [subs=-attributes]
 +string+
@@ -767,7 +809,7 @@ a| [subs=-attributes]
 +object+
 a| [subs=-attributes]
 see detailed service configuration options below
-| NATS service.
+| NATS service. Not used if `messagingSystem.external` equals `true`.
 | services.nats.persistence.accessModes
 a| [subs=-attributes]
 +list+
@@ -791,7 +833,7 @@ a| [subs=-attributes]
 +bool+
 a| [subs=-attributes]
 `false`
-| Enables persistence. Needs to be enabled on production installations. If not enabled, pod restarts will lead to data loss. Also scaling this service beyond one instance is not possible if the service instances don't share the same storage.
+| Enables persistence. Needs to be enabled on production installations, except `messagingSystem.external` equals `true`. If not enabled, pod restarts will lead to data loss. Also scaling this service beyond one instance is not possible if the service instances don't share the same storage.
 | services.nats.persistence.existingClaim
 a| [subs=-attributes]
 +string+

--- a/charts/ocis/docs/values-desc-table.adoc
+++ b/charts/ocis/docs/values-desc-table.adoc
@@ -809,7 +809,7 @@ a| [subs=-attributes]
 +object+
 a| [subs=-attributes]
 see detailed service configuration options below
-| NATS service. Not used if `messagingSystem.external` equals `true`.
+| NATS service. Not used if `messagingSystem.external.enabled` equals `true`.
 | services.nats.persistence.accessModes
 a| [subs=-attributes]
 +list+
@@ -833,7 +833,7 @@ a| [subs=-attributes]
 +bool+
 a| [subs=-attributes]
 `false`
-| Enables persistence. Needs to be enabled on production installations, except `messagingSystem.external` equals `true`. If not enabled, pod restarts will lead to data loss. Also scaling this service beyond one instance is not possible if the service instances don't share the same storage.
+| Enables persistence. Needs to be enabled on production installations, except `messagingSystem.external.enabled` equals `true`. If not enabled, pod restarts will lead to data loss. Also scaling this service beyond one instance is not possible if the service instances don't share the same storage.
 | services.nats.persistence.existingClaim
 a| [subs=-attributes]
 +string+

--- a/charts/ocis/docs/values-desc-table.adoc
+++ b/charts/ocis/docs/values-desc-table.adoc
@@ -472,7 +472,7 @@ a| [subs=-attributes]
 a| [subs=-attributes]
 +bool+
 a| [subs=-attributes]
-`true`
+`false`
 | Use an external NATS messaging system instead of the internal one. Recommended for all production instances. Needs to be used if HighAvailability is needed. Needs to be used if oCIS shall be used by more than a 2-digit user count.
 | messagingSystem.external.endpoint
 a| [subs=-attributes]

--- a/charts/ocis/docs/values.adoc.yaml
+++ b/charts/ocis/docs/values.adoc.yaml
@@ -63,7 +63,7 @@ messagingSystem:
     # Recommended for all production instances.
     # Needs to be used if HighAvailability is needed.
     # Needs to be used if oCIS shall be used by more than a 2-digit user count.
-    enabled: true
+    enabled: false
     # -- Endpoint of the messaging system.
     endpoint: "nats.ocis-nats.svc.cluster.local:4222"
     # -- Cluster name to use with the messaging system.

--- a/charts/ocis/docs/values.adoc.yaml
+++ b/charts/ocis/docs/values.adoc.yaml
@@ -57,6 +57,30 @@ cache:
   #   - redis-master-1.ocis-redis.svc.cluster.local:6379
   #   - redis-master-2.ocis-redis.svc.cluster.local:6379
 
+messagingSystem:
+  external:
+    # -- Use an external NATS messaging system instead of the internal one.
+    # Recommended for all production instances.
+    # Needs to be used if HighAvailability is needed.
+    # Needs to be used if oCIS shall be used by more than a 2-digit user count.
+    enabled: true
+    # -- Endpoint of the messaging system.
+    endpoint: "nats.ocis-nats.svc.cluster.local:4222"
+    # -- Cluster name to use with the messaging system.
+    cluster: "ocis-cluster"
+    tls:
+      # -- Enables TLS encrypted communication with the messaging system.
+      # Recommended for production installations.
+      enabled: true
+      # -- Set only to false, if the certificate of your messaging system service is not trusted.
+      # If set to false, you need to put the CA cert of the messaging system server into the secret referenced by "messagingSystemCaRef"
+      certTrusted: true
+      # -- Disables SSL certificate checking for connections to the messaging system server.
+      # -- For self signed certificates, consider to put the CA cert of the messaging system secure server into the secret referenced by "messagingSystemCaRef"
+      # Not recommended for production installations.
+      insecure: false
+
+
 # Feature options.
 # Enable or disable features of oCIS.
 features:
@@ -248,6 +272,8 @@ secretRefs:
   ldapSecretRef: "ldap-bind-secrets"
   # -- Reference to an existing machine auth api key secret (see xref:{secrets}[Secrets])
   machineAuthApiKeySecretRef: "machine-auth-api-key"
+  # -- Reference to an existing messaging system certificate authority secret (see xref:{secrets}[Secrets])
+  messagingSystemCaRef: "messaging-system-ca"
   # -- Reference to an existing SMTP email server settings secret (see xref:{secrets}[Secrets]). Not used if `features.emailNotifications.enabled` equals `false`.
   notificationsSmtpSecretRef: "notifications-smtp-secret"
   # -- Reference to an existing storage-system JWT secret (see xref:{secrets}[Secrets])
@@ -455,12 +481,12 @@ services:
     # -- Per-service resources configuration. Overrides the default setting from `resources` if set.
     resources: {}
 
-  # -- NATS service.
+  # -- NATS service. Not used if `messagingSystem.external` equals `true`.
   # @default -- see detailed service configuration options below
   nats:
     persistence:
       # -- Enables persistence.
-      # Needs to be enabled on production installations.
+      # Needs to be enabled on production installations, except `messagingSystem.external` equals `true`.
       # If not enabled, pod restarts will lead to data loss.
       # Also scaling this service beyond one instance is not possible if the service instances don't share the same storage.
       enabled: false

--- a/charts/ocis/docs/values.adoc.yaml
+++ b/charts/ocis/docs/values.adoc.yaml
@@ -481,12 +481,12 @@ services:
     # -- Per-service resources configuration. Overrides the default setting from `resources` if set.
     resources: {}
 
-  # -- NATS service. Not used if `messagingSystem.external` equals `true`.
+  # -- NATS service. Not used if `messagingSystem.external.enabled` equals `true`.
   # @default -- see detailed service configuration options below
   nats:
     persistence:
       # -- Enables persistence.
-      # Needs to be enabled on production installations, except `messagingSystem.external` equals `true`.
+      # Needs to be enabled on production installations, except `messagingSystem.external.enabled` equals `true`.
       # If not enabled, pod restarts will lead to data loss.
       # Also scaling this service beyond one instance is not possible if the service instances don't share the same storage.
       enabled: false

--- a/charts/ocis/templates/NOTES.txt
+++ b/charts/ocis/templates/NOTES.txt
@@ -1,5 +1,5 @@
 {{- $idm := and (not .Values.features.externalUserManagement.enabled) (not .Values.services.idm.persistence.enabled) -}}
-{{- $nats := not .Values.services.nats.persistence.enabled -}}
+{{- $nats := and (not .Values.messagingSystem.external.enabled) (not .Values.services.nats.persistence.enabled) -}}
 {{- $search := not .Values.services.search.persistence.enabled -}}
 {{- $storageSystem := not .Values.services.storageSystem.persistence.enabled -}}
 {{- $storageUsers := not .Values.services.storageUsers.persistence.enabled -}}

--- a/charts/ocis/templates/app-provider/deployment.yaml
+++ b/charts/ocis/templates/app-provider/deployment.yaml
@@ -99,19 +99,20 @@ spec:
             failureThreshold: 3
 
           resources: {{ toYaml $.resources | nindent 12 }}
+
           ports:
             - name: grpc
               containerPort: 9164
             - name: metrics-debug
               containerPort: 9165
+
           volumeMounts:
             - name: tmp-volume
               mountPath: /tmp
+
       volumes:
         - name: tmp-volume
-          emptyDir:
-            medium: Memory
-            sizeLimit: 6Mi
+          emptyDir: {}
 {{ end }}
 {{ end }}
 {{ end }}

--- a/charts/ocis/templates/app-provider/deployment.yaml
+++ b/charts/ocis/templates/app-provider/deployment.yaml
@@ -14,7 +14,7 @@ metadata:
 spec:
   selector:
     matchLabels:
-      app:  {{ $.appName }}
+      app: {{ $.appName }}
   replicas: 1 #TODO: https://github.com/owncloud/ocis-charts/issues/48
   {{- if $.Values.deploymentStrategy }}
   strategy: {{ toYaml $.Values.deploymentStrategy | nindent 4 }}
@@ -22,7 +22,7 @@ spec:
   template:
     metadata:
       labels:
-        app:  {{ $.appName }}
+        app: {{ $.appName }}
         {{- include "ocis.labels" $ | nindent 8 }}
     spec:
       securityContext:
@@ -33,7 +33,7 @@ spec:
         {{- tpl . $ | nindent 8 }}
       {{- end }}
       containers:
-        - name:  {{ $.appName }}
+        - name: {{ $.appName }}
           image: {{ template "ocis.image" $ }}
           imagePullPolicy: {{ $.Values.image.pullPolicy }}
           command: ["ocis"]

--- a/charts/ocis/templates/app-provider/service.yaml
+++ b/charts/ocis/templates/app-provider/service.yaml
@@ -14,7 +14,7 @@ metadata:
     {{- include "ocis.labels" $ | nindent 4 }}
 spec:
   selector:
-    app:  {{ $.appName }}
+    app: {{ $.appName }}
   ports:
     - name: grpc
       port: 9164

--- a/charts/ocis/templates/app-registry/deployment.yaml
+++ b/charts/ocis/templates/app-registry/deployment.yaml
@@ -80,21 +80,22 @@ spec:
             failureThreshold: 3
 
           resources: {{ toYaml .resources | nindent 12 }}
+
           ports:
             - name: http
               containerPort: 9242
             - name: metrics-debug
               containerPort: 9243
+
           volumeMounts:
             - name: tmp-volume
               mountPath: /tmp
             - name: configs
               mountPath: /etc/ocis
+
       volumes:
         - name: tmp-volume
-          emptyDir:
-            medium: Memory
-            sizeLimit: 6Mi
+          emptyDir: {}
         - name: configs
           configMap:
             name: app-registry-config

--- a/charts/ocis/templates/app-registry/service.yaml
+++ b/charts/ocis/templates/app-registry/service.yaml
@@ -1,5 +1,5 @@
-{{- $_ := set . "appName" "app-registry" -}}
 {{ if .Values.features.appsIntegration.enabled }}
+{{- $_ := set . "appName" "app-registry" -}}
 apiVersion: v1
 kind: Service
 metadata:

--- a/charts/ocis/templates/audit/deployment.yaml
+++ b/charts/ocis/templates/audit/deployment.yaml
@@ -64,11 +64,11 @@ spec:
             - name: AUDIT_EVENTS_TLS_INSECURE
               value: {{ .Values.messagingSystem.external.tls.insecure | quote }}
             - name: AUDIT_EVENTS_TLS_ROOT_CA_CERTIFICATE
-              {{ if or (not .Values.messagingSystem.external.enabled) (not .Values.messagingSystem.external.tls.certTrusted) }}
+              {{- if not .Values.messagingSystem.external.tls.certTrusted }}
               value: /etc/ocis/messaging-system-ca/messaging-system-ca.crt
-              {{ else }}
+              {{- else }}
               value: "" # no cert needed
-              {{ end }}
+              {{- end }}
             {{- end }}
 
             - name: AUDIT_LOG_TO_CONSOLE
@@ -87,7 +87,7 @@ spec:
         - name: ocis-config-tmp
           emptyDir: {}
         - name: messaging-system-ca
-          {{ if or (not .Values.messagingSystem.external.enabled) (not .Values.messagingSystem.external.tls.certTrusted) }}
+          {{ if and (.Values.messagingSystem.external.enabled) (not .Values.messagingSystem.external.tls.certTrusted) }}
           secret:
             secretName: {{ .Values.secretRefs.messagingSystemCaRef }}
           {{ else }}

--- a/charts/ocis/templates/audit/deployment.yaml
+++ b/charts/ocis/templates/audit/deployment.yaml
@@ -1,3 +1,4 @@
+{{- $_ := set . "appName" "audit" -}}
 {{- $_ := set . "resources" (default (default (dict) .Values.resources) .Values.services.audit.resources) -}}
 apiVersion: apps/v1
 kind: Deployment
@@ -13,7 +14,6 @@ spec:
   {{- if and (not .Values.autoscaling.enabled) (.Values.replicas) }}
   replicas: {{ .Values.replicas }}
   {{- end }}
-  {{- $_ := set . "appName" "audit" -}}
   {{- if .Values.deploymentStrategy }}
   strategy: {{ toYaml .Values.deploymentStrategy | nindent 4 }}
   {{ end }}
@@ -53,9 +53,43 @@ spec:
               value: {{ .Values.logging.pretty | quote }}
 
             - name: AUDIT_EVENTS_ENDPOINT
+            {{- if not .Values.messagingSystem.external.enabled }}
               value: nats:9233
+            {{- else }}
+              value: {{ .Values.messagingSystem.external.endpoint }}
+            - name: AUDIT_EVENTS_CLUSTER
+              value: {{ .Values.messagingSystem.external.cluster }}
+            - name: AUDIT_EVENTS_ENABLE_TLS
+              value: {{ .Values.messagingSystem.external.tls.enabled }}
+            - name: AUDIT_EVENTS_TLS_INSECURE
+              value: {{ .Values.messagingSystem.external.tls.insecure }}
+            - name: AUDIT_EVENTS_TLS_ROOT_CA_CERTIFICATE
+              {{ if or (not .Values.messagingSystem.external.enabled) (not .Values.messagingSystem.external.tls.certTrusted) }}
+              value: /etc/ocis/messaging-system-ca/messaging-system-ca.crt
+              {{ else }}
+              value: "" # no cert needed
+              {{ end }}
+            {{- end }}
 
             - name: AUDIT_LOG_TO_CONSOLE
               value: "true"
 
           resources: {{ toYaml .resources | nindent 12 }}
+
+          volumeMounts:
+            - name: ocis-config-tmp
+              mountPath: /etc/ocis # we mount that volume only to apply fsGroup to that path
+            - name: messaging-system-ca
+              mountPath: /etc/ocis/messaging-system-ca
+              readOnly: true
+
+      volumes:
+        - name: ocis-config-tmp
+          emptyDir: {}
+        - name: messaging-system-ca
+          {{ if or (not .Values.messagingSystem.external.enabled) (not .Values.messagingSystem.external.tls.certTrusted) }}
+          secret:
+            secretName: {{ .Values.secretRefs.messagingSystemCaRef }}
+          {{ else }}
+          emptyDir: {}
+          {{ end }}

--- a/charts/ocis/templates/audit/deployment.yaml
+++ b/charts/ocis/templates/audit/deployment.yaml
@@ -56,13 +56,13 @@ spec:
             {{- if not .Values.messagingSystem.external.enabled }}
               value: nats:9233
             {{- else }}
-              value: {{ .Values.messagingSystem.external.endpoint }}
+              value: {{ .Values.messagingSystem.external.endpoint | quote }}
             - name: AUDIT_EVENTS_CLUSTER
-              value: {{ .Values.messagingSystem.external.cluster }}
+              value: {{ .Values.messagingSystem.external.cluster | quote }}
             - name: AUDIT_EVENTS_ENABLE_TLS
-              value: {{ .Values.messagingSystem.external.tls.enabled }}
+              value: {{ .Values.messagingSystem.external.tls.enabled | quote }}
             - name: AUDIT_EVENTS_TLS_INSECURE
-              value: {{ .Values.messagingSystem.external.tls.insecure }}
+              value: {{ .Values.messagingSystem.external.tls.insecure | quote }}
             - name: AUDIT_EVENTS_TLS_ROOT_CA_CERTIFICATE
               {{ if or (not .Values.messagingSystem.external.enabled) (not .Values.messagingSystem.external.tls.certTrusted) }}
               value: /etc/ocis/messaging-system-ca/messaging-system-ca.crt

--- a/charts/ocis/templates/auth-basic/deployment.yaml
+++ b/charts/ocis/templates/auth-basic/deployment.yaml
@@ -1,5 +1,5 @@
-{{- $_ := set . "appName" "auth-basic" -}}
 {{ if .Values.features.basicAuthentication }}
+{{- $_ := set . "appName" "auth-basic" -}}
 {{- $_ := set . "resources" (default (default (dict) .Values.resources) .Values.services.authBasic.resources) -}}
 apiVersion: apps/v1
 kind: Deployment
@@ -168,33 +168,32 @@ spec:
             failureThreshold: 3
 
           resources: {{ toYaml .resources | nindent 12 }}
+
           ports:
             - name: grpc
               containerPort: 9146
             - name: metrics-debug
               containerPort: 9147
+
           volumeMounts:
+            - name: tmp-volume
+              mountPath: /tmp
             - name: ocis-config-tmp
               mountPath: /etc/ocis # we mount that volume only to apply fsGroup to that path
-            {{ if or (not .Values.features.externalUserManagement.enabled) ( not .Values.features.externalUserManagement.ldap.certTrusted) }}
             - name: ldap-ca
               mountPath: /etc/ocis/ldap-ca
               readOnly: true
-            {{ end }}
-            - name: tmp-volume
-              mountPath: /tmp
+
       volumes:
+        - name: tmp-volume
+          emptyDir: {}
         - name: ocis-config-tmp
-          emptyDir:
-            medium: Memory
-            sizeLimit: 6Mi
-        {{ if or (not .Values.features.externalUserManagement.enabled) ( not .Values.features.externalUserManagement.ldap.certTrusted) }}
+          emptyDir: {}
         - name: ldap-ca
+          {{ if or (not .Values.features.externalUserManagement.enabled) ( not .Values.features.externalUserManagement.ldap.certTrusted) }}
           secret:
             secretName: {{ .Values.secretRefs.ldapCaRef }}
-        {{ end }}
-        - name: tmp-volume
-          emptyDir:
-            medium: Memory
-            sizeLimit: 6Mi
+          {{ else }}
+          emptyDir: {}
+          {{ end }}
 {{ end }}

--- a/charts/ocis/templates/auth-basic/service.yaml
+++ b/charts/ocis/templates/auth-basic/service.yaml
@@ -1,5 +1,5 @@
-{{- $_ := set . "appName" "auth-basic" -}}
 {{ if .Values.features.basicAuthentication }}
+{{- $_ := set . "appName" "auth-basic" -}}
 apiVersion: v1
 kind: Service
 metadata:

--- a/charts/ocis/templates/auth-machine/deployment.yaml
+++ b/charts/ocis/templates/auth-machine/deployment.yaml
@@ -85,16 +85,17 @@ spec:
             failureThreshold: 3
 
           resources: {{ toYaml .resources | nindent 12 }}
+
           ports:
             - name: grpc
               containerPort: 9166
             - name: metrics-debug
               containerPort: 9167
+
           volumeMounts:
             - name: tmp-volume
               mountPath: /tmp
+
       volumes:
         - name: tmp-volume
-          emptyDir:
-            medium: Memory
-            sizeLimit: 6Mi
+          emptyDir: {}

--- a/charts/ocis/templates/frontend/deployment.yaml
+++ b/charts/ocis/templates/frontend/deployment.yaml
@@ -100,16 +100,17 @@ spec:
             failureThreshold: 3
 
           resources: {{ toYaml .resources | nindent 12 }}
+
           ports:
             - name: http
               containerPort: 9140
             - name: metrics-debug
               containerPort: 9141
+
           volumeMounts:
             - name: tmp-volume
               mountPath: /tmp
+
       volumes:
         - name: tmp-volume
-          emptyDir:
-            medium: Memory
-            sizeLimit: 6Mi
+          emptyDir: {}

--- a/charts/ocis/templates/gateway/deployment.yaml
+++ b/charts/ocis/templates/gateway/deployment.yaml
@@ -130,16 +130,17 @@ spec:
             failureThreshold: 3
 
           resources: {{ toYaml .resources | nindent 12 }}
+
           ports:
             - name: grpc
               containerPort: 9142
             - name: metrics-debug
               containerPort: 9143
+
           volumeMounts:
             - name: tmp-volume
               mountPath: /tmp
+
       volumes:
         - name: tmp-volume
-          emptyDir:
-            medium: Memory
-            sizeLimit: 6Mi
+          emptyDir: {}

--- a/charts/ocis/templates/graph/deployment.yaml
+++ b/charts/ocis/templates/graph/deployment.yaml
@@ -142,13 +142,13 @@ spec:
             {{- if not .Values.messagingSystem.external.enabled }}
               value: nats:9233
             {{- else }}
-              value: {{ .Values.messagingSystem.external.endpoint }}
+              value: {{ .Values.messagingSystem.external.endpoint | quote }}
             - name: GRAPH_EVENTS_CLUSTER
-              value: {{ .Values.messagingSystem.external.cluster }}
+              value: {{ .Values.messagingSystem.external.cluster | quote }}
             - name: GRAPH_EVENTS_ENABLE_TLS
-              value: {{ .Values.messagingSystem.external.tls.enabled }}
+              value: {{ .Values.messagingSystem.external.tls.enabled | quote }}
             - name: GRAPH_EVENTS_TLS_INSECURE
-              value: {{ .Values.messagingSystem.external.tls.insecure }}
+              value: {{ .Values.messagingSystem.external.tls.insecure | quote }}
             - name: GRAPH_EVENTS_TLS_ROOT_CA_CERTIFICATE
               {{ if or (not .Values.messagingSystem.external.enabled) (not .Values.messagingSystem.external.tls.certTrusted) }}
               value: /etc/ocis/messaging-system-ca/messaging-system-ca.crt

--- a/charts/ocis/templates/graph/deployment.yaml
+++ b/charts/ocis/templates/graph/deployment.yaml
@@ -150,11 +150,11 @@ spec:
             - name: GRAPH_EVENTS_TLS_INSECURE
               value: {{ .Values.messagingSystem.external.tls.insecure | quote }}
             - name: GRAPH_EVENTS_TLS_ROOT_CA_CERTIFICATE
-              {{ if or (not .Values.messagingSystem.external.enabled) (not .Values.messagingSystem.external.tls.certTrusted) }}
+              {{- if not .Values.messagingSystem.external.tls.certTrusted }}
               value: /etc/ocis/messaging-system-ca/messaging-system-ca.crt
-              {{ else }}
+              {{- else }}
               value: "" # no cert needed
-              {{ end }}
+              {{- end }}
             {{- end }}
 
 
@@ -195,7 +195,7 @@ spec:
         - name: ocis-config-tmp
           emptyDir: {}
         - name: messaging-system-ca
-          {{ if or (not .Values.messagingSystem.external.enabled) (not .Values.messagingSystem.external.tls.certTrusted) }}
+          {{ if and (.Values.messagingSystem.external.enabled) (not .Values.messagingSystem.external.tls.certTrusted) }}
           secret:
             secretName: {{ .Values.secretRefs.messagingSystemCaRef }}
           {{ else }}

--- a/charts/ocis/templates/graph/deployment.yaml
+++ b/charts/ocis/templates/graph/deployment.yaml
@@ -139,7 +139,24 @@ spec:
             - name: REVA_GATEWAY
               value: gateway:9142
             - name: GRAPH_EVENTS_ENDPOINT
+            {{- if not .Values.messagingSystem.external.enabled }}
               value: nats:9233
+            {{- else }}
+              value: {{ .Values.messagingSystem.external.endpoint }}
+            - name: GRAPH_EVENTS_CLUSTER
+              value: {{ .Values.messagingSystem.external.cluster }}
+            - name: GRAPH_EVENTS_ENABLE_TLS
+              value: {{ .Values.messagingSystem.external.tls.enabled }}
+            - name: GRAPH_EVENTS_TLS_INSECURE
+              value: {{ .Values.messagingSystem.external.tls.insecure }}
+            - name: GRAPH_EVENTS_TLS_ROOT_CA_CERTIFICATE
+              {{ if or (not .Values.messagingSystem.external.enabled) (not .Values.messagingSystem.external.tls.certTrusted) }}
+              value: /etc/ocis/messaging-system-ca/messaging-system-ca.crt
+              {{ else }}
+              value: "" # no cert needed
+              {{ end }}
+            {{- end }}
+
 
             - name: GRAPH_JWT_SECRET
               valueFrom:
@@ -157,26 +174,37 @@ spec:
             failureThreshold: 3
 
           resources: {{ toYaml .resources | nindent 12 }}
+
           ports:
             - name: http
               containerPort: 9120
             - name: metrics-debug
               containerPort: 9124
-          {{ if not .Values.features.externalUserManagement.enabled }}
+
           volumeMounts:
             - name: ocis-config-tmp
               mountPath: /etc/ocis # we mount that volume only to apply fsGroup to that path
+            - name: messaging-system-ca
+              mountPath: /etc/ocis/messaging-system-ca
+              readOnly: true
             - name: ldap-ca
               mountPath: /etc/ocis/ldap-ca
               readOnly: true
-          {{ end }}
-      {{ if not .Values.features.externalUserManagement.enabled }}
+
       volumes:
         - name: ocis-config-tmp
-          emptyDir:
-            medium: Memory
-            sizeLimit: 6Mi
+          emptyDir: {}
+        - name: messaging-system-ca
+          {{ if or (not .Values.messagingSystem.external.enabled) (not .Values.messagingSystem.external.tls.certTrusted) }}
+          secret:
+            secretName: {{ .Values.secretRefs.messagingSystemCaRef }}
+          {{ else }}
+          emptyDir: {}
+          {{ end }}
         - name: ldap-ca
+          {{ if not .Values.features.externalUserManagement.enabled }}
           secret:
             secretName: {{ .Values.secretRefs.ldapCaRef }}
-      {{ end }}
+          {{ else }}
+          emptyDir: {}
+          {{ end }}

--- a/charts/ocis/templates/groups/deployment.yaml
+++ b/charts/ocis/templates/groups/deployment.yaml
@@ -166,32 +166,31 @@ spec:
             failureThreshold: 3
 
           resources: {{ toYaml .resources | nindent 12 }}
+
           ports:
             - name: grpc
               containerPort: 9160
             - name: metrics-debug
               containerPort: 9161
+
           volumeMounts:
+            - name: tmp-volume
+              mountPath: /tmp
             - name: ocis-config-tmp
               mountPath: /etc/ocis # we mount that volume only to apply fsGroup to that path
-            {{ if or (not .Values.features.externalUserManagement.enabled) ( not .Values.features.externalUserManagement.ldap.certTrusted) }}
             - name: ldap-ca
               mountPath: /etc/ocis/ldap-ca
               readOnly: true
-            {{ end }}
-            - name: tmp-volume
-              mountPath: /tmp
+
       volumes:
+        - name: tmp-volume
+          emptyDir: {}
         - name: ocis-config-tmp
-          emptyDir:
-            medium: Memory
-            sizeLimit: 6Mi
-        {{ if or (not .Values.features.externalUserManagement.enabled) ( not .Values.features.externalUserManagement.ldap.certTrusted) }}
+          emptyDir: {}
         - name: ldap-ca
+          {{ if or (not .Values.features.externalUserManagement.enabled) ( not .Values.features.externalUserManagement.ldap.certTrusted) }}
           secret:
             secretName: {{ .Values.secretRefs.ldapCaRef }}
-        {{ end }}
-        - name: tmp-volume
-          emptyDir:
-            medium: Memory
-            sizeLimit: 6Mi
+          {{ else }}
+          emptyDir: {}
+          {{ end }}

--- a/charts/ocis/templates/idm/deployment.yaml
+++ b/charts/ocis/templates/idm/deployment.yaml
@@ -1,5 +1,5 @@
-{{- $_ := set . "appName" "idm" -}}
 {{- if not .Values.features.externalUserManagement.enabled }}
+{{- $_ := set . "appName" "idm" -}}
 {{- $_ := set . "resources" (default (default (dict) .Values.resources) .Values.services.idm.resources) -}}
 apiVersion: apps/v1
 kind: Deployment
@@ -134,12 +134,14 @@ spec:
             failureThreshold: 3
 
           resources: {{ toYaml .resources | nindent 12 }}
+
           ports:
             - name: ldaps
               containerPort: 9235
             # TODO: IDM does not currently provide a debug port, re-enable this once that is implemented
             # - name: metrics-debug
             #   containerPort: 9239
+
           volumeMounts:
             - name: ocis-config-tmp
               mountPath: /etc/ocis # we mount that volume only to apply fsGroup to that path
@@ -148,20 +150,18 @@ spec:
               readOnly: true
             - name: idm-data
               mountPath: /var/lib/ocis
+
       volumes:
         - name: ocis-config-tmp
-          emptyDir:
-            medium: Memory
-            sizeLimit: 6Mi
+          emptyDir: {}
         - name: ldap-cert
           secret:
             secretName: {{ .Values.secretRefs.ldapCertRef }}
-      {{ if .Values.services.idm.persistence.enabled }}
         - name: idm-data
+          {{ if .Values.services.idm.persistence.enabled }}
           persistentVolumeClaim:
             claimName: idm-data
-      {{ else }}
-        - name: idm-data
+          {{ else }}
           emptyDir: {}
-      {{ end }}
+          {{ end }}
 {{- end }}

--- a/charts/ocis/templates/idm/service.yaml
+++ b/charts/ocis/templates/idm/service.yaml
@@ -1,5 +1,5 @@
-{{- $_ := set . "appName" "idm" -}}
 {{- if not .Values.features.externalUserManagement.enabled }}
+{{- $_ := set . "appName" "idm" -}}
 apiVersion: v1
 kind: Service
 metadata:

--- a/charts/ocis/templates/idp/deployment.yaml
+++ b/charts/ocis/templates/idp/deployment.yaml
@@ -1,5 +1,5 @@
-{{- $_ := set . "appName" "idp" -}}
 {{- if not .Values.features.externalUserManagement.enabled }}
+{{- $_ := set . "appName" "idp" -}}
 {{- $_ := set . "resources" (default (default (dict) .Values.resources) .Values.services.idp.resources) -}}
 apiVersion: apps/v1
 kind: Deployment
@@ -89,12 +89,16 @@ spec:
             failureThreshold: 3
 
           resources: {{ toYaml .resources | nindent 12 }}
+
           ports:
             - name: http
               containerPort: 9130
             - name: metrics-debug
               containerPort: 9134
+
           volumeMounts:
+            - name: ocis-data-tmp
+              mountPath: /var/lib/ocis # we mount that volume to apply fsGroup to that path, so that the idp can write the temporary idp/tmp/identifier-registration.yaml file
             - name: ocis-config-tmp
               mountPath: /etc/ocis # we mount that volume only to apply fsGroup to that path
             - name: ldap-ca
@@ -103,21 +107,16 @@ spec:
             - name: idp-secrets
               mountPath: /etc/ocis/idp
               readOnly: true
-            - name: ocis-data-tmp
-              mountPath: /var/lib/ocis # we mount that volume to apply fsGroup to that path, so that the idp can write the temporary idp/tmp/identifier-registration.yaml file
+
       volumes:
+        - name: ocis-data-tmp
+          emptyDir: {}
         - name: ocis-config-tmp
-          emptyDir:
-            medium: Memory
-            sizeLimit: 6Mi
+          emptyDir: {}
         - name: ldap-ca
           secret:
             secretName: {{ .Values.secretRefs.ldapCaRef }}
         - name: idp-secrets
           secret:
             secretName: {{ .Values.secretRefs.idpSecretRef }}
-        - name: ocis-data-tmp
-          emptyDir:
-            medium: Memory
-            sizeLimit: 6Mi
 {{- end }}

--- a/charts/ocis/templates/idp/service.yaml
+++ b/charts/ocis/templates/idp/service.yaml
@@ -1,5 +1,5 @@
-{{- $_ := set . "appName" "idp" -}}
 {{- if not .Values.features.externalUserManagement.enabled }}
+{{- $_ := set . "appName" "idp" -}}
 apiVersion: v1
 kind: Service
 metadata:

--- a/charts/ocis/templates/nats/deployment.yaml
+++ b/charts/ocis/templates/nats/deployment.yaml
@@ -1,4 +1,4 @@
-{{- if not .Values.messagingSystem.external }}
+{{- if not .Values.messagingSystem.external.enabled }}
 {{- $_ := set . "appName" "nats" -}}
 {{- $_ := set . "resources" (default (default (dict) .Values.resources) .Values.services.nats.resources) -}}
 apiVersion: apps/v1

--- a/charts/ocis/templates/nats/deployment.yaml
+++ b/charts/ocis/templates/nats/deployment.yaml
@@ -1,3 +1,4 @@
+{{- if not .Values.messagingSystem.external }}
 {{- $_ := set . "appName" "nats" -}}
 {{- $_ := set . "resources" (default (default (dict) .Values.resources) .Values.services.nats.resources) -}}
 apiVersion: apps/v1
@@ -84,21 +85,24 @@ spec:
             failureThreshold: 3
 
           resources: {{ toYaml .resources | nindent 12 }}
+
           ports:
             - name: nats
               containerPort: 9233
             # TODO: NATS does not currently provide a debug port, re-enable this once that is implemented
             # - name: metrics-debug
             #   containerPort: 9234
+
           volumeMounts:
             - name: nats-data
               mountPath: /var/lib/ocis
+
       volumes:
-      {{- if .Values.services.nats.persistence.enabled }}
         - name: nats-data
+          {{ if .Values.services.nats.persistence.enabled }}
           persistentVolumeClaim:
             claimName: nats-data
-      {{ else }}
-        - name: nats-data
+          {{ else }}
           emptyDir: {}
-      {{ end }}
+          {{ end }}
+{{- end }}

--- a/charts/ocis/templates/nats/pvc.yaml
+++ b/charts/ocis/templates/nats/pvc.yaml
@@ -1,3 +1,4 @@
+{{- if not .Values.messagingSystem.external }}
 {{- if and .Values.services.nats.persistence.enabled (not .Values.services.nats.persistence.existingClaim)}}
 apiVersion: v1
 kind: PersistentVolumeClaim
@@ -30,4 +31,5 @@ spec:
     matchLabels:
 {{ toYaml . | indent 6 }}
   {{- end }}
-{{- end -}}
+{{- end }}
+{{- end }}

--- a/charts/ocis/templates/nats/pvc.yaml
+++ b/charts/ocis/templates/nats/pvc.yaml
@@ -1,4 +1,4 @@
-{{- if not .Values.messagingSystem.external }}
+{{- if not .Values.messagingSystem.external.enabled }}
 {{- if and .Values.services.nats.persistence.enabled (not .Values.services.nats.persistence.existingClaim)}}
 apiVersion: v1
 kind: PersistentVolumeClaim

--- a/charts/ocis/templates/nats/service.yaml
+++ b/charts/ocis/templates/nats/service.yaml
@@ -1,4 +1,4 @@
-{{- if not .Values.messagingSystem.external }}
+{{- if not .Values.messagingSystem.external.enabled }}
 {{- $_ := set . "appName" "nats" -}}
 apiVersion: v1
 kind: Service

--- a/charts/ocis/templates/nats/service.yaml
+++ b/charts/ocis/templates/nats/service.yaml
@@ -1,3 +1,4 @@
+{{- if not .Values.messagingSystem.external }}
 {{- $_ := set . "appName" "nats" -}}
 apiVersion: v1
 kind: Service
@@ -19,3 +20,4 @@ spec:
     # - name: metrics-debug
     #   port: 9234
     #   protocol: TCP
+{{- end }}

--- a/charts/ocis/templates/notifications/deployment.yaml
+++ b/charts/ocis/templates/notifications/deployment.yaml
@@ -100,11 +100,11 @@ spec:
             - name: NOTIFICIATIONS_EVENTS_TLS_INSECURE
               value: {{ .Values.messagingSystem.external.tls.insecure | quote }}
             - name: NOTIFICIATIONS_EVENTS_TLS_ROOT_CA_CERTIFICATE
-              {{ if or (not .Values.messagingSystem.external.enabled) (not .Values.messagingSystem.external.tls.certTrusted) }}
+              {{- if not .Values.messagingSystem.external.tls.certTrusted }}
               value: /etc/ocis/messaging-system-ca/messaging-system-ca.crt
-              {{ else }}
+              {{- else }}
               value: "" # no cert needed
-              {{ end }}
+              {{- end }}
             {{- end }}
 
             - name: NOTIFICATIONS_MACHINE_AUTH_API_KEY
@@ -141,7 +141,7 @@ spec:
         - name: ocis-config-tmp
           emptyDir: {}
         - name: messaging-system-ca
-          {{ if or (not .Values.messagingSystem.external.enabled) (not .Values.messagingSystem.external.tls.certTrusted) }}
+          {{ if and (.Values.messagingSystem.external.enabled) (not .Values.messagingSystem.external.tls.certTrusted) }}
           secret:
             secretName: {{ .Values.secretRefs.messagingSystemCaRef }}
           {{ else }}

--- a/charts/ocis/templates/notifications/deployment.yaml
+++ b/charts/ocis/templates/notifications/deployment.yaml
@@ -1,5 +1,5 @@
-{{- $_ := set . "appName" "notifications" -}}
 {{- if .Values.features.emailNotifications.enabled }}
+{{- $_ := set . "appName" "notifications" -}}
 {{- $_ := set . "resources" (default (default (dict) .Values.resources) .Values.services.notifications.resources) -}}
 apiVersion: apps/v1
 kind: Deployment
@@ -89,7 +89,23 @@ spec:
             - name: REVA_GATEWAY
               value: gateway:9142
             - name: NOTIFICATIONS_EVENTS_ENDPOINT
+            {{- if not .Values.messagingSystem.external.enabled }}
               value: nats:9233
+            {{- else }}
+              value: {{ .Values.messagingSystem.external.endpoint }}
+            - name: NOTIFICIATIONS_EVENTS_CLUSTER
+              value: {{ .Values.messagingSystem.external.cluster }}
+            - name: NOTIFICIATIONS_EVENTS_ENABLE_TLS
+              value: {{ .Values.messagingSystem.external.tls.enabled }}
+            - name: NOTIFICIATIONS_EVENTS_TLS_INSECURE
+              value: {{ .Values.messagingSystem.external.tls.insecure }}
+            - name: NOTIFICIATIONS_EVENTS_TLS_ROOT_CA_CERTIFICATE
+              {{ if or (not .Values.messagingSystem.external.enabled) (not .Values.messagingSystem.external.tls.certTrusted) }}
+              value: /etc/ocis/messaging-system-ca/messaging-system-ca.crt
+              {{ else }}
+              value: "" # no cert needed
+              {{ end }}
+            {{- end }}
 
             - name: NOTIFICATIONS_MACHINE_AUTH_API_KEY
               valueFrom:
@@ -113,4 +129,22 @@ spec:
           # ports:
           #   - name: metrics-debug
           #     containerPort: 9174
+
+          volumeMounts:
+            - name: ocis-config-tmp
+              mountPath: /etc/ocis # we mount that volume only to apply fsGroup to that path
+            - name: messaging-system-ca
+              mountPath: /etc/ocis/messaging-system-ca
+              readOnly: true
+
+      volumes:
+        - name: ocis-config-tmp
+          emptyDir: {}
+        - name: messaging-system-ca
+          {{ if or (not .Values.messagingSystem.external.enabled) (not .Values.messagingSystem.external.tls.certTrusted) }}
+          secret:
+            secretName: {{ .Values.secretRefs.messagingSystemCaRef }}
+          {{ else }}
+          emptyDir: {}
+          {{ end }}
 {{- end }}

--- a/charts/ocis/templates/notifications/deployment.yaml
+++ b/charts/ocis/templates/notifications/deployment.yaml
@@ -92,13 +92,13 @@ spec:
             {{- if not .Values.messagingSystem.external.enabled }}
               value: nats:9233
             {{- else }}
-              value: {{ .Values.messagingSystem.external.endpoint }}
+              value: {{ .Values.messagingSystem.external.endpoint | quote }}
             - name: NOTIFICIATIONS_EVENTS_CLUSTER
-              value: {{ .Values.messagingSystem.external.cluster }}
+              value: {{ .Values.messagingSystem.external.cluster | quote }}
             - name: NOTIFICIATIONS_EVENTS_ENABLE_TLS
-              value: {{ .Values.messagingSystem.external.tls.enabled }}
+              value: {{ .Values.messagingSystem.external.tls.enabled | quote }}
             - name: NOTIFICIATIONS_EVENTS_TLS_INSECURE
-              value: {{ .Values.messagingSystem.external.tls.insecure }}
+              value: {{ .Values.messagingSystem.external.tls.insecure | quote }}
             - name: NOTIFICIATIONS_EVENTS_TLS_ROOT_CA_CERTIFICATE
               {{ if or (not .Values.messagingSystem.external.enabled) (not .Values.messagingSystem.external.tls.certTrusted) }}
               value: /etc/ocis/messaging-system-ca/messaging-system-ca.crt

--- a/charts/ocis/templates/proxy/deployment.yaml
+++ b/charts/ocis/templates/proxy/deployment.yaml
@@ -113,14 +113,17 @@ spec:
             failureThreshold: 3
 
           resources: {{ toYaml .resources | nindent 12 }}
+
           ports:
             - name: http
               containerPort: 9200
             - name: metrics-debug
               containerPort: 9205
+
           volumeMounts:
             - name: configs
               mountPath: /etc/ocis
+
       volumes:
         - name: configs
           configMap:

--- a/charts/ocis/templates/search/deployment.yaml
+++ b/charts/ocis/templates/search/deployment.yaml
@@ -86,11 +86,11 @@ spec:
             - name: SEARCH_EVENTS_TLS_INSECURE
               value: {{ .Values.messagingSystem.external.tls.insecure | quote }}
             - name: SEARCH_EVENTS_TLS_ROOT_CA_CERTIFICATE
-              {{ if or (not .Values.messagingSystem.external.enabled) (not .Values.messagingSystem.external.tls.certTrusted) }}
+              {{- if not .Values.messagingSystem.external.tls.certTrusted }}
               value: /etc/ocis/messaging-system-ca/messaging-system-ca.crt
-              {{ else }}
+              {{- else }}
               value: "" # no cert needed
-              {{ end }}
+              {{- end }}
             {{- end }}
 
 
@@ -131,7 +131,7 @@ spec:
         - name: ocis-config-tmp
           emptyDir: {}
         - name: messaging-system-ca
-          {{ if or (not .Values.messagingSystem.external.enabled) (not .Values.messagingSystem.external.tls.certTrusted) }}
+          {{ if and (.Values.messagingSystem.external.enabled) (not .Values.messagingSystem.external.tls.certTrusted) }}
           secret:
             secretName: {{ .Values.secretRefs.messagingSystemCaRef }}
           {{ else }}

--- a/charts/ocis/templates/search/deployment.yaml
+++ b/charts/ocis/templates/search/deployment.yaml
@@ -75,7 +75,25 @@ spec:
             - name: REVA_GATEWAY
               value: gateway:9142
             - name: SEARCH_EVENTS_ENDPOINT
+            {{- if not .Values.messagingSystem.external.enabled }}
               value: nats:9233
+            {{- else }}
+              value: {{ .Values.messagingSystem.external.endpoint }}
+            - name: SEARCH_EVENTS_CLUSTER
+              value: {{ .Values.messagingSystem.external.cluster }}
+            - name: SEARCH_EVENTS_ENABLE_TLS
+              value: {{ .Values.messagingSystem.external.tls.enabled }}
+            - name: SEARCH_EVENTS_TLS_INSECURE
+              value: {{ .Values.messagingSystem.external.tls.insecure }}
+            - name: SEARCH_EVENTS_TLS_ROOT_CA_CERTIFICATE
+              {{ if or (not .Values.messagingSystem.external.enabled) (not .Values.messagingSystem.external.tls.certTrusted) }}
+              value: /etc/ocis/messaging-system-ca/messaging-system-ca.crt
+              {{ else }}
+              value: "" # no cert needed
+              {{ end }}
+            {{- end }}
+
+
 
             - name: SEARCH_MACHINE_AUTH_API_KEY
               valueFrom:
@@ -93,20 +111,36 @@ spec:
             failureThreshold: 3
 
           resources: {{ toYaml .resources | nindent 12 }}
+
           ports:
             - name: grpc
               containerPort: 9220
             - name: metrics-debug
               containerPort: 9224
+
           volumeMounts:
+            - name: ocis-config-tmp
+              mountPath: /etc/ocis # we mount that volume only to apply fsGroup to that path
+            - name: messaging-system-ca
+              mountPath: /etc/ocis/messaging-system-ca
+              readOnly: true
             - name: search-data
               mountPath: /var/lib/ocis
+
       volumes:
-      {{- if .Values.services.search.persistence.enabled }}
+        - name: ocis-config-tmp
+          emptyDir: {}
+        - name: messaging-system-ca
+          {{ if or (not .Values.messagingSystem.external.enabled) (not .Values.messagingSystem.external.tls.certTrusted) }}
+          secret:
+            secretName: {{ .Values.secretRefs.messagingSystemCaRef }}
+          {{ else }}
+          emptyDir: {}
+          {{ end }}
         - name: search-data
+          {{ if .Values.services.search.persistence.enabled }}
           persistentVolumeClaim:
             claimName: search-data
-      {{ else }}
-        - name: search-data
+          {{ else }}
           emptyDir: {}
-      {{ end }}
+          {{ end }}

--- a/charts/ocis/templates/search/deployment.yaml
+++ b/charts/ocis/templates/search/deployment.yaml
@@ -82,9 +82,9 @@ spec:
             - name: SEARCH_EVENTS_CLUSTER
               value: {{ .Values.messagingSystem.external.cluster }}
             - name: SEARCH_EVENTS_ENABLE_TLS
-              value: {{ .Values.messagingSystem.external.tls.enabled }}
+              value: {{ .Values.messagingSystem.external.tls.enabled | quote }}
             - name: SEARCH_EVENTS_TLS_INSECURE
-              value: {{ .Values.messagingSystem.external.tls.insecure }}
+              value: {{ .Values.messagingSystem.external.tls.insecure | quote }}
             - name: SEARCH_EVENTS_TLS_ROOT_CA_CERTIFICATE
               {{ if or (not .Values.messagingSystem.external.enabled) (not .Values.messagingSystem.external.tls.certTrusted) }}
               value: /etc/ocis/messaging-system-ca/messaging-system-ca.crt

--- a/charts/ocis/templates/sharing/deployment.yaml
+++ b/charts/ocis/templates/sharing/deployment.yaml
@@ -74,11 +74,11 @@ spec:
             - name: SHARING_EVENTS_TLS_INSECURE
               value: {{ .Values.messagingSystem.external.tls.insecure | quote }}
             - name: SHARING_EVENTS_TLS_ROOT_CA_CERTIFICATE
-              {{ if or (not .Values.messagingSystem.external.enabled) (not .Values.messagingSystem.external.tls.certTrusted) }}
+              {{- if not .Values.messagingSystem.external.tls.certTrusted }}
               value: /etc/ocis/messaging-system-ca/messaging-system-ca.crt
-              {{ else }}
+              {{- else }}
               value: "" # no cert needed
-              {{ end }}
+              {{- end }}
             {{- end }}
 
             - name: SHARING_JWT_SECRET
@@ -152,7 +152,7 @@ spec:
         - name: ocis-config-tmp
           emptyDir: {}
         - name: messaging-system-ca
-          {{ if or (not .Values.messagingSystem.external.enabled) (not .Values.messagingSystem.external.tls.certTrusted) }}
+          {{ if and (.Values.messagingSystem.external.enabled) (not .Values.messagingSystem.external.tls.certTrusted) }}
           secret:
             secretName: {{ .Values.secretRefs.messagingSystemCaRef }}
           {{ else }}

--- a/charts/ocis/templates/sharing/deployment.yaml
+++ b/charts/ocis/templates/sharing/deployment.yaml
@@ -70,9 +70,9 @@ spec:
             - name: SHARING_EVENTS_CLUSTER
               value: {{ .Values.messagingSystem.external.cluster }}
             - name: SHARING_EVENTS_ENABLE_TLS
-              value: {{ .Values.messagingSystem.external.tls.enabled }}
+              value: {{ .Values.messagingSystem.external.tls.enabled | quote }}
             - name: SHARING_EVENTS_TLS_INSECURE
-              value: {{ .Values.messagingSystem.external.tls.insecure }}
+              value: {{ .Values.messagingSystem.external.tls.insecure | quote }}
             - name: SHARING_EVENTS_TLS_ROOT_CA_CERTIFICATE
               {{ if or (not .Values.messagingSystem.external.enabled) (not .Values.messagingSystem.external.tls.certTrusted) }}
               value: /etc/ocis/messaging-system-ca/messaging-system-ca.crt

--- a/charts/ocis/templates/sharing/deployment.yaml
+++ b/charts/ocis/templates/sharing/deployment.yaml
@@ -63,7 +63,23 @@ spec:
             - name: REVA_GATEWAY
               value: gateway:9142
             - name: SHARING_EVENTS_ENDPOINT
+            {{- if not .Values.messagingSystem.external.enabled }}
               value: nats:9233
+            {{- else }}
+              value: {{ .Values.messagingSystem.external.endpoint }}
+            - name: SHARING_EVENTS_CLUSTER
+              value: {{ .Values.messagingSystem.external.cluster }}
+            - name: SHARING_EVENTS_ENABLE_TLS
+              value: {{ .Values.messagingSystem.external.tls.enabled }}
+            - name: SHARING_EVENTS_TLS_INSECURE
+              value: {{ .Values.messagingSystem.external.tls.insecure }}
+            - name: SHARING_EVENTS_TLS_ROOT_CA_CERTIFICATE
+              {{ if or (not .Values.messagingSystem.external.enabled) (not .Values.messagingSystem.external.tls.certTrusted) }}
+              value: /etc/ocis/messaging-system-ca/messaging-system-ca.crt
+              {{ else }}
+              value: "" # no cert needed
+              {{ end }}
+            {{- end }}
 
             - name: SHARING_JWT_SECRET
               valueFrom:
@@ -113,16 +129,32 @@ spec:
             failureThreshold: 3
 
           resources: {{ toYaml .resources | nindent 12 }}
+
           ports:
             - name: grpc
               containerPort: 9150
             - name: metrics-debug
               containerPort: 9151
+
           volumeMounts:
             - name: tmp-volume
               mountPath: /tmp
+            - name: ocis-config-tmp
+              mountPath: /etc/ocis # we mount that volume only to apply fsGroup to that path
+            - name: messaging-system-ca
+              mountPath: /etc/ocis/messaging-system-ca
+              readOnly: true
+
+
       volumes:
         - name: tmp-volume
-          emptyDir:
-            medium: Memory
-            sizeLimit: 6Mi
+          emptyDir: {}
+        - name: ocis-config-tmp
+          emptyDir: {}
+        - name: messaging-system-ca
+          {{ if or (not .Values.messagingSystem.external.enabled) (not .Values.messagingSystem.external.tls.certTrusted) }}
+          secret:
+            secretName: {{ .Values.secretRefs.messagingSystemCaRef }}
+          {{ else }}
+          emptyDir: {}
+          {{ end }}

--- a/charts/ocis/templates/storage-publiclink/deployment.yaml
+++ b/charts/ocis/templates/storage-publiclink/deployment.yaml
@@ -79,16 +79,17 @@ spec:
             failureThreshold: 3
 
           resources: {{ toYaml .resources | nindent 12 }}
+
           ports:
             - name: grpc
               containerPort: 9178
             - name: metrics-debug
               containerPort: 9179
+
           volumeMounts:
             - name: tmp-volume
               mountPath: /tmp
+
       volumes:
         - name: tmp-volume
-          emptyDir:
-            medium: Memory
-            sizeLimit: 6Mi
+          emptyDir: {}

--- a/charts/ocis/templates/storage-shares/deployment.yaml
+++ b/charts/ocis/templates/storage-shares/deployment.yaml
@@ -82,16 +82,17 @@ spec:
             failureThreshold: 3
 
           resources: {{ toYaml .resources | nindent 12 }}
+
           ports:
             - name: grpc
               containerPort: 9154
             - name: metrics-debug
               containerPort: 9156
+
           volumeMounts:
             - name: tmp-volume
               mountPath: /tmp
+
       volumes:
         - name: tmp-volume
-          emptyDir:
-            medium: Memory
-            sizeLimit: 6Mi
+          emptyDir: {}

--- a/charts/ocis/templates/storage-system/deployment.yaml
+++ b/charts/ocis/templates/storage-system/deployment.yaml
@@ -111,6 +111,7 @@ spec:
             failureThreshold: 3
 
           resources: {{ toYaml .resources | nindent 12 }}
+
           ports:
             - name: grpc
               containerPort: 9215
@@ -118,21 +119,20 @@ spec:
               containerPort: 9216
             - name: metrics-debug
               containerPort: 9217
+
           volumeMounts:
             - name: tmp-volume
               mountPath: /tmp
             - name: storage-system-data
               mountPath: /var/lib/ocis
+
       volumes:
         - name: tmp-volume
-          emptyDir:
-              medium: Memory
-              sizeLimit: 6Mi
-      {{- if .Values.services.storageSystem.persistence.enabled }}
+          emptyDir: {}
         - name: storage-system-data
+          {{ if .Values.services.storageSystem.persistence.enabled }}
           persistentVolumeClaim:
             claimName: storage-system-data
-      {{ else }}
-        - name: storage-system-data
+          {{ else }}
           emptyDir: {}
-      {{ end }}
+          {{ end }}

--- a/charts/ocis/templates/storage-users/deployment.yaml
+++ b/charts/ocis/templates/storage-users/deployment.yaml
@@ -110,13 +110,13 @@ spec:
             {{- if not .Values.messagingSystem.external.enabled }}
               value: nats:9233
             {{- else }}
-              value: {{ .Values.messagingSystem.external.endpoint }}
+              value: {{ .Values.messagingSystem.external.endpoint | quote }}
             - name: STORAGE_USERS_EVENTS_CLUSTER
-              value: {{ .Values.messagingSystem.external.cluster }}
+              value: {{ .Values.messagingSystem.external.cluster | quote }}
             - name: STORAGE_USERS_EVENTS_ENABLE_TLS
-              value: {{ .Values.messagingSystem.external.tls.enabled }}
+              value: {{ .Values.messagingSystem.external.tls.enabled | quote }}
             - name: STORAGE_USERS_EVENTS_TLS_INSECURE
-              value: {{ .Values.messagingSystem.external.tls.insecure }}
+              value: {{ .Values.messagingSystem.external.tls.insecure | quote }}
             - name: STORAGE_USERS_EVENTS_TLS_ROOT_CA_CERTIFICATE
               {{ if or (not .Values.messagingSystem.external.enabled) (not .Values.messagingSystem.external.tls.certTrusted) }}
               value: /etc/ocis/messaging-system-ca/messaging-system-ca.crt

--- a/charts/ocis/templates/storage-users/deployment.yaml
+++ b/charts/ocis/templates/storage-users/deployment.yaml
@@ -107,7 +107,23 @@ spec:
 
             # events
             - name: STORAGE_USERS_EVENTS_ENDPOINT
+            {{- if not .Values.messagingSystem.external.enabled }}
               value: nats:9233
+            {{- else }}
+              value: {{ .Values.messagingSystem.external.endpoint }}
+            - name: STORAGE_USERS_EVENTS_CLUSTER
+              value: {{ .Values.messagingSystem.external.cluster }}
+            - name: STORAGE_USERS_EVENTS_ENABLE_TLS
+              value: {{ .Values.messagingSystem.external.tls.enabled }}
+            - name: STORAGE_USERS_EVENTS_TLS_INSECURE
+              value: {{ .Values.messagingSystem.external.tls.insecure }}
+            - name: STORAGE_USERS_EVENTS_TLS_ROOT_CA_CERTIFICATE
+              {{ if or (not .Values.messagingSystem.external.enabled) (not .Values.messagingSystem.external.tls.certTrusted) }}
+              value: /etc/ocis/messaging-system-ca/messaging-system-ca.crt
+              {{ else }}
+              value: "" # no cert needed
+              {{ end }}
+            {{- end }}
 
             - name: REVA_GATEWAY
               value: gateway:9142
@@ -148,6 +164,7 @@ spec:
             failureThreshold: 3
 
           resources: {{ toYaml .resources | nindent 12 }}
+
           ports:
             - name: grpc
               containerPort: 9157
@@ -155,21 +172,34 @@ spec:
               containerPort: 9158
             - name: metrics-debug
               containerPort: 9159
+
           volumeMounts:
             - name: tmp-volume
               mountPath: /tmp
+            - name: ocis-config-tmp
+              mountPath: /etc/ocis # we mount that volume only to apply fsGroup to that path
+            - name: messaging-system-ca
+              mountPath: /etc/ocis/messaging-system-ca
+              readOnly: true
             - name: storage-users-data
               mountPath: /var/lib/ocis
+
       volumes:
         - name: tmp-volume
-          emptyDir:
-            medium: Memory
-            sizeLimit: 6Mi
-      {{- if .Values.services.storageUsers.persistence.enabled }}
+          emptyDir: {}
+        - name: ocis-config-tmp
+          emptyDir: {}
+        - name: messaging-system-ca
+            {{ if or (not .Values.messagingSystem.external.enabled) (not .Values.messagingSystem.external.tls.certTrusted) }}
+          secret:
+            secretName: {{ .Values.secretRefs.messagingSystemCaRef }}
+          {{ else }}
+          emptyDir: {}
+          {{ end }}
         - name: storage-users-data
+          {{ if .Values.services.storageUsers.persistence.enabled }}
           persistentVolumeClaim:
             claimName: storage-users-data
-      {{ else }}
-        - name: storage-users-data
+          {{ else }}
           emptyDir: {}
-      {{ end }}
+          {{ end }}

--- a/charts/ocis/templates/storage-users/deployment.yaml
+++ b/charts/ocis/templates/storage-users/deployment.yaml
@@ -118,11 +118,11 @@ spec:
             - name: STORAGE_USERS_EVENTS_TLS_INSECURE
               value: {{ .Values.messagingSystem.external.tls.insecure | quote }}
             - name: STORAGE_USERS_EVENTS_TLS_ROOT_CA_CERTIFICATE
-              {{ if or (not .Values.messagingSystem.external.enabled) (not .Values.messagingSystem.external.tls.certTrusted) }}
+              {{- if not .Values.messagingSystem.external.tls.certTrusted }}
               value: /etc/ocis/messaging-system-ca/messaging-system-ca.crt
-              {{ else }}
+              {{- else }}
               value: "" # no cert needed
-              {{ end }}
+              {{- end }}
             {{- end }}
 
             - name: REVA_GATEWAY
@@ -190,7 +190,7 @@ spec:
         - name: ocis-config-tmp
           emptyDir: {}
         - name: messaging-system-ca
-            {{ if or (not .Values.messagingSystem.external.enabled) (not .Values.messagingSystem.external.tls.certTrusted) }}
+          {{ if and (.Values.messagingSystem.external.enabled) (not .Values.messagingSystem.external.tls.certTrusted) }}
           secret:
             secretName: {{ .Values.secretRefs.messagingSystemCaRef }}
           {{ else }}

--- a/charts/ocis/templates/storage-users/jobs.yaml
+++ b/charts/ocis/templates/storage-users/jobs.yaml
@@ -75,11 +75,10 @@ spec:
                   mountPath: /tmp
                 - name: storage-users-data
                   mountPath: /var/lib/ocis
+
           volumes:
             - name: tmp-volume
-              emptyDir:
-                medium: Memory
-                sizeLimit: 6Mi
+              emptyDir: {}
             - name: storage-users-data
               persistentVolumeClaim:
                 claimName: storage-users-data

--- a/charts/ocis/templates/store/deployment.yaml
+++ b/charts/ocis/templates/store/deployment.yaml
@@ -80,20 +80,22 @@ spec:
             failureThreshold: 3
 
           resources: {{ toYaml .resources | nindent 12 }}
+
           ports:
             - name: grpc
               containerPort: 9460
             - name: metrics-debug
               containerPort: 9464
+
           volumeMounts:
             - name: store-data
               mountPath: /var/lib/ocis
+
       volumes:
-      {{- if .Values.services.store.persistence.enabled }}
         - name: store-data
+          {{ if .Values.services.store.persistence.enabled }}
           persistentVolumeClaim:
             claimName: store-data
-      {{ else }}
-        - name: store-data
+          {{ else }}
           emptyDir: {}
-      {{ end }}
+          {{ end }}

--- a/charts/ocis/templates/thumbnails/deployment.yaml
+++ b/charts/ocis/templates/thumbnails/deployment.yaml
@@ -102,6 +102,7 @@ spec:
             failureThreshold: 3
 
           resources: {{ toYaml .resources | nindent 12 }}
+
           ports:
             - name: grpc
               containerPort: 9185
@@ -109,15 +110,16 @@ spec:
               containerPort: 9186
             - name: metrics-debug
               containerPort: 9189
+
           volumeMounts:
             - name: thumbnails-data
               mountPath: /var/lib/ocis
+
       volumes:
-      {{- if .Values.services.thumbnails.persistence.enabled }}
         - name: thumbnails-data
+          {{ if .Values.services.thumbnails.persistence.enabled }}
           persistentVolumeClaim:
             claimName: thumbnails-data
-      {{ else }}
-        - name: thumbnails-data
+          {{ else }}
           emptyDir: {}
-      {{ end }}
+          {{ end }}

--- a/charts/ocis/templates/users/deployment.yaml
+++ b/charts/ocis/templates/users/deployment.yaml
@@ -166,32 +166,31 @@ spec:
             failureThreshold: 3
 
           resources: {{ toYaml .resources | nindent 12 }}
+
           ports:
             - name: grpc
               containerPort: 9144
             - name: metrics-debug
               containerPort: 9145
+
           volumeMounts:
+            - name: tmp-volume
+              mountPath: /tmp
             - name: ocis-config-tmp
               mountPath: /etc/ocis # we mount that volume only to apply fsGroup to that path
-            {{ if or (not .Values.features.externalUserManagement.enabled) ( not .Values.features.externalUserManagement.ldap.certTrusted) }}
             - name: ldap-ca
               mountPath: /etc/ocis/ldap-ca
               readOnly: true
-            {{ end }}
-            - name: tmp-volume
-              mountPath: /tmp
+
       volumes:
+        - name: tmp-volume
+          emptyDir: {}
         - name: ocis-config-tmp
-          emptyDir:
-            medium: Memory
-            sizeLimit: 6Mi
-        {{ if or (not .Values.features.externalUserManagement.enabled) ( not .Values.features.externalUserManagement.ldap.certTrusted) }}
+          emptyDir: {}
         - name: ldap-ca
+          {{ if or (not .Values.features.externalUserManagement.enabled) (not .Values.features.externalUserManagement.ldap.certTrusted) }}
           secret:
             secretName: {{ .Values.secretRefs.ldapCaRef }}
-        {{ end }}
-        - name: tmp-volume
-          emptyDir:
-            medium: Memory
-            sizeLimit: 6Mi
+          {{ else }}
+          emptyDir: {}
+          {{ end }}

--- a/charts/ocis/templates/web/deployment.yaml
+++ b/charts/ocis/templates/web/deployment.yaml
@@ -95,14 +95,17 @@ spec:
             failureThreshold: 3
 
           resources: {{ toYaml .resources | nindent 12 }}
+
           ports:
             - name: http
               containerPort: 9100
             - name: metrics-debug
               containerPort: 9104
+
           volumeMounts:
             - name: configs
               mountPath: /etc/ocis
+
       volumes:
         - name: configs
           configMap:

--- a/charts/ocis/values.yaml
+++ b/charts/ocis/values.yaml
@@ -480,12 +480,12 @@ services:
     # -- Per-service resources configuration. Overrides the default setting from `resources` if set.
     resources: {}
 
-  # -- NATS service. Not used if `messagingSystem.external` equals `true`.
+  # -- NATS service. Not used if `messagingSystem.external.enabled` equals `true`.
   # @default -- see detailed service configuration options below
   nats:
     persistence:
       # -- Enables persistence.
-      # Needs to be enabled on production installations, except `messagingSystem.external` equals `true`.
+      # Needs to be enabled on production installations, except `messagingSystem.external.enabled` equals `true`.
       # If not enabled, pod restarts will lead to data loss.
       # Also scaling this service beyond one instance is not possible if the service instances don't share the same storage.
       enabled: false

--- a/charts/ocis/values.yaml
+++ b/charts/ocis/values.yaml
@@ -56,6 +56,30 @@ cache:
   #   - redis-master-1.ocis-redis.svc.cluster.local:6379
   #   - redis-master-2.ocis-redis.svc.cluster.local:6379
 
+messagingSystem:
+  external:
+    # -- Use an external NATS messaging system instead of the internal one.
+    # Recommended for all production instances.
+    # Needs to be used if HighAvailability is needed.
+    # Needs to be used if oCIS shall be used by more than a 2-digit user count.
+    enabled: true
+    # -- Endpoint of the messaging system.
+    endpoint: "nats.ocis-nats.svc.cluster.local:4222"
+    # -- Cluster name to use with the messaging system.
+    cluster: "ocis-cluster"
+    tls:
+      # -- Enables TLS encrypted communication with the messaging system.
+      # Recommended for production installations.
+      enabled: true
+      # -- Set only to false, if the certificate of your messaging system service is not trusted.
+      # If set to false, you need to put the CA cert of the messaging system server into the secret referenced by "messagingSystemCaRef"
+      certTrusted: true
+      # -- Disables SSL certificate checking for connections to the messaging system server.
+      # -- For self signed certificates, consider to put the CA cert of the messaging system secure server into the secret referenced by "messagingSystemCaRef"
+      # Not recommended for production installations.
+      insecure: false
+
+
 # Feature options.
 # Enable or disable features of oCIS.
 features:
@@ -247,6 +271,8 @@ secretRefs:
   ldapSecretRef: "ldap-bind-secrets"
   # -- Reference to an existing machine auth api key secret (see ref:Secrets#secrets)
   machineAuthApiKeySecretRef: "machine-auth-api-key"
+  # -- Reference to an existing messaging system certificate authority secret (see ref:Secrets#secrets)
+  messagingSystemCaRef: "messaging-system-ca"
   # -- Reference to an existing SMTP email server settings secret (see ref:Secrets#secrets). Not used if `features.emailNotifications.enabled` equals `false`.
   notificationsSmtpSecretRef: "notifications-smtp-secret"
   # -- Reference to an existing storage-system JWT secret (see ref:Secrets#secrets)
@@ -454,12 +480,12 @@ services:
     # -- Per-service resources configuration. Overrides the default setting from `resources` if set.
     resources: {}
 
-  # -- NATS service.
+  # -- NATS service. Not used if `messagingSystem.external` equals `true`.
   # @default -- see detailed service configuration options below
   nats:
     persistence:
       # -- Enables persistence.
-      # Needs to be enabled on production installations.
+      # Needs to be enabled on production installations, except `messagingSystem.external` equals `true`.
       # If not enabled, pod restarts will lead to data loss.
       # Also scaling this service beyond one instance is not possible if the service instances don't share the same storage.
       enabled: false

--- a/charts/ocis/values.yaml
+++ b/charts/ocis/values.yaml
@@ -62,7 +62,7 @@ messagingSystem:
     # Recommended for all production instances.
     # Needs to be used if HighAvailability is needed.
     # Needs to be used if oCIS shall be used by more than a 2-digit user count.
-    enabled: true
+    enabled: false
     # -- Endpoint of the messaging system.
     endpoint: "nats.ocis-nats.svc.cluster.local:4222"
     # -- Cluster name to use with the messaging system.


### PR DESCRIPTION
## Description
adds an option to configure an external NATS

## Related Issue
<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->
- Fixes #12

## Motivation and Context
scalable NATS

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
- with following helmfile in Minikube:
  <details>
  
  ```yaml
  repositories:
    - name: nats
      url: https://nats-io.github.io/k8s/helm/charts
  
  releases:
    - name: nats
      chart: nats/nats
      version: 0.19.1
      namespace: nats
      values:
        - cluster:
            enabled: true
            name: "ocis-cluster"
            replicas: 3
        - nats:
            jetstream:
              enabled: true
              memStorage:
                enabled: true
                size: 2Gi
              fileStorage:
                enabled: true
                size: 10Gi
                storageClassName:
              resources:
                limits:
                  cpu: 100m
                  memory: 128Mi
                requests:
                  cpu: 100m
                  memory: 128Mi
        - natsbox:
            # -- Enables the NATS box, which includes utilities for NATS.
            enabled: false
        - reloader:
            enabled: false
  
        - topologyKeys:
            - "kubernetes.io/hostname"
            - "topology.kubernetes.io/zone"
            - "topology.kubernetes.io/region"
  
    - name: ocis
      chart: ../../charts/ocis
      namespace: ocis
      values:
        - externalDomain: ocis.kube.owncloud.test
        - ingress:
            enabled: true
            ingressClassName: nginx
            annotations:
              nginx.ingress.kubernetes.io/proxy-body-size: 1024m
        - insecure:
            oidcIdpInsecure: true
            ocisHttpApiInsecure: true
  
        - messagingSystem:
            external:
              enabled: true
              endpoint: "nats.nats.svc.cluster.local:4222"
              tls:
                enabled: false
  
        - extraResources:
            # generic secrets
            - |
              apiVersion: v1
              kind: Secret
              ....
  ```
  <\details>

## Screenshots (if appropriate):

## Types of changes
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Technical debt
- [ ] Tests only (no source changes)

## Checklist:
- [x] Code changes
- [ ] Unit tests added
- [ ] Acceptance tests added
- [ ] Documentation generated (`make docs`) and committed
- [ ] Documentation ticket raised: <link>
- [ ] Documentation PR created: <link>
