### PR TITLE
fix appregistry configmap reference

### DIFF
--- a/charts/ocis/templates/appregistry/deployment.yaml
+++ b/charts/ocis/templates/appregistry/deployment.yaml
@@ -99,5 +99,5 @@ spec:
           emptyDir: {}
         - name: configs
           configMap:
-            name: {{ .appName }}-registry-config
+            name: {{ .appName }}-config
 {{ end }}


### PR DESCRIPTION
## Description
the appregistry services references a non existing configmap

This is the configmap it should reference:
https://github.com/owncloud/ocis-charts/blob/4bad8c1780225010e3a6680429471f2e2be452a3/charts/ocis/templates/appregistry/config.yaml#L6

## Related Issue
<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->
- Fixes office integration

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->

## How Has This Been Tested?
- minikube

## Screenshots (if appropriate):

## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Technical debt
- [ ] Tests only (no source changes)

## Checklist:
- [x] Code changes
- [ ] Unit tests added
- [ ] Acceptance tests added
- [ ] Documentation generated (`make docs`) and committed
- [ ] Documentation ticket raised: <link>
- [ ] Documentation PR created: <link>
