### PR TITLE
add configuration option to make external ldap writable

### DIFF
--- a/charts/ocis/docs/values-desc-table.adoc
+++ b/charts/ocis/docs/values-desc-table.adoc
@@ -366,6 +366,12 @@ a| [subs=-attributes]
 a| [subs=-attributes]
 `"any"`
 | Type of substring search filter to use for substring searches for users. Possible values: `initial` for doing prefix only searches, `final` for doing suffix only searches or `any` for doing full substring searches
+| features.externalUserManagement.ldap.writeable
+a| [subs=-attributes]
++bool+
+a| [subs=-attributes]
+`true`
+| Writeable configures if oCIS is allowed to write to the LDAP server, to eg. create users.
 | features.externalUserManagement.oidc.issuerURI
 a| [subs=-attributes]
 +string+

--- a/charts/ocis/docs/values.adoc.yaml
+++ b/charts/ocis/docs/values.adoc.yaml
@@ -173,6 +173,8 @@ features:
 
     # LDAP related settings.
     ldap:
+      # -- Writeable configures if oCIS is allowed to write to the LDAP server, to eg. create users.
+      writeable: true
       # -- URI to connect to the LDAP secure server.
       uri: ldaps://ldaps.owncloud.test
       # -- Set only to false, if the certificate of your LDAP secure service is not trusted.

--- a/charts/ocis/templates/graph/deployment.yaml
+++ b/charts/ocis/templates/graph/deployment.yaml
@@ -84,7 +84,7 @@ spec:
                   name: {{ .Values.secretRefs.ldapSecretRef }}
                   key: reva-ldap-bind-password
             - name: GRAPH_LDAP_SERVER_WRITE_ENABLED
-              value: "false"
+              value: {{ .Values.features.externalUserManagement.ldap.writeable | quote }}
             - name: LDAP_CACERT
               {{ if or (not .Values.features.externalUserManagement.enabled) (not .Values.features.externalUserManagement.ldap.certTrusted) }}
               value: /etc/ocis/ldap-ca/ldap-ca.crt

--- a/charts/ocis/values.yaml
+++ b/charts/ocis/values.yaml
@@ -172,6 +172,8 @@ features:
 
     # LDAP related settings.
     ldap:
+      # -- Writeable configures if oCIS is allowed to write to the LDAP server, to eg. create users.
+      writeable: true
       # -- URI to connect to the LDAP secure server.
       uri: ldaps://ldaps.owncloud.test
       # -- Set only to false, if the certificate of your LDAP secure service is not trusted.


### PR DESCRIPTION
## Description
expose configuration option to mark the external ldap as writable

## Related Issue
- -

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->

## How Has This Been Tested?
- in minikube

## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Technical debt
- [ ] Tests only (no source changes)

## Checklist:
- [x] Code changes
- [ ] Unit tests added
- [ ] Acceptance tests added
- [x] Documentation generated (`make docs`) and committed
- [ ] Documentation ticket raised: <link>
- [ ] Documentation PR created: <link>
