### PR TITLE
Added replicas, hpa, pdb and configuration option for store addresses

### DIFF
--- a/charts/ocis/templates/eventhistory/deployment.yaml
+++ b/charts/ocis/templates/eventhistory/deployment.yaml
@@ -11,7 +11,12 @@ spec:
   selector:
     matchLabels:
       app: {{ .appName }}
-  replicas: 1
+  {{- if and (not .Values.autoscaling.enabled) (.Values.replicas) }}
+  replicas: {{ .Values.replicas }}
+  {{- end }}
+  {{- if .Values.deploymentStrategy }}
+  strategy: {{ toYaml .Values.deploymentStrategy | nindent 4 }}
+  {{ end }}
   template:
     metadata:
       labels:
@@ -55,10 +60,10 @@ spec:
             # - name: EVENTHISTORY_DEBUG_ADDR
             #   value: 0.0.0.0:8081
 
-            # - name: EVENTHISTORY_STORE_TYPE
-            #   value: "mem" # TODO
-            # - name: EVENTHISTORY_STORE_ADDRESSES
-            #   value: "nats:9233" # TODO
+            - name: EVENTHISTORY_STORE_TYPE
+              value: {{ .Values.services.eventhistory.storeType }}
+            - name: EVENTHISTORY_STORE_ADDRESSES
+              value: {{ tpl .Values.services.eventhistory.storeAddresses . }}
 
             - name: EVENTHISTORY_EVENTS_ENDPOINT
             {{- if not .Values.messagingSystem.external.enabled }}

--- a/charts/ocis/templates/eventhistory/hpa.yaml
+++ b/charts/ocis/templates/eventhistory/hpa.yaml
@@ -1,0 +1,19 @@
+{{- if .Values.autoscaling.enabled }}
+{{- include "ocis.appNames" (dict "scope" . "appName" "appNameEventhistory" "appNameSuffix" "") -}}
+apiVersion: {{ template "common.apiversion.hpa" . }}
+kind: HorizontalPodAutoscaler
+metadata:
+  name: {{ .appName }}
+  namespace: {{ template "ocis.namespace" . }}
+  labels:
+    {{- include "ocis.labels" . | nindent 4 }}
+spec:
+  scaleTargetRef:
+    apiVersion: apps/v1
+    kind: Deployment
+    name: {{ .appName }}
+  minReplicas: {{ .Values.autoscaling.minReplicas }}
+  maxReplicas: {{ .Values.autoscaling.maxReplicas }}
+  metrics:
+{{ toYaml .Values.autoscaling.metrics | indent 4 }}
+{{- end }}

--- a/charts/ocis/templates/eventhistory/pdb.yaml
+++ b/charts/ocis/templates/eventhistory/pdb.yaml
@@ -1,0 +1,2 @@
+{{- include "ocis.appNames" (dict "scope" . "appName" "appNameEventhistory" "appNameSuffix" "") -}}
+{{ include "ocis.pdb" . }}

--- a/charts/ocis/templates/userlog/deployment.yaml
+++ b/charts/ocis/templates/userlog/deployment.yaml
@@ -11,7 +11,12 @@ spec:
   selector:
     matchLabels:
       app: {{ .appName }}
-  replicas: 1
+  {{- if and (not .Values.autoscaling.enabled) (.Values.replicas) }}
+  replicas: {{ .Values.replicas }}
+  {{- end }}
+  {{- if .Values.deploymentStrategy }}
+  strategy: {{ toYaml .Values.deploymentStrategy | nindent 4 }}
+  {{ end }}
   template:
     metadata:
       labels:
@@ -56,9 +61,9 @@ spec:
             #   value: 0.0.0.0:8081
 
             - name: USERLOG_STORE_TYPE
-              value: "mem" # TODO
-            # - name: USERLOG_STORE_ADDRESSES
-            #   value: "nats:9233" # TODO
+              value: {{ .Values.services.userlog.storeType }}
+            - name: USERLOG_STORE_ADDRESSES
+              value: {{ tpl .Values.services.userlog.storeAddresses . }}
 
             - name: USERLOG_EVENTS_ENDPOINT
             {{- if not .Values.messagingSystem.external.enabled }}

--- a/charts/ocis/templates/userlog/hpa.yaml
+++ b/charts/ocis/templates/userlog/hpa.yaml
@@ -1,0 +1,19 @@
+{{- if .Values.autoscaling.enabled }}
+{{- include "ocis.appNames" (dict "scope" . "appName" "appNameUserlog" "appNameSuffix" "") -}}
+apiVersion: {{ template "common.apiversion.hpa" . }}
+kind: HorizontalPodAutoscaler
+metadata:
+  name: {{ .appName }}
+  namespace: {{ template "ocis.namespace" . }}
+  labels:
+    {{- include "ocis.labels" . | nindent 4 }}
+spec:
+  scaleTargetRef:
+    apiVersion: apps/v1
+    kind: Deployment
+    name: {{ .appName }}
+  minReplicas: {{ .Values.autoscaling.minReplicas }}
+  maxReplicas: {{ .Values.autoscaling.maxReplicas }}
+  metrics:
+{{ toYaml .Values.autoscaling.metrics | indent 4 }}
+{{- end }}

--- a/charts/ocis/templates/userlog/pdb.yaml
+++ b/charts/ocis/templates/userlog/pdb.yaml
@@ -1,0 +1,2 @@
+{{- include "ocis.appNames" (dict "scope" . "appName" "appNameUserlog" "appNameSuffix" "") -}}
+{{ include "ocis.pdb" . }}

--- a/charts/ocis/values.yaml
+++ b/charts/ocis/values.yaml
@@ -471,6 +471,14 @@ services:
   eventhistory:
     # -- Per-service resources configuration. Overrides the default setting from `resources` if set.
     resources: {}
+    # -- Configure the store type for the userlog service. Might be `memory`, `ocmem`, `etcd`, `redis`, 
+    # `redis-sentinel`, `nats-js` or `noop`
+    storeType: nats-js
+    # -- Provide a list of comma-separated addresses of `etcd`, `redis`, `redis-sentinel` or `nats-js` servers here
+    # if the proper store is selected
+    storeAddresses: "{{ .appNameNats }}:9233"
+    # -- Per-service PodDisruptionBudget. Overrides the default setting from `podDisruptionBudget` if set.
+    podDisruptionBudget: {}
 
   # -- FRONTEND service.
   # @default -- see detailed service configuration options below
@@ -892,6 +900,14 @@ services:
   userlog:
     # -- Per-service resources configuration. Overrides the default setting from `resources` if set.
     resources: {}
+    # -- Configure the store type for the userlog service. Might be `memory`, `ocmem`, `etcd`, `redis`, 
+    # `redis-sentinel`, `nats-js` or `noop`
+    storeType: nats-js
+    # -- Provide a list of comma-separated addresses of `etcd`, `redis`, `redis-sentinel` or `nats-js` servers here
+    # if the proper store is selected
+    storeAddresses: "{{ .appNameNats }}:9233"
+    # -- Per-service PodDisruptionBudget. Overrides the default setting from `podDisruptionBudget` if set.
+    podDisruptionBudget: {}
 
   # -- USERS service.
   # @default -- see detailed service configuration options below


### PR DESCRIPTION
## Description
Added replicas, hpa, pdb and configuration option for store addresses for userlog and eventhistory

## Related Issue
- Fixes #165

## Motivation and Context
Feature Request

## How Has This Been Tested?
Mostly with `helm template` and the following own values YAML:

```YAML
replicas: 2

externalDomain: ocis.owncloud.test
ingress:
  enabled: true
  annotations:
    nginx.ingress.kubernetes.io/proxy-body-size: 1024m
  tls:
    - hosts:
        - ocis.owncloud.test
insecure:
  # disables ssl certificate checking for connections to the openID connect identity provider.
  # Not recommended for production setups, but we don't have valid certificates in minikube
  oidcIdpInsecure: true
  # disables ssl certificate checking for connections to the oCIS http apis.
  # Not recommended for production setups, but we don't have valid certificates in minikube
  ocisHttpApiInsecure: true

podDisruptionBudget:
  maxUnavailable: 1
services:
 userlog:
    # -- Configure the store type for the userlog service. Might be `memory`, `ocmem`, `etcd`, `redis`, 
    # `redis-sentinel`, `nats-js` or `noop`
    storeType: redis
    # -- Provide a list of comma-separated addresses of `redis`, `redis-sentinel` or `etcd` servers here
    # if the proper store is selected
    storeAddresses: "127.0.0.1:433,127.0.0.2:433"
    podDisruptionBudget:
      maxUnavailable: 1
 eventhistory:
    # -- Configure the store type for the userlog service. Might be `memory`, `ocmem`, `etcd`, `redis`, 
    # `redis-sentinel`, `nats-js` or `noop`
    storeType: redis
    # -- Provide a list of comma-separated addresses of `redis`, `redis-sentinel` or `etcd` servers here
    # if the proper store is selected
    storeAddresses: "127.0.0.1:433,127.0.0.2:433"
    podDisruptionBudget:
      maxUnavailable: 1
```

Strangely there is no error in the logs and the system run flawlessly even if invalid addresses are set.

## Types of changes
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Technical debt
- [ ] Tests only (no source changes)

## Checklist:
- [ ] Code changes
- [ ] Unit tests added
- [ ] Acceptance tests added
- [ ] Documentation generated (`make docs`) and committed
- [ ] Documentation ticket raised: <link>
- [ ] Documentation PR created: <link>
