### PR TITLE
enforce best practices

### DIFF
--- a/charts/ocis/templates/NOTES.txt
+++ b/charts/ocis/templates/NOTES.txt
@@ -25,7 +25,7 @@ kubectl -n <namespace> get secrets/admin-user --template='{{"{{"}}.data.password
 {{- $oidcIdpInsecure := .Values.insecure.oidcIdpInsecure -}}
 {{- $ocisHttpApiInsecure := .Values.insecure.ocisHttpApiInsecure -}}
 {{- $externalLDAPinsecure := and .Values.features.externalUserManagement.enabled .Values.features.externalUserManagement.ldap.insecure -}}
-{{- $noSMTPencryption := and .Values.features.emailNotifications.enabled (eq .Values.cache.type "noop") -}}
+{{- $noSMTPencryption := and .Values.features.emailNotifications.enabled (eq .Values.features.emailNotifications.smtp.encryption "none") -}}
 
 {{ if or $noExternalUserManagement $noopCache $basicAuth $demoUsers $oidcIdpInsecure $ocisHttpApiInsecure $externalLDAPinsecure $noSMTPencryption }}
 #################################################################################
@@ -57,7 +57,8 @@ kubectl -n <namespace> get secrets/admin-user --template='{{"{{"}}.data.password
 ######        be set to `false`                                             #####
 {{- end }}
 {{- if $noSMTPencryption}}
-######     - `features.emailNotifications.enabled` should be set to `false` #####
+######     - `features.emailNotifications.smtp.encryption` should           #####
+######        not be set to `none`                                          #####
 {{- end }}
 #################################################################################
 {{ end }}


### PR DESCRIPTION
## Description
add best practice hints to the NOTES.txt

This is what I will see when I violate most of the best practices, eg. on my minikube dev deployment:

```
helmfile sync
Building dependency release=ocis, chart=../../charts/ocis
Upgrading release=ocis, chart=../../charts/ocis
Release "ocis" has been upgraded. Happy Helming!
NAME: ocis
LAST DEPLOYED: Thu Mar  9 09:00:37 2023
NAMESPACE: ocis
STATUS: deployed
REVISION: 52
TEST SUITE: None
NOTES:
You're now running
                 ,----..      ,---,   .--.--.
                /   /   \  ,`--.' |  /  /    '.
       ,---.   |   :     : |   :  : |  :  /`. /
      '   ,'\  .   |  ;. / :   |  ' ;  |  |--`
     /   /   | .   ; /--`  |   :  | |  :  ;_
    .   ; ,. : ;   | ;     '   '  ;  \  \    `.
    '   | |: : |   : |     |   |  |   `----.   \
    '   | .; : .   | '___  '   :  ;   __ \  \  |
    |   :    | '   ; : .'| |   |  '  /  /`--'  /
     \   \  /  '   | '/  : '   :  | '--'.     /
      `----'   |   :    /  ;   |.'    `--'---'
                \   \ .'   '---'
                 `---`


You can get the initial "admin" administrator user password by running:

kubectl -n <namespace> get secrets/admin-user --template='{{.data.password | base64decode}}'


#################################################################################
######   WARNING: Your deployment of oCIS does not follow all best          #####
######   practices for production deployments of oCIS.                      #####
######                                                                      #####
######   Following best practices are not applied:                          #####
######     - `features.externalUserManagement.enabled` should be            #####
######       set to `true`.                                                 #####
######     - `cache.type` should not be set to `noop`                       #####
######     - `features.basicAuthentication` should be set to `false`        #####
######     - `insecure.oidcIdpInsecure` should be set to `false`            #####
######     - `insecure.ocisHttpApiInsecure` should be set to `false`        #####
#################################################################################

#################################################################################
######   WARNING: Persistence is disabled for some services.                #####
######   You will lose your data when a service's pod is terminated.        #####
######                                                                      #####
######   Following services don't use persistence:                          #####
######     - storage-users                                                  #####
######     - storage-system                                                 #####
######     - idm                                                            #####
######     - store                                                          #####
######     - search                                                         #####
######     - nats                                                           #####
#################################################################################

Listing releases matching ^ocis$
ocis	ocis     	52      	2023-03-09 09:00:37.301174228 +0100 CET	deployed	ocis-0.1.0	3.0.0-alpha.1


UPDATED RELEASES:
NAME   CHART               VERSION
ocis   ../../charts/ocis     0.1.0
```
## Related Issue
<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->
- Fixes parts of #112

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
- -

## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Technical debt
- [ ] Tests only (no source changes)

## Checklist:
- [x] Code changes
- [ ] Unit tests added
- [ ] Acceptance tests added
- [ ] Documentation generated (`make docs`) and committed
- [ ] Documentation ticket raised: <link>
- [ ] Documentation PR created: <link>
