### PR TITLE
- add support for Kubernetes sub versions

### DIFF
--- a/charts/ocis/Chart.yaml
+++ b/charts/ocis/Chart.yaml
@@ -14,7 +14,7 @@ appVersion: 2.0.0
 # supported Kubernetes versions
 # should only contain non EOL versions from https://kubernetes.io/releases/patch-releases/#non-active-branch-history
 # if this changes, also kubernetesVersions in .drone.star needs to be changed
-kubeVersion: "~1.23.0 || ~1.24.0 || ~1.25.0"
+kubeVersion: "~1.23.0-0 || ~1.24.0-0 || ~1.25.0-0"
 sources:
   - https://github.com/owncloud/ocis-charts
   - https://github.com/owncloud/ocis


### PR DESCRIPTION
## Description
The change adds support for Kubernetes sub versions. Currently a Kubernetes version like `v1.23.4-r0-CCE22.5.1` will not be detect although it's in the `1.24` range specified.

## Related Issue
None

## Motivation and Context
Something users run Kubernetes systems with identify themselves with a subversion. Currently this will not work properly.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Technical debt
- [ ] Tests only (no source changes)

## Checklist:
<!-- Tick the checkboxes when done. -->
<!-- Raise documentation ticket in https://github.com/owncloud/docs-ocis/issues -->
<!-- or create documentation PR in https://github.com/owncloud/docs-ocis/tree/master/modules/ROOT/pages/deployment/container>
- [ ] Code changes
- [ ] Unit tests added
- [ ] Acceptance tests added
- [ ] Documentation generated (`make docs`) and committed
- [ ] Documentation ticket raised: <link>
- [ ] Documentation PR created: <link>
