### PR TITLE
change default log level to info to break the silence

### DIFF
--- a/charts/ocis/docs/values-desc-table.adoc
+++ b/charts/ocis/docs/values-desc-table.adoc
@@ -460,7 +460,7 @@ a| [subs=-attributes]
 a| [subs=-attributes]
 +string+
 a| [subs=-attributes]
-`"error"`
+`"info"`
 | Log level. Valid values: `panic`, `fatal`, `error`, `warn`, `info`, `debug`, `trace`.
 | logging.pretty
 a| [subs=-attributes]

--- a/charts/ocis/docs/values.adoc.yaml
+++ b/charts/ocis/docs/values.adoc.yaml
@@ -15,7 +15,7 @@ image:
 # Logging settings for oCIS services
 logging:
   # -- Log level. Valid values: `panic`, `fatal`, `error`, `warn`, `info`, `debug`, `trace`.
-  level: "error"
+  level: "info"
   # -- Activates pretty log output.
   # Not recommended for production installations.
   pretty: "false"

--- a/charts/ocis/values.yaml
+++ b/charts/ocis/values.yaml
@@ -14,7 +14,7 @@ image:
 # Logging settings for oCIS services
 logging:
   # -- Log level. Valid values: `panic`, `fatal`, `error`, `warn`, `info`, `debug`, `trace`.
-  level: "error"
+  level: "info"
   # -- Activates pretty log output.
   # Not recommended for production installations.
   pretty: "false"


### PR DESCRIPTION
## Description
default log level "error" logs almost nothing. Info seems a quite balanced level for a default

## Related Issue
- -

## Motivation and Context

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
- -

## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Technical debt
- [ ] Tests only (no source changes)

## Checklist:
<!-- Tick the checkboxes when done. -->
<!-- Raise documentation ticket in https://github.com/owncloud/docs-ocis/issues -->
<!-- or create documentation PR in https://github.com/owncloud/docs-ocis/tree/master/modules/ROOT/pages/deployment/container>
- [x] Code changes
- [ ] Unit tests added
- [ ] Acceptance tests added
- [ ] Documentation generated (`make docs`) and committed
- [ ] Documentation ticket raised: <link>
- [ ] Documentation PR created: <link>
