### PR TITLE
Added configuration for PodDisruptionBudget

### DIFF
--- a/charts/ocis/templates/_common/_tplvalues.tpl
+++ b/charts/ocis/templates/_common/_tplvalues.tpl
@@ -36,3 +36,28 @@ oCIS image logic
 "{{ $.Values.image.repository }}:{{ $tag }}"
   {{- end -}}
 {{- end -}}
+
+{{/*
+oCIS PDB template
+
+@param .appName         The name of the service/app
+@param .valuesAppName   The name of the service/app in the values file
+@param .root            Access to the root scope
+*/}}
+{{- define "ocis.pdb" -}}
+{{- $_ := set . "podDisruptionBudget" (default (default (dict) .root.Values.podDisruptionBudget) (index .root.Values.services .valuesAppName).podDisruptionBudget) -}}
+{{ if .podDisruptionBudget }}
+apiVersion: policy/v1
+kind: PodDisruptionBudget
+metadata:
+  name: {{ .appName }}
+  namespace: {{ template "ocis.namespace" .root }}
+  labels:
+    {{- include "ocis.labels" .root | nindent 4 }}
+spec:
+  {{- toYaml .podDisruptionBudget | nindent 2 }}
+  selector:
+  matchLabels:
+    app: {{ .appName }}
+{{- end }}
+{{- end -}}

--- a/charts/ocis/templates/audit/pdb.yaml
+++ b/charts/ocis/templates/audit/pdb.yaml
@@ -1,0 +1,1 @@
+{{ include "ocis.pdb" (dict "appName" "audit" "valuesAppName" "audit" "root" $) }}

--- a/charts/ocis/templates/auth-basic/pdb.yaml
+++ b/charts/ocis/templates/auth-basic/pdb.yaml
@@ -1,0 +1,3 @@
+{{ if .Values.features.basicAuthentication }}
+{{ include "ocis.pdb" (dict "appName" "auth-basic" "valuesAppName" "authBasic" "root" $) }}
+{{ end }}

--- a/charts/ocis/templates/auth-machine/pdb.yaml
+++ b/charts/ocis/templates/auth-machine/pdb.yaml
@@ -1,0 +1,1 @@
+{{ include "ocis.pdb" (dict "appName" "auth-machine" "valuesAppName" "authMachine" "root" $) }}

--- a/charts/ocis/templates/frontend/pdb.yaml
+++ b/charts/ocis/templates/frontend/pdb.yaml
@@ -1,0 +1,1 @@
+{{ include "ocis.pdb" (dict "appName" "frontend" "valuesAppName" "frontend" "root" $) }}

--- a/charts/ocis/templates/gateway/pdb.yaml
+++ b/charts/ocis/templates/gateway/pdb.yaml
@@ -1,0 +1,1 @@
+{{ include "ocis.pdb" (dict "appName" "gateway" "valuesAppName" "gateway" "root" $) }}

--- a/charts/ocis/templates/graph/pdb.yaml
+++ b/charts/ocis/templates/graph/pdb.yaml
@@ -1,0 +1,1 @@
+{{ include "ocis.pdb" (dict "appName" "graph" "valuesAppName" "graph" "root" $) }}

--- a/charts/ocis/templates/groups/pdb.yaml
+++ b/charts/ocis/templates/groups/pdb.yaml
@@ -1,0 +1,1 @@
+{{ include "ocis.pdb" (dict "appName" "groups" "valuesAppName" "groups" "root" $) }}

--- a/charts/ocis/templates/notifications/pdb.yaml
+++ b/charts/ocis/templates/notifications/pdb.yaml
@@ -1,0 +1,1 @@
+{{ include "ocis.pdb" (dict "appName" "notifications" "valuesAppName" "notifications" "root" $) }}

--- a/charts/ocis/templates/ocdav/pdb.yaml
+++ b/charts/ocis/templates/ocdav/pdb.yaml
@@ -1,0 +1,1 @@
+{{ include "ocis.pdb" (dict "appName" "ocdav" "valuesAppName" "ocdav" "root" $) }}

--- a/charts/ocis/templates/ocs/pdb.yaml
+++ b/charts/ocis/templates/ocs/pdb.yaml
@@ -1,0 +1,1 @@
+{{ include "ocis.pdb" (dict "appName" "ocs" "valuesAppName" "ocs" "root" $) }}

--- a/charts/ocis/templates/proxy/pdb.yaml
+++ b/charts/ocis/templates/proxy/pdb.yaml
@@ -1,0 +1,1 @@
+{{ include "ocis.pdb" (dict "appName" "proxy" "valuesAppName" "proxy" "root" $) }}

--- a/charts/ocis/templates/search/pdb.yaml
+++ b/charts/ocis/templates/search/pdb.yaml
@@ -1,0 +1,1 @@
+{{ include "ocis.pdb" (dict "appName" "search" "valuesAppName" "search" "root" $) }}

--- a/charts/ocis/templates/settings/pdb.yaml
+++ b/charts/ocis/templates/settings/pdb.yaml
@@ -1,0 +1,1 @@
+{{ include "ocis.pdb" (dict "appName" "settings" "valuesAppName" "settings" "root" $) }}

--- a/charts/ocis/templates/sharing/pdb.yaml
+++ b/charts/ocis/templates/sharing/pdb.yaml
@@ -1,0 +1,1 @@
+{{ include "ocis.pdb" (dict "appName" "sharing" "valuesAppName" "sharing" "root" $) }}

--- a/charts/ocis/templates/storage-publiclink/pdb.yaml
+++ b/charts/ocis/templates/storage-publiclink/pdb.yaml
@@ -1,0 +1,1 @@
+{{ include "ocis.pdb" (dict "appName" "storage-publiclink" "valuesAppName" "storagePublicLink" "root" $) }}

--- a/charts/ocis/templates/storage-shares/pdb.yaml
+++ b/charts/ocis/templates/storage-shares/pdb.yaml
@@ -1,0 +1,1 @@
+{{ include "ocis.pdb" (dict "appName" "storage-shares" "valuesAppName" "storageShares" "root" $) }}

--- a/charts/ocis/templates/storage-system/pdb.yaml
+++ b/charts/ocis/templates/storage-system/pdb.yaml
@@ -1,0 +1,1 @@
+{{ include "ocis.pdb" (dict "appName" "storage-system" "valuesAppName" "storageSystem" "root" $) }}

--- a/charts/ocis/templates/storage-users/pdb.yaml
+++ b/charts/ocis/templates/storage-users/pdb.yaml
@@ -1,0 +1,1 @@
+{{ include "ocis.pdb" (dict "appName" "storage-users" "valuesAppName" "storageUsers" "root" .) }}

--- a/charts/ocis/templates/thumbnails/pdb.yaml
+++ b/charts/ocis/templates/thumbnails/pdb.yaml
@@ -1,0 +1,1 @@
+{{ include "ocis.pdb" (dict "appName" "thumbnails" "valuesAppName" "thumbnails" "root" .) }}

--- a/charts/ocis/templates/users/pdb.yaml
+++ b/charts/ocis/templates/users/pdb.yaml
@@ -1,0 +1,1 @@
+{{ include "ocis.pdb" (dict "appName" "users" "valuesAppName" "users" "root" .) }}

--- a/charts/ocis/templates/web/pdb.yaml
+++ b/charts/ocis/templates/web/pdb.yaml
@@ -1,0 +1,1 @@
+{{ include "ocis.pdb" (dict "appName" "web" "valuesAppName" "web" "root" .) }}

--- a/charts/ocis/templates/webdav/pdb.yaml
+++ b/charts/ocis/templates/webdav/pdb.yaml
@@ -1,0 +1,1 @@
+{{ include "ocis.pdb" (dict "appName" "webdav" "valuesAppName" "webdav" "root" .) }}

--- a/charts/ocis/values.yaml
+++ b/charts/ocis/values.yaml
@@ -322,6 +322,11 @@ namespaceOverride:
 # -- Number of replicas for each scalable service. Has no effect when `autoscaling.enabled` is set to `true`.
 replicas: 1
 
+# Default PodDisruptionBudget to apply to all services, except per-service PodDisruptionBudget configuration in `services.<service-name>.podDisruptionBudget` is set.
+podDisruptionBudget: {}
+  # -- Sets the maxUnavailable or the global PodDisruptionBudget.
+  #maxUnavailable: 1
+
 # Autoscaling settings.
 autoscaling:
   # -- Enables autoscaling. When set to `true`, `replicas` is no longer applied.
@@ -410,18 +415,24 @@ services:
   audit:
     # -- Per-service resources configuration. Overrides the default setting from `resources` if set.
     resources: {}
+    # -- Per-service PodDisruptionBudget. Overrides the default setting from `podDisruptionBudget` if set.
+    podDisruptionBudget: {}
 
   # -- AUTH BASIC service. Not used if `features.externalUserManagement.enabled` equals `true`.
   # @default -- see detailed service configuration options below
   authBasic:
     # -- Per-service resources configuration. Overrides the default setting from `resources` if set.
     resources: {}
+    # -- Per-service PodDisruptionBudget. Overrides the default setting from `podDisruptionBudget` if set.
+    podDisruptionBudget: {}
 
   # -- AUTH MACHINE service.
   # @default -- see detailed service configuration options below
   authMachine:
     # -- Per-service resources configuration. Overrides the default setting from `resources` if set.
     resources: {}
+    # -- Per-service PodDisruptionBudget. Overrides the default setting from `podDisruptionBudget` if set.
+    podDisruptionBudget: {}
 
   # -- EVENT HISTORY service.
   # @default -- see detailed service configuration options below
@@ -434,24 +445,32 @@ services:
   frontend:
     # -- Per-service resources configuration. Overrides the default setting from `resources` if set.
     resources: {}
+    # -- Per-service PodDisruptionBudget. Overrides the default setting from `podDisruptionBudget` if set.
+    podDisruptionBudget: {}
 
   # -- GATEWAY service.
   # @default -- see detailed service configuration options below
   gateway:
     # -- Per-service resources configuration. Overrides the default setting from `resources` if set.
     resources: {}
+    # -- Per-service PodDisruptionBudget. Overrides the default setting from `podDisruptionBudget` if set.
+    podDisruptionBudget: {}
 
   # -- GRAPH service.
   # @default -- see detailed service configuration options below
   graph:
     # -- Per-service resources configuration. Overrides the default setting from `resources` if set.
     resources: {}
+    # -- Per-service PodDisruptionBudget. Overrides the default setting from `podDisruptionBudget` if set.
+    podDisruptionBudget: {}
 
   # -- GROUPS service.
   # @default -- see detailed service configuration options below
   groups:
     # -- Per-service resources configuration. Overrides the default setting from `resources` if set.
     resources: {}
+    # -- Per-service PodDisruptionBudget. Overrides the default setting from `podDisruptionBudget` if set.
+    podDisruptionBudget: {}
 
   # -- IDM service. Not used if `features.externalUserManagement.enabled` equals `true`.
   # @default -- see detailed service configuration options below
@@ -535,18 +554,24 @@ services:
   notifications:
     # -- Per-service resources configuration. Overrides the default setting from `resources` if set.
     resources: {}
+    # -- Per-service PodDisruptionBudget. Overrides the default setting from `podDisruptionBudget` if set.
+    podDisruptionBudget: {}
 
   # -- OCDAV service.
   # @default -- see detailed service configuration options below
   ocdav:
     # -- Per-service resources configuration. Overrides the default setting from `resources` if set.
     resources: {}
+    # -- Per-service PodDisruptionBudget. Overrides the default setting from `podDisruptionBudget` if set.
+    podDisruptionBudget: {}
 
   # -- OCS service.
   # @default -- see detailed service configuration options below
   ocs:
     # -- Per-service resources configuration. Overrides the default setting from `resources` if set.
     resources: {}
+    # -- Per-service PodDisruptionBudget. Overrides the default setting from `podDisruptionBudget` if set.
+    podDisruptionBudget: {}
 
   # -- POSTPROCESSING service.
   # @default -- see detailed service configuration options below
@@ -559,6 +584,8 @@ services:
   proxy:
     # -- Per-service resources configuration. Overrides the default setting from `resources` if set.
     resources: {}
+    # -- Per-service PodDisruptionBudget. Overrides the default setting from `podDisruptionBudget` if set.
+    podDisruptionBudget: {}
 
   # -- SEARCH service.
   # @default -- see detailed service configuration options below
@@ -604,30 +631,40 @@ services:
       existingClaim:
     # -- Per-service resources configuration. Overrides the default setting from `resources` if set.
     resources: {}
+    # -- Per-service PodDisruptionBudget. Overrides the default setting from `podDisruptionBudget` if set.
+    podDisruptionBudget: {}
 
   # -- SETTINGS service.
   # @default -- see detailed service configuration options below
   settings:
     # -- Per-service resources configuration. Overrides the default setting from `resources` if set.
     resources: {}
+    # -- Per-service PodDisruptionBudget. Overrides the default setting from `podDisruptionBudget` if set.
+    podDisruptionBudget: {}
 
   # -- SHARING service.
   # @default -- see detailed service configuration options below
   sharing:
     # -- Per-service resources configuration. Overrides the default setting from `resources` if set.
     resources: {}
+    # -- Per-service PodDisruptionBudget. Overrides the default setting from `podDisruptionBudget` if set.
+    podDisruptionBudget: {}
 
   # -- STORAGE-PUBLICLINK service.
   # @default -- see detailed service configuration options below
   storagePublicLink:
     # -- Per-service resources configuration. Overrides the default setting from `resources` if set.
     resources: {}
+    # -- Per-service PodDisruptionBudget. Overrides the default setting from `podDisruptionBudget` if set.
+    podDisruptionBudget: {}
 
   # -- STORAGE-SHARES service.
   # @default -- see detailed service configuration options below
   storageShares:
     # -- Per-service resources configuration. Overrides the default setting from `resources` if set.
     resources: {}
+    # -- Per-service PodDisruptionBudget. Overrides the default setting from `podDisruptionBudget` if set.
+    podDisruptionBudget: {}
 
   # -- STORAGE-SYSTEM service.
   # @default -- see detailed service configuration options below
@@ -663,6 +700,8 @@ services:
       existingClaim:
     # -- Per-service resources configuration. Overrides the default setting from `resources` if set.
     resources: {}
+    # -- Per-service PodDisruptionBudget. Overrides the default setting from `podDisruptionBudget` if set.
+    podDisruptionBudget: {}
 
   # -- STORAGE-USERS service.
   # @default -- see detailed service configuration options below
@@ -741,6 +780,8 @@ services:
       existingClaim:
     # -- Per-service resources configuration. Overrides the default setting from `resources` if set.
     resources: {}
+    # -- Per-service PodDisruptionBudget. Overrides the default setting from `podDisruptionBudget` if set.
+    podDisruptionBudget: {}
 
 
   # -- STORE service.
@@ -811,6 +852,8 @@ services:
       existingClaim:
     # -- Per-service resources configuration. Overrides the default setting from `resources` if set.
     resources: {}
+    # -- Per-service PodDisruptionBudget. Overrides the default setting from `podDisruptionBudget` if set.
+    podDisruptionBudget: {}
 
   # -- USERLOG service.
   # @default -- see detailed service configuration options below
@@ -823,6 +866,8 @@ services:
   users:
     # -- Per-service resources configuration. Overrides the default setting from `resources` if set.
     resources: {}
+    # -- Per-service PodDisruptionBudget. Overrides the default setting from `podDisruptionBudget` if set.
+    podDisruptionBudget: {}
 
   # -- ownCloud WEB service.
   # @default -- see detailed service configuration options below
@@ -868,12 +913,16 @@ services:
         path: ""
     # -- Per-service resources configuration. Overrides the default setting from `resources` if set.
     resources: {}
+    # -- Per-service PodDisruptionBudget. Overrides the default setting from `podDisruptionBudget` if set.
+    podDisruptionBudget: {}
 
   # -- WEBDAV service.
   # @default -- see detailed service configuration options below
   webdav:
     # -- Per-service resources configuration. Overrides the default setting from `resources` if set.
     resources: {}
+    # -- Per-service PodDisruptionBudget. Overrides the default setting from `podDisruptionBudget` if set.
+    podDisruptionBudget: {}
 
   # -- WEBFINGER service.
   # @default -- see detailed service configuration options below


### PR DESCRIPTION
## Description
This PR adds the configuration for PodDisruptionBudget. It can be configured globally and/or overwrites by service/app.

## Related Issue
- Fixes #149

## Motivation and Context
Feature Request

## How Has This Been Tested?
Tested with `helm template` and the following own values YAML:

```
features:
  basicAuthentication: true
podDisruptionBudget:
  maxUnavailable: 1
services:
 webdav:
   podDisruptionBudget:
     maxUnavailable: 2
```

## Types of changes
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Technical debt
- [ ] Tests only (no source changes)

## Checklist:
- [ ] Code changes
- [ ] Unit tests added
- [ ] Acceptance tests added
- [ ] Documentation generated (`make docs`) and committed
- [ ] Documentation ticket raised: <link>
- [ ] Documentation PR created: <link>
