### PR TITLE
Fix WEB_OIDC_METADATA_URL for external idp setup

### DIFF
--- a/charts/ocis/templates/web/deployment.yaml
+++ b/charts/ocis/templates/web/deployment.yaml
@@ -83,7 +83,11 @@ spec:
             - name: WEB_UI_CONFIG_SERVER
               value: "https://{{ .Values.externalDomain }}"
             - name: WEB_OIDC_METADATA_URL
+            {{ if not .Values.features.externalUserManagement.enabled }}
               value: "https://{{ .Values.externalDomain }}/.well-known/openid-configuration"
+            {{ else }}
+              value: "{{ .Values.features.externalUserManagement.oidc.issuerURI }}/.well-known/openid-configuration"
+            {{ end }}
 
           livenessProbe:
             httpGet:


### PR DESCRIPTION
## Description
When an external idp, the WEB_OIDC_METADATA_URL  value in deployment.yml for web has to point. to the external idp not the integrated one.

## Motivation and Context
Testing cis with different oidc providers 