### PR TITLE
feature: set APP_PROVIDER_WOPI_FOLDER_URL_BASE_URL

### DIFF
--- a/charts/ocis/templates/app-provider/deployment.yaml
+++ b/charts/ocis/templates/app-provider/deployment.yaml
@@ -77,6 +77,8 @@ spec:
               value: {{ $officeSuite.insecure | quote }}
             - name: APP_PROVIDER_WOPI_WOPI_SERVER_EXTERNAL_URL
               value: {{ $.Values.features.appsIntegration.wopiIntegration.wopiServerURI | quote }}
+            - name: APP_PROVIDER_WOPI_FOLDER_URL_BASE_URL
+              value: {{ $.Values.features.appsIntegration.wopiIntegration.wopiFolderURI | quote }}
 
             - name: REVA_GATEWAY
               value: gateway:9142

--- a/charts/ocis/values.yaml
+++ b/charts/ocis/values.yaml
@@ -112,6 +112,8 @@ features:
     wopiIntegration:
       # -- URL of the https://github.com/cs3org/wopiserver[cs3org/wopiserver]. Can be deployed https://artifacthub.io/packages/helm/cs3org/wopiserver[with this Chart].
       wopiServerURI: https://wopiserver.owncloud.test
+      # -- Base url to navigate back from the app to the containing folder in the file list.
+      wopiFolderURI: https://ocis.owncloud.test
       # List of WOPI compliant office suites.
       officeSuites:
         - # -- Name of the office suite. Will be displayed to the users.


### PR DESCRIPTION


## Description
This PR implements the feature in issue #155

## Related Issue
- Fixes #155

## Motivation and Context
Feature Request

## How Has This Been Tested?
Test with `helm template` and custom values:

```
features:
  appsIntegration:
    enabled: true
    wopiIntegration:
      wopiFolderURI: https://myurl.com
      officeSuites:
        - # -- Name of the office suite. Will be displayed to the users.
          name: Collabora
          # -- Enables the office suite.
          enabled: true
          # -- URI of the office suite.
          uri: https://collabora.owncloud.test
          # -- URI for the icon of the office suite. Will be displayed to the users.
          iconURI: https://collabora.owncloud.test/favicon.ico
          # -- Disables SSL certificate checking for connections to the office suites http api.
          # Not recommended for production installations.
          insecure: false
```



## Types of changes
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Technical debt
- [ ] Tests only (no source changes)

## Checklist:
- [ ] Code changes
- [ ] Unit tests added
- [ ] Acceptance tests added
- [ ] Documentation generated (`make docs`) and committed
- [ ] Documentation ticket raised: <link>
- [ ] Documentation PR created: <link>
