### PR TITLE
Added configuration option for custom roles

### DIFF
--- a/charts/ocis/docs/values-desc-table.adoc
+++ b/charts/ocis/docs/values-desc-table.adoc
@@ -390,6 +390,24 @@ a| [subs=-attributes]
 a| [subs=-attributes]
 `"userid"`
 | Attribute mapping of for the userIDClaim. Set to `userid` if the claim specified in `...oidc.userIDClaim` holds the value of the ldap user attribute specified in `...ldap.user.schema.id`. Set to `mail` if the claim specified in `...oidc.userIDClaim` holds the value of the ldap user attribute specified in  `...ldap.user.schema.mail`. Set to `username` if the claim specified in `...oidc.userIDClaim` holds the value of the ldap user attribute specified in `...ldap.user.schema.userName`.
+| features.roles
+a| [subs=-attributes]
++object+
+a| [subs=-attributes]
+`{"customRoles":"","customRolesConfigRef":null}`
+| Define custom roles here. Note that the definition will be either or. So you cannot provide a ConfigMap name and text at once.
+| features.roles.customRoles
+a| [subs=-attributes]
++string+
+a| [subs=-attributes]
+`""`
+| Define the roles by providing the JSON text here.
+| features.roles.customRolesConfigRef
+a| [subs=-attributes]
++string+
+a| [subs=-attributes]
+`nil`
+| Define the roles by specifying a name of a ConfigMap which already contains the the role description (might also be defined in the `extraResources` section). The ConfigMap needs to contain a file named `custom-roles.json` which holds the role description in JSON format Please note that you have to restart the settings manually if you change the content of you ConfigMap.
 | image.pullPolicy
 a| [subs=-attributes]
 +string+

--- a/charts/ocis/docs/values.adoc.yaml
+++ b/charts/ocis/docs/values.adoc.yaml
@@ -232,6 +232,14 @@ features:
         filter:
         # -- The object class to use for groups in the default group search filter like `groupOfNames`.
         objectClass: groupOfNames
+  # -- Define custom roles here. Note that the definition will be either or. So you cannot provide a ConfigMap name and text at once.
+  roles: 
+    # -- Define the roles by specifying a name of a ConfigMap which already contains the the role description (might also be defined in the `extraResources` section).
+    # The ConfigMap needs to contain a file named `custom-roles.json` which holds the role description in JSON format
+    # Please note that you have to restart the settings manually if you change the content of you ConfigMap.
+    customRolesConfigRef: 
+    # -- Define the roles by providing the JSON text here.
+    customRoles: ""
 
 # Ingress for oCIS.
 ingress:

--- a/charts/ocis/templates/settings/config.yaml
+++ b/charts/ocis/templates/settings/config.yaml
@@ -1,0 +1,11 @@
+{{- if .Values.features.roles.customRoles }}
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: ocis-role-config
+  namespace: {{ template "ocis.namespace" . }}
+  labels:
+    {{- include "ocis.labels" . | nindent 4 }}
+data:
+  custom-roles.json: {{ .Values.features.roles.customRoles | quote }}
+{{- end }}

--- a/charts/ocis/templates/settings/deployment.yaml
+++ b/charts/ocis/templates/settings/deployment.yaml
@@ -22,6 +22,9 @@ spec:
       labels:
         app: {{ .appName }}
         {{- include "ocis.labels" . | nindent 8 }}
+      annotations:
+        checksum/config: {{ include (print $.Template.BasePath "/settings/config.yaml") . | sha256sum }}
+
     spec:
       securityContext:
           fsGroup: {{ .Values.securityContext.fsGroup }}
@@ -77,6 +80,10 @@ spec:
                   key: user-id
             {{- end }}
 
+            {{- if or .Values.features.roles.customRoles .Values.features.roles.customRolesConfigRef }}
+            - name: SETTINGS_BUNDLES_PATH
+              value: /etc/ocis/custom-roles.json
+            {{- end }}
             - name: SETTINGS_JWT_SECRET
               valueFrom:
                 secretKeyRef:
@@ -111,3 +118,22 @@ spec:
               containerPort: 9191
             - name: metrics-debug
               containerPort: 9194
+
+          {{- if or .Values.features.roles.customRoles .Values.features.roles.customRolesConfigRef }}
+          volumeMounts:
+            - name: ocis-role-config
+              mountPath: /etc/ocis 
+
+          {{- end }}
+      {{- if .Values.features.roles.customRoles }}
+      volumes:
+        - name: ocis-role-config
+          configMap:
+            name: ocis-role-config
+      {{- end }}
+      {{- if .Values.features.roles.customRolesConfigRef }}
+      volumes:
+        - name: ocis-role-config
+          configMap:
+            name: {{ .Values.features.roles.customRolesConfigRef }}
+      {{- end }}

--- a/charts/ocis/values.yaml
+++ b/charts/ocis/values.yaml
@@ -231,6 +231,14 @@ features:
         filter:
         # -- The object class to use for groups in the default group search filter like `groupOfNames`.
         objectClass: groupOfNames
+  # -- Define custom roles here. Note that the definition will be either or. So you cannot provide a ConfigMap name and text at once.
+  roles: 
+    # -- Define the roles by specifying a name of a ConfigMap which already contains the the role description (might also be defined in the `extraResources` section).
+    # The ConfigMap needs to contain a file named `custom-roles.json` which holds the role description in JSON format
+    # Please note that you have to restart the settings manually if you change the content of you ConfigMap.
+    customRolesConfigRef: 
+    # -- Define the roles by providing the JSON text here.
+    customRoles: ""
 
 # Ingress for oCIS.
 ingress:


### PR DESCRIPTION
## Description
This PR adds a configuration option for custom roles.

## Related Issue
- Fixes #148

## Motivation and Context
Feature Request

## How Has This Been Tested?
Tested via execution of `helm upgrade --install` with the following own values YAML:

```YAML
externalDomain: ocis.owncloud.test
ingress:
  enabled: true
  annotations:
    nginx.ingress.kubernetes.io/proxy-body-size: 1024m
  tls:
    - hosts:
        - ocis.owncloud.test
insecure:
  # disables ssl certificate checking for connections to the openID connect identity provider.
  # Not recommended for production setups, but we don't have valid certificates in minikube
  oidcIdpInsecure: true
  # disables ssl certificate checking for connections to the oCIS http apis.
  # Not recommended for production setups, but we don't have valid certificates in minikube
  ocisHttpApiInsecure: true
features:
  # -- Define custom roles here. Note that the definition will be either or. So you cannot provide a ConfigMap name and text at once.
  roles: 
    # -- Define the roles by specifying a name of a ConfigMap which already contains the the role description (might also be defined in the `extraResources` section).
    # customRolesConfigRef: my-ocis-role-config
    # -- Define the roles by providing the text here.
    customRoles: |
      [
          {
            "id": "71881883-1768-46bd-a24d-a356a2afdf7f",
            "name": "admin23",
            "type": "TYPE_ROLE",
            "extension": "ocis-roles",
            "displayName": "AdministratorIn23",
            "settings": [
              {
                "id": "a53e601e-571f-4f86-8fec-d4576ef49c62",
                "name": "role-management",
                "displayName": "Role Management",
                "description": "This permission gives full access to everything that is related to role management.",
                "permissionValue": {
                  "operation": "OPERATION_READWRITE",
                  "constraint": "CONSTRAINT_ALL"
                },
                "resource": {
                  "type": "TYPE_USER",
                  "id": "all"
                }
              },
              {
                "id": "3d58f441-4a05-42f8-9411-ef5874528ae1",
                "name": "settings-management",
                "displayName": "Settings Management",
                "description": "This permission gives full access to everything that is related to settings management.",
                "permissionValue": {
                  "operation": "OPERATION_READWRITE",
                  "constraint": "CONSTRAINT_ALL"
                },
                "resource": {
                  "type": "TYPE_USER",
                  "id": "all"
                }
              },
              {
                "id": "7d81f103-0488-4853-bce5-98dcce36d649",
                "name": "language-readwrite",
                "displayName": "Permission to read and set the language (anyone)",
                "permissionValue": {
                  "operation": "OPERATION_READWRITE",
                  "constraint": "CONSTRAINT_ALL"
                },
                "resource": {
                  "type": "TYPE_SETTING",
                  "id": "aa8cfbe5-95d4-4f7e-a032-c3c01f5f062f"
                }
              },
              {
                "id": "8e587774-d929-4215-910b-a317b1e80f73",
                "name": "account-management",
                "displayName": "Account Management",
                "description": "This permission gives full access to everything that is related to account management.",
                "permissionValue": {
                  "operation": "OPERATION_READWRITE",
                  "constraint": "CONSTRAINT_ALL"
                },
                "resource": {
                  "type": "TYPE_USER",
                  "id": "all"
                }
              },
              {
                "id": "522adfbe-5908-45b4-b135-41979de73245",
                "name": "group-management",
                "displayName": "Group Management",
                "description": "This permission gives full access to everything that is related to group management.",
                "permissionValue": {
                  "operation": "OPERATION_READWRITE",
                  "constraint": "CONSTRAINT_ALL"
                },
                "resource": {
                  "type": "TYPE_GROUP",
                  "id": "all"
                }
              },
              {
                "id": "4e6f9709-f9e7-44f1-95d4-b762d27b7896",
                "name": "set-space-quota",
                "displayName": "Set Space Quota",
                "description": "This permission allows to manage space quotas.",
                "permissionValue": {
                  "operation": "OPERATION_READWRITE",
                  "constraint": "CONSTRAINT_ALL"
                },
                "resource": {
                  "type": "TYPE_SYSTEM"
                }
              },
              {
                "id": "79e13b30-3e22-11eb-bc51-0b9f0bad9a58",
                "name": "create-space",
                "displayName": "Create Space",
                "description": "This permission allows to create new spaces.",
                "permissionValue": {
                  "operation": "OPERATION_READWRITE",
                  "constraint": "CONSTRAINT_ALL"
                },
                "resource": {
                  "type": "TYPE_SYSTEM"
                }
              },
              {
                "id": "016f6ddd-9501-4a0a-8ebe-64a20ee8ec82",
                "name": "list-all-spaces",
                "displayName": "List All Spaces",
                "description": "This permission allows list all spaces.",
                "permissionValue": {
                  "operation": "OPERATION_READ",
                  "constraint": "CONSTRAINT_ALL"
                },
                "resource": {
                  "type": "TYPE_SYSTEM"
                }
              },
              {
                "id": "5de9fe0a-4bc5-4a47-b758-28f370caf169",
                "name": "delete-all-home-spaces",
                "displayName": "Delete All Home Spaces",
                "description": "This permission allows to delete home spaces.",
                "permissionValue": {
                  "operation": "OPERATION_DELETE",
                  "constraint": "CONSTRAINT_ALL"
                },
                "resource": {
                  "type": "TYPE_SYSTEM"
                }
              },
              {
                "id": "fb60b004-c1fa-4f09-bf87-55ce7d46ac61",
                "name": "delete-all-spaces",
                "displayName": "Delete AllSpaces",
                "description": "This permission allows to delete all spaces.",
                "permissionValue": {
                  "operation": "OPERATION_DELETE",
                  "constraint": "CONSTRAINT_ALL"
                },
                "resource": {
                  "type": "TYPE_SYSTEM"
                }
              },
              {
                "id": "ed83fc10-1f54-4a9e-b5a7-fb517f5f3e01",
                "name": "change-logo",
                "displayName": "Change logo",
                "description": "This permission permits to change the system logo.",
                "permissionValue": {
                  "operation": "OPERATION_READWRITE",
                  "constraint": "CONSTRAINT_ALL"
                },
                "resource": {
                  "type": "TYPE_SYSTEM"
                }
              }
            ],
            "resource": {
              "type": "TYPE_SYSTEM"
            }
          }
      ]
```

For the `customRolesConfigRef` the corresponding line in the own values YAML was uncomment (and `customRoles` commented) and the following YAML was applied with `kubectl apply`

```YAML
apiVersion: v1
kind: ConfigMap
metadata:
  name: my-ocis-role-config
  namespace: default
data:
  custom-roles.json: |
    [
        {
          "id": "71881883-1768-46bd-a24d-a356a2afdf7f",
          "name": "admin32",
          "type": "TYPE_ROLE",
          "extension": "ocis-roles",
          "displayName": "AdministratorIn32",
          "settings": [
            {
              "id": "a53e601e-571f-4f86-8fec-d4576ef49c62",
              "name": "role-management",
              "displayName": "Role Management",
              "description": "This permission gives full access to everything that is related to role management.",
              "permissionValue": {
                "operation": "OPERATION_READWRITE",
                "constraint": "CONSTRAINT_ALL"
              },
              "resource": {
                "type": "TYPE_USER",
                "id": "all"
              }
            },
            {
              "id": "3d58f441-4a05-42f8-9411-ef5874528ae1",
              "name": "settings-management",
              "displayName": "Settings Management",
              "description": "This permission gives full access to everything that is related to settings management.",
              "permissionValue": {
                "operation": "OPERATION_READWRITE",
                "constraint": "CONSTRAINT_ALL"
              },
              "resource": {
                "type": "TYPE_USER",
                "id": "all"
              }
            },
            {
              "id": "7d81f103-0488-4853-bce5-98dcce36d649",
              "name": "language-readwrite",
              "displayName": "Permission to read and set the language (anyone)",
              "permissionValue": {
                "operation": "OPERATION_READWRITE",
                "constraint": "CONSTRAINT_ALL"
              },
              "resource": {
                "type": "TYPE_SETTING",
                "id": "aa8cfbe5-95d4-4f7e-a032-c3c01f5f062f"
              }
            },
            {
              "id": "8e587774-d929-4215-910b-a317b1e80f73",
              "name": "account-management",
              "displayName": "Account Management",
              "description": "This permission gives full access to everything that is related to account management.",
              "permissionValue": {
                "operation": "OPERATION_READWRITE",
                "constraint": "CONSTRAINT_ALL"
              },
              "resource": {
                "type": "TYPE_USER",
                "id": "all"
              }
            },
            {
              "id": "522adfbe-5908-45b4-b135-41979de73245",
              "name": "group-management",
              "displayName": "Group Management",
              "description": "This permission gives full access to everything that is related to group management.",
              "permissionValue": {
                "operation": "OPERATION_READWRITE",
                "constraint": "CONSTRAINT_ALL"
              },
              "resource": {
                "type": "TYPE_GROUP",
                "id": "all"
              }
            },
            {
              "id": "4e6f9709-f9e7-44f1-95d4-b762d27b7896",
              "name": "set-space-quota",
              "displayName": "Set Space Quota",
              "description": "This permission allows to manage space quotas.",
              "permissionValue": {
                "operation": "OPERATION_READWRITE",
                "constraint": "CONSTRAINT_ALL"
              },
              "resource": {
                "type": "TYPE_SYSTEM"
              }
            },
            {
              "id": "79e13b30-3e22-11eb-bc51-0b9f0bad9a58",
              "name": "create-space",
              "displayName": "Create Space",
              "description": "This permission allows to create new spaces.",
              "permissionValue": {
                "operation": "OPERATION_READWRITE",
                "constraint": "CONSTRAINT_ALL"
              },
              "resource": {
                "type": "TYPE_SYSTEM"
              }
            },
            {
              "id": "016f6ddd-9501-4a0a-8ebe-64a20ee8ec82",
              "name": "list-all-spaces",
              "displayName": "List All Spaces",
              "description": "This permission allows list all spaces.",
              "permissionValue": {
                "operation": "OPERATION_READ",
                "constraint": "CONSTRAINT_ALL"
              },
              "resource": {
                "type": "TYPE_SYSTEM"
              }
            },
            {
              "id": "5de9fe0a-4bc5-4a47-b758-28f370caf169",
              "name": "delete-all-home-spaces",
              "displayName": "Delete All Home Spaces",
              "description": "This permission allows to delete home spaces.",
              "permissionValue": {
                "operation": "OPERATION_DELETE",
                "constraint": "CONSTRAINT_ALL"
              },
              "resource": {
                "type": "TYPE_SYSTEM"
              }
            },
            {
              "id": "fb60b004-c1fa-4f09-bf87-55ce7d46ac61",
              "name": "delete-all-spaces",
              "displayName": "Delete AllSpaces",
              "description": "This permission allows to delete all spaces.",
              "permissionValue": {
                "operation": "OPERATION_DELETE",
                "constraint": "CONSTRAINT_ALL"
              },
              "resource": {
                "type": "TYPE_SYSTEM"
              }
            },
            {
              "id": "ed83fc10-1f54-4a9e-b5a7-fb517f5f3e01",
              "name": "change-logo",
              "displayName": "Change logo",
              "description": "This permission permits to change the system logo.",
              "permissionValue": {
                "operation": "OPERATION_READWRITE",
                "constraint": "CONSTRAINT_ALL"
              },
              "resource": {
                "type": "TYPE_SYSTEM"
              }
            }
          ],
          "resource": {
            "type": "TYPE_SYSTEM"
          }
        }
    ]
```

## Types of changes
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Technical debt
- [ ] Tests only (no source changes)

## Checklist:
- [ ] Code changes
- [ ] Unit tests added
- [ ] Acceptance tests added
- [x] Documentation generated (`make docs`) and committed
- [ ] Documentation ticket raised: <link>
- [ ] Documentation PR created: <link>
