### PR TITLE
Added imagePullSecrets

### DIFF
--- a/charts/ocis/docs/values-desc-table.adoc
+++ b/charts/ocis/docs/values-desc-table.adoc
@@ -396,6 +396,12 @@ a| [subs=-attributes]
 a| [subs=-attributes]
 `"IfNotPresent"`
 | Image pull policy
+| image.pullSecrets
+a| [subs=-attributes]
++list+
+a| [subs=-attributes]
+`[]`
+| Name of the secret containing the credentials to pull an image from the registry. More  information how a secret can be defined at https://kubernetes.io/docs/tasks/configure-pod-container/pull-image-private-registry/
 | image.repository
 a| [subs=-attributes]
 +string+

--- a/charts/ocis/docs/values.adoc.yaml
+++ b/charts/ocis/docs/values.adoc.yaml
@@ -11,6 +11,13 @@ image:
   sha: ""
   # -- Image pull policy
   pullPolicy: IfNotPresent
+  # -- Name of the secret containing the credentials to pull an image from the registry. More 
+  # information how a secret can be defined at https://kubernetes.io/docs/tasks/configure-pod-container/pull-image-private-registry/
+  pullSecrets: []
+  # pullSecrets:
+  #   - name: mySecret
+  #   - name: mySecret2
+
 
 # Logging settings for oCIS services
 logging:

--- a/charts/ocis/templates/app-provider/deployment.yaml
+++ b/charts/ocis/templates/app-provider/deployment.yaml
@@ -110,6 +110,10 @@ spec:
             - name: tmp-volume
               mountPath: /tmp
 
+      {{- with $.Values.image.pullSecrets }}
+      imagePullSecrets:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
       volumes:
         - name: tmp-volume
           emptyDir: {}

--- a/charts/ocis/templates/app-registry/deployment.yaml
+++ b/charts/ocis/templates/app-registry/deployment.yaml
@@ -93,6 +93,10 @@ spec:
             - name: configs
               mountPath: /etc/ocis
 
+      {{- with $.Values.image.pullSecrets }}
+      imagePullSecrets:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
       volumes:
         - name: tmp-volume
           emptyDir: {}

--- a/charts/ocis/templates/audit/deployment.yaml
+++ b/charts/ocis/templates/audit/deployment.yaml
@@ -83,6 +83,10 @@ spec:
               mountPath: /etc/ocis/messaging-system-ca
               readOnly: true
 
+      {{- with $.Values.image.pullSecrets }}
+      imagePullSecrets:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
       volumes:
         - name: ocis-config-tmp
           emptyDir: {}

--- a/charts/ocis/templates/auth-basic/deployment.yaml
+++ b/charts/ocis/templates/auth-basic/deployment.yaml
@@ -184,6 +184,10 @@ spec:
               mountPath: /etc/ocis/ldap-ca
               readOnly: true
 
+      {{- with $.Values.image.pullSecrets }}
+      imagePullSecrets:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
       volumes:
         - name: tmp-volume
           emptyDir: {}

--- a/charts/ocis/templates/auth-machine/deployment.yaml
+++ b/charts/ocis/templates/auth-machine/deployment.yaml
@@ -96,6 +96,10 @@ spec:
             - name: tmp-volume
               mountPath: /tmp
 
+      {{- with $.Values.image.pullSecrets }}
+      imagePullSecrets:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
       volumes:
         - name: tmp-volume
           emptyDir: {}

--- a/charts/ocis/templates/eventhistory/deployment.yaml
+++ b/charts/ocis/templates/eventhistory/deployment.yaml
@@ -106,6 +106,10 @@ spec:
               mountPath: /etc/ocis/messaging-system-ca
               readOnly: true
 
+      {{- with $.Values.image.pullSecrets }}
+      imagePullSecrets:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
       volumes:
         - name: ocis-config-tmp
           emptyDir: {}

--- a/charts/ocis/templates/frontend/deployment.yaml
+++ b/charts/ocis/templates/frontend/deployment.yaml
@@ -111,6 +111,10 @@ spec:
             - name: tmp-volume
               mountPath: /tmp
 
+      {{- with $.Values.image.pullSecrets }}
+      imagePullSecrets:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
       volumes:
         - name: tmp-volume
           emptyDir: {}

--- a/charts/ocis/templates/gateway/deployment.yaml
+++ b/charts/ocis/templates/gateway/deployment.yaml
@@ -141,6 +141,10 @@ spec:
             - name: tmp-volume
               mountPath: /tmp
 
+      {{- with $.Values.image.pullSecrets }}
+      imagePullSecrets:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
       volumes:
         - name: tmp-volume
           emptyDir: {}

--- a/charts/ocis/templates/graph/deployment.yaml
+++ b/charts/ocis/templates/graph/deployment.yaml
@@ -196,6 +196,10 @@ spec:
               mountPath: /etc/ocis/ldap-ca
               readOnly: true
 
+      {{- with $.Values.image.pullSecrets }}
+      imagePullSecrets:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
       volumes:
         - name: ocis-config-tmp
           emptyDir: {}

--- a/charts/ocis/templates/groups/deployment.yaml
+++ b/charts/ocis/templates/groups/deployment.yaml
@@ -182,6 +182,10 @@ spec:
               mountPath: /etc/ocis/ldap-ca
               readOnly: true
 
+      {{- with $.Values.image.pullSecrets }}
+      imagePullSecrets:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
       volumes:
         - name: tmp-volume
           emptyDir: {}

--- a/charts/ocis/templates/idm/deployment.yaml
+++ b/charts/ocis/templates/idm/deployment.yaml
@@ -151,6 +151,10 @@ spec:
             - name: idm-data
               mountPath: /var/lib/ocis
 
+      {{- with $.Values.image.pullSecrets }}
+      imagePullSecrets:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
       volumes:
         - name: ocis-config-tmp
           emptyDir: {}

--- a/charts/ocis/templates/idp/deployment.yaml
+++ b/charts/ocis/templates/idp/deployment.yaml
@@ -108,6 +108,10 @@ spec:
               mountPath: /etc/ocis/idp
               readOnly: true
 
+      {{- with $.Values.image.pullSecrets }}
+      imagePullSecrets:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
       volumes:
         - name: ocis-data-tmp
           emptyDir: {}

--- a/charts/ocis/templates/nats/deployment.yaml
+++ b/charts/ocis/templates/nats/deployment.yaml
@@ -97,6 +97,10 @@ spec:
             - name: nats-data
               mountPath: /var/lib/ocis
 
+      {{- with $.Values.image.pullSecrets }}
+      imagePullSecrets:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
       volumes:
         - name: nats-data
           {{ if .Values.services.nats.persistence.enabled }}

--- a/charts/ocis/templates/notifications/deployment.yaml
+++ b/charts/ocis/templates/notifications/deployment.yaml
@@ -137,6 +137,10 @@ spec:
               mountPath: /etc/ocis/messaging-system-ca
               readOnly: true
 
+      {{- with $.Values.image.pullSecrets }}
+      imagePullSecrets:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
       volumes:
         - name: ocis-config-tmp
           emptyDir: {}

--- a/charts/ocis/templates/ocdav/deployment.yaml
+++ b/charts/ocis/templates/ocdav/deployment.yaml
@@ -96,3 +96,7 @@ spec:
               containerPort: 8080
             - name: metrics-debug
               containerPort: 9163
+      {{- with $.Values.image.pullSecrets }}
+      imagePullSecrets:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}

--- a/charts/ocis/templates/ocs/deployment.yaml
+++ b/charts/ocis/templates/ocs/deployment.yaml
@@ -97,3 +97,7 @@ spec:
               containerPort: 9110
             - name: metrics-debug
               containerPort: 9114
+      {{- with $.Values.image.pullSecrets }}
+      imagePullSecrets:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}

--- a/charts/ocis/templates/postprocessing/deployment.yaml
+++ b/charts/ocis/templates/postprocessing/deployment.yaml
@@ -99,6 +99,10 @@ spec:
               mountPath: /etc/ocis/messaging-system-ca
               readOnly: true
 
+      {{- with $.Values.image.pullSecrets }}
+      imagePullSecrets:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
       volumes:
         - name: ocis-config-tmp
           emptyDir: {}

--- a/charts/ocis/templates/proxy/deployment.yaml
+++ b/charts/ocis/templates/proxy/deployment.yaml
@@ -124,6 +124,10 @@ spec:
             - name: configs
               mountPath: /etc/ocis
 
+      {{- with $.Values.image.pullSecrets }}
+      imagePullSecrets:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
       volumes:
         - name: configs
           configMap:

--- a/charts/ocis/templates/search/deployment.yaml
+++ b/charts/ocis/templates/search/deployment.yaml
@@ -141,6 +141,10 @@ spec:
             - name: search-data
               mountPath: /var/lib/ocis
 
+      {{- with $.Values.image.pullSecrets }}
+      imagePullSecrets:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
       volumes:
         - name: ocis-config-tmp
           emptyDir: {}

--- a/charts/ocis/templates/settings/deployment.yaml
+++ b/charts/ocis/templates/settings/deployment.yaml
@@ -111,3 +111,7 @@ spec:
               containerPort: 9191
             - name: metrics-debug
               containerPort: 9194
+      {{- with $.Values.image.pullSecrets }}
+      imagePullSecrets:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}

--- a/charts/ocis/templates/sharing/deployment.yaml
+++ b/charts/ocis/templates/sharing/deployment.yaml
@@ -145,7 +145,10 @@ spec:
               mountPath: /etc/ocis/messaging-system-ca
               readOnly: true
 
-
+      {{- with $.Values.image.pullSecrets }}
+      imagePullSecrets:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
       volumes:
         - name: tmp-volume
           emptyDir: {}

--- a/charts/ocis/templates/storage-publiclink/deployment.yaml
+++ b/charts/ocis/templates/storage-publiclink/deployment.yaml
@@ -90,6 +90,10 @@ spec:
             - name: tmp-volume
               mountPath: /tmp
 
+      {{- with $.Values.image.pullSecrets }}
+      imagePullSecrets:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
       volumes:
         - name: tmp-volume
           emptyDir: {}

--- a/charts/ocis/templates/storage-shares/deployment.yaml
+++ b/charts/ocis/templates/storage-shares/deployment.yaml
@@ -93,6 +93,10 @@ spec:
             - name: tmp-volume
               mountPath: /tmp
 
+      {{- with $.Values.image.pullSecrets }}
+      imagePullSecrets:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
       volumes:
         - name: tmp-volume
           emptyDir: {}

--- a/charts/ocis/templates/storage-system/deployment.yaml
+++ b/charts/ocis/templates/storage-system/deployment.yaml
@@ -126,6 +126,10 @@ spec:
             - name: storage-system-data
               mountPath: /var/lib/ocis
 
+      {{- with $.Values.image.pullSecrets }}
+      imagePullSecrets:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
       volumes:
         - name: tmp-volume
           emptyDir: {}

--- a/charts/ocis/templates/storage-users/deployment.yaml
+++ b/charts/ocis/templates/storage-users/deployment.yaml
@@ -184,6 +184,10 @@ spec:
             - name: storage-users-data
               mountPath: /var/lib/ocis
 
+      {{- with $.Values.image.pullSecrets }}
+      imagePullSecrets:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
       volumes:
         - name: tmp-volume
           emptyDir: {}

--- a/charts/ocis/templates/storage-users/jobs.yaml
+++ b/charts/ocis/templates/storage-users/jobs.yaml
@@ -76,6 +76,10 @@ spec:
                 - name: storage-users-data
                   mountPath: /var/lib/ocis
 
+          {{- with $.Values.image.pullSecrets }}
+          imagePullSecrets:
+            {{- toYaml . | nindent 12 }}
+          {{- end }}
           volumes:
             - name: tmp-volume
               emptyDir: {}

--- a/charts/ocis/templates/store/deployment.yaml
+++ b/charts/ocis/templates/store/deployment.yaml
@@ -91,6 +91,10 @@ spec:
             - name: store-data
               mountPath: /var/lib/ocis
 
+      {{- with $.Values.image.pullSecrets }}
+      imagePullSecrets:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
       volumes:
         - name: store-data
           {{ if .Values.services.store.persistence.enabled }}

--- a/charts/ocis/templates/thumbnails/deployment.yaml
+++ b/charts/ocis/templates/thumbnails/deployment.yaml
@@ -115,6 +115,10 @@ spec:
             - name: thumbnails-data
               mountPath: /var/lib/ocis
 
+      {{- with $.Values.image.pullSecrets }}
+      imagePullSecrets:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
       volumes:
         - name: thumbnails-data
           {{ if .Values.services.thumbnails.persistence.enabled }}

--- a/charts/ocis/templates/userlog/deployment.yaml
+++ b/charts/ocis/templates/userlog/deployment.yaml
@@ -121,6 +121,10 @@ spec:
               mountPath: /etc/ocis/messaging-system-ca
               readOnly: true
 
+      {{- with $.Values.image.pullSecrets }}
+      imagePullSecrets:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
       volumes:
         - name: ocis-config-tmp
           emptyDir: {}

--- a/charts/ocis/templates/users/deployment.yaml
+++ b/charts/ocis/templates/users/deployment.yaml
@@ -182,6 +182,10 @@ spec:
               mountPath: /etc/ocis/ldap-ca
               readOnly: true
 
+      {{- with $.Values.image.pullSecrets }}
+      imagePullSecrets:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
       volumes:
         - name: tmp-volume
           emptyDir: {}

--- a/charts/ocis/templates/web/deployment.yaml
+++ b/charts/ocis/templates/web/deployment.yaml
@@ -113,6 +113,10 @@ spec:
             - name: configs
               mountPath: /etc/ocis
 
+      {{- with $.Values.image.pullSecrets }}
+      imagePullSecrets:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
       volumes:
         - name: configs
           configMap:

--- a/charts/ocis/templates/webdav/deployment.yaml
+++ b/charts/ocis/templates/webdav/deployment.yaml
@@ -80,3 +80,7 @@ spec:
               containerPort: 9115
             - name: metrics-debug
               containerPort: 9119
+      {{- with $.Values.image.pullSecrets }}
+      imagePullSecrets:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}

--- a/charts/ocis/templates/webfinger/deployment.yaml
+++ b/charts/ocis/templates/webfinger/deployment.yaml
@@ -81,3 +81,7 @@ spec:
               containerPort: 8080
             - name: metrics-debug
               containerPort: 8081
+      {{- with $.Values.image.pullSecrets }}
+      imagePullSecrets:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}

--- a/charts/ocis/values.yaml
+++ b/charts/ocis/values.yaml
@@ -10,6 +10,13 @@ image:
   sha: ""
   # -- Image pull policy
   pullPolicy: IfNotPresent
+  # -- Name of the secret containing the credentials to pull an image from the registry. More 
+  # information how a secret can be defined at https://kubernetes.io/docs/tasks/configure-pod-container/pull-image-private-registry/
+  pullSecrets: []
+  # pullSecrets:
+  #   - name: mySecret
+  #   - name: mySecret2
+
 
 # Logging settings for oCIS services
 logging:


### PR DESCRIPTION
## Description
This PR adds `imagePullSecrets` support for the helm chart.

## Related Issue
- Fixes #152

## Motivation and Context
Feature Request

## How Has This Been Tested?
Tested `helm template` and the following own values YAML

```
image:
  pullSecrets:
    - name: test
    - name: test2
features:
  appsIntegration:
    enabled: true
    wopiIntegration:
      officeSuites:
        - # -- Name of the office suite. Will be displayed to the users.
          name: Collabora
          # -- Enables the office suite.
          enabled: true
          # -- URI of the office suite.
          uri: https://collabora.owncloud.test
          # -- URI for the icon of the office suite. Will be displayed to the users.
          iconURI: https://collabora.owncloud.test/favicon.ico
          # -- Disables SSL certificate checking for connections to the office suites http api.
          # Not recommended for production installations.
          insecure: false
  basicAuthentication: true
  externalUserManagement:
    enabled: false
  emailNotifications:
    enabled: true
services:
  storageUsers:
    persistence:
      enabled: true
    maintenance:
      cleanUpExpiredUploads:
        enabled: true
```

## Types of changes
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Technical debt
- [ ] Tests only (no source changes)

## Checklist:
- [ ] Code changes
- [ ] Unit tests added
- [ ] Acceptance tests added
- [x] Documentation generated (`make docs`) and committed
- [ ] Documentation ticket raised: <link>
- [ ] Documentation PR created: <link>
