### PR TITLE
Added support for antivirus service

### DIFF
--- a/charts/ocis/ci/values_<1.25.0.yaml
+++ b/charts/ocis/ci/values_<1.25.0.yaml
@@ -43,6 +43,8 @@ features:
         icon: ""
         default_app: ""
         allow_creation: true
+  virusscan:
+    enabled: true
 
 extraLabels:
   extra1: lorem

--- a/charts/ocis/ci/values_>=1.25.0.yaml
+++ b/charts/ocis/ci/values_>=1.25.0.yaml
@@ -43,6 +43,8 @@ features:
         icon: ""
         default_app: ""
         allow_creation: true
+  virusscan:
+    enabled: true
 
 extraLabels:
   extra1: lorem

--- a/charts/ocis/docs/values-desc-table.adoc
+++ b/charts/ocis/docs/values-desc-table.adoc
@@ -485,13 +485,13 @@ a| [subs=-attributes]
 +string+
 a| [subs=-attributes]
 `"delete"`
-| Define what should happen with infected files
+| Define what should happen with infected files. upported options are: 'delete', 'continue' and 'abort '.  Delete will delete the file.  Continue will mark the file as infected but continues further processing.  Abort will keep the file in the uploads folder for further admin inspection and will not move it to its final destination.
 | features.virusscan.maxScanSize
 a| [subs=-attributes]
 +string+
 a| [subs=-attributes]
 `nil`
-| Sets a maximum file size for scans
+| Sets a maximum file size for scans. Only this many bytes of a file will be scanned. 0 means unlimited and is the default.  Usable common abbreviations: [KB, KiB, GB, GiB, TB, TiB, PB, PiB, EB, EiB], example: 2GB.
 | image.pullPolicy
 a| [subs=-attributes]
 +string+

--- a/charts/ocis/docs/values-desc-table.adoc
+++ b/charts/ocis/docs/values-desc-table.adoc
@@ -450,6 +450,48 @@ a| [subs=-attributes]
 a| [subs=-attributes]
 `nil`
 | Define the roles by specifying a name of a ConfigMap which already contains the the role description (might also be defined in the `extraResources` section). The ConfigMap needs to contain a file named `custom-roles.json` which holds the role description in JSON format Please note that you have to restart the settings service manually if you change the content of you ConfigMap.
+| features.virusscan.enabled
+a| [subs=-attributes]
++bool+
+a| [subs=-attributes]
+`false`
+| Enabled virus scanning
+| features.virusscan.icap
+a| [subs=-attributes]
++object+
+a| [subs=-attributes]
+`{"service":"avscan","timeout":300,"url":"icap://127.0.0.1:1344"}`
+| Define icap parameters
+| features.virusscan.icap.service
+a| [subs=-attributes]
++string+
+a| [subs=-attributes]
+`"avscan"`
+| Sets the service to be used in icap
+| features.virusscan.icap.timeout
+a| [subs=-attributes]
++int+
+a| [subs=-attributes]
+`300`
+| Sets the timeout for icap scans
+| features.virusscan.icap.url
+a| [subs=-attributes]
++string+
+a| [subs=-attributes]
+`"icap://127.0.0.1:1344"`
+| Sets the icap url
+| features.virusscan.infectedFileHandling
+a| [subs=-attributes]
++string+
+a| [subs=-attributes]
+`"delete"`
+| Define what should happen with infected files
+| features.virusscan.maxScanSize
+a| [subs=-attributes]
++string+
+a| [subs=-attributes]
+`nil`
+| Sets a maximum file size for scans
 | image.pullPolicy
 a| [subs=-attributes]
 +string+
@@ -702,6 +744,24 @@ a| [subs=-attributes]
 a| [subs=-attributes]
 `1000`
 | User ID that all processes within any containers will run with.
+| services.antivirus
+a| [subs=-attributes]
++object+
+a| [subs=-attributes]
+see detailed service configuration options below
+| ANTIVIRUS service.
+| services.antivirus.podDisruptionBudget
+a| [subs=-attributes]
++object+
+a| [subs=-attributes]
+`{}`
+| Per-service PodDisruptionBudget. Overrides the default setting from `podDisruptionBudget` if set.
+| services.antivirus.resources
+a| [subs=-attributes]
++object+
+a| [subs=-attributes]
+`{}`
+| Per-service resources configuration. Overrides the default setting from `resources` if set.
 | services.appprovider
 a| [subs=-attributes]
 +object+

--- a/charts/ocis/docs/values-desc-table.adoc
+++ b/charts/ocis/docs/values-desc-table.adoc
@@ -389,7 +389,7 @@ a| [subs=-attributes]
 +object+
 a| [subs=-attributes]
 `{"claim":"roles","enabled":false,"mapping":{"admin":"ocisAdmin","guest":"ocisGuest","spaceadmin":"ocisSpaceAdmin","user":"ocisUser"}}`
-| Configure OIDC role assignment. If activated, oCIS will read the role assigment from the OIDC token, see  xref:{s-path}/proxy.adoc#automatic-role-assignments[Automatic Role Assignments]
+| Configure OIDC role assignment. If activated, oCIS will read the role assigment from the OIDC token, see xref:{s-path}/proxy.adoc#automatic-role-assignments[Automatic Role Assignments]
 | features.externalUserManagement.oidc.roleAssignment.claim
 a| [subs=-attributes]
 +string+
@@ -485,13 +485,13 @@ a| [subs=-attributes]
 +string+
 a| [subs=-attributes]
 `"delete"`
-| Define what should happen with infected files. upported options are: 'delete', 'continue' and 'abort '.  Delete will delete the file.  Continue will mark the file as infected but continues further processing.  Abort will keep the file in the uploads folder for further admin inspection and will not move it to its final destination.
+| Define what should happen with infected files. Supported options are: 'delete', 'continue' and 'abort '. Delete will delete the file. Continue will mark the file as infected but continues further processing. Abort will keep the file in the uploads folder for further admin inspection and will not move it to its final destination.
 | features.virusscan.maxScanSize
 a| [subs=-attributes]
 +string+
 a| [subs=-attributes]
 `nil`
-| Sets a maximum file size for scans. Only this many bytes of a file will be scanned. 0 means unlimited and is the default.  Usable common abbreviations: [KB, KiB, GB, GiB, TB, TiB, PB, PiB, EB, EiB], example: 2GB.
+| Sets a maximum file size for scans. Only this many bytes of a file will be scanned. 0 means unlimited and is the default. Usable common abbreviations: [KB, KiB, GB, GiB, TB, TiB, PB, PiB, EB, EiB], example: 2GB.
 | image.pullPolicy
 a| [subs=-attributes]
 +string+
@@ -749,7 +749,7 @@ a| [subs=-attributes]
 +object+
 a| [subs=-attributes]
 see detailed service configuration options below
-| ANTIVIRUS service.
+| ANTIVIRUS service. Not used if `features.virusscan.enabled` equals `false`.
 | services.antivirus.podDisruptionBudget
 a| [subs=-attributes]
 +object+

--- a/charts/ocis/docs/values.adoc.yaml
+++ b/charts/ocis/docs/values.adoc.yaml
@@ -292,9 +292,13 @@ features:
   virusscan:
     # -- Enabled virus scanning
     enabled: false
-    # -- Define what should happen with infected files
+    # -- Define what should happen with infected files. upported options are: 'delete', 'continue' and 'abort '. 
+    # Delete will delete the file. 
+    # Continue will mark the file as infected but continues further processing. 
+    # Abort will keep the file in the uploads folder for further admin inspection and will not move it to its final destination.
     infectedFileHandling: delete
-    # -- Sets a maximum file size for scans
+    # -- Sets a maximum file size for scans. Only this many bytes of a file will be scanned. 0 means unlimited and is the default. 
+    # Usable common abbreviations: [KB, KiB, GB, GiB, TB, TiB, PB, PiB, EB, EiB], example: 2GB.
     maxScanSize: 
     # -- Define icap parameters
     icap:

--- a/charts/ocis/docs/values.adoc.yaml
+++ b/charts/ocis/docs/values.adoc.yaml
@@ -69,7 +69,7 @@ store:
   type: nats-js
   # -- Provide a list of comma-separated addresses of `etcd`, `redis`, `redis-sentinel` or `nats-js` servers here
   # if the proper store is selected
-  addresses: 
+  addresses:
     - "{{ .appNameNats }}:9233"
 
 messagingSystem:
@@ -191,14 +191,14 @@ features:
       # Set to `username` if the claim specified in `...oidc.userIDClaim` holds the value of the ldap user attribute specified in `...ldap.user.schema.userName`.
       userIDClaimAttributeMapping: userid
 
-      # -- Configure OIDC role assignment. If activated, oCIS will read the role assigment from the OIDC token, see 
+      # -- Configure OIDC role assignment. If activated, oCIS will read the role assigment from the OIDC token, see
       # xref:{s-path}/proxy.adoc#automatic-role-assignments[Automatic Role Assignments]
-      roleAssignment: 
+      roleAssignment:
         enabled: false
         # -- The name of the OIDC claim holding the role assignment
         claim: roles
         # -- Configure the mapping for the role assignment
-        mapping: 
+        mapping:
           admin: ocisAdmin
           user: ocisUser
           spaceadmin: ocisSpaceAdmin
@@ -292,21 +292,21 @@ features:
   virusscan:
     # -- Enabled virus scanning
     enabled: false
-    # -- Define what should happen with infected files. upported options are: 'delete', 'continue' and 'abort '. 
-    # Delete will delete the file. 
-    # Continue will mark the file as infected but continues further processing. 
+    # -- Define what should happen with infected files. Supported options are: 'delete', 'continue' and 'abort '.
+    # Delete will delete the file.
+    # Continue will mark the file as infected but continues further processing.
     # Abort will keep the file in the uploads folder for further admin inspection and will not move it to its final destination.
     infectedFileHandling: delete
-    # -- Sets a maximum file size for scans. Only this many bytes of a file will be scanned. 0 means unlimited and is the default. 
+    # -- Sets a maximum file size for scans. Only this many bytes of a file will be scanned. 0 means unlimited and is the default.
     # Usable common abbreviations: [KB, KiB, GB, GiB, TB, TiB, PB, PiB, EB, EiB], example: 2GB.
-    maxScanSize: 
+    maxScanSize:
     # -- Define icap parameters
     icap:
       # -- Sets the timeout for icap scans
       timeout: 300
       # -- Sets the icap url
       url: icap://127.0.0.1:1344
-      # -- Sets the service to be used in icap 
+      # -- Sets the service to be used in icap
       service: avscan
 
 # Ingress for oCIS.
@@ -511,7 +511,7 @@ services:
     # -- Per-service PodDisruptionBudget. Overrides the default setting from `podDisruptionBudget` if set.
     podDisruptionBudget: {}
 
-  # -- ANTIVIRUS service.
+  # -- ANTIVIRUS service. Not used if `features.virusscan.enabled` equals `false`.
   # @default -- see detailed service configuration options below
   antivirus:
     # -- Per-service resources configuration. Overrides the default setting from `resources` if set.
@@ -526,9 +526,9 @@ services:
     resources: {}
     # -- Per-service store configuration for the eventhistory service. Overrides the default setting from `store` if set.
     store: {}
-      # -- Configure the store type for the eventhistory service. Might be `memory`, `ocmem`, `etcd`, `redis`, 
+      # -- Configure the store type for the eventhistory service. Might be `memory`, `ocmem`, `etcd`, `redis`,
       # `redis-sentinel`, `nats-js` or `noop`
-      #type: 
+      #type:
       # -- Provide a list of comma-separated addresses of `etcd`, `redis`, `redis-sentinel` or `nats-js` servers here
       # if the proper store is selected
       # addresses: []
@@ -963,12 +963,12 @@ services:
     resources: {}
     # -- Per-service store configuration for the userlog service. Overrides the default setting from `store` if set.
     store: {}
-      # -- Configure the store type for the userlog service. Might be `memory`, `ocmem`, `etcd`, `redis`, 
+      # -- Configure the store type for the userlog service. Might be `memory`, `ocmem`, `etcd`, `redis`,
       # `redis-sentinel`, `nats-js` or `noop`
-      # type: 
+      # type:
       # -- Provide a list of comma-separated addresses of `etcd`, `redis`, `redis-sentinel` or `nats-js` servers here
       # if the proper store is selected
-      # addresses: 
+      # addresses:
         # - "{{ .appNameNats }}:9233"
     # -- Per-service PodDisruptionBudget. Overrides the default setting from `podDisruptionBudget` if set.
     podDisruptionBudget: {}

--- a/charts/ocis/docs/values.adoc.yaml
+++ b/charts/ocis/docs/values.adoc.yaml
@@ -288,6 +288,22 @@ features:
     #   71881883-1768-46bd-a24d-a356a2afdf7f: 100000000000
     #   # Space Administrator Role set to 100GB
     #   2aadd357-682c-406b-8874-293091995fdd: 100000000000
+  # Define virus scanning
+  virusscan:
+    # -- Enabled virus scanning
+    enabled: false
+    # -- Define what should happen with infected files
+    infectedFileHandling: delete
+    # -- Sets a maximum file size for scans
+    maxScanSize: 
+    # -- Define icap parameters
+    icap:
+      # -- Sets the timeout for icap scans
+      timeout: 300
+      # -- Sets the icap url
+      url: icap://127.0.0.1:1344
+      # -- Sets the service to be used in icap 
+      service: avscan
 
 # Ingress for oCIS.
 ingress:
@@ -486,6 +502,14 @@ services:
   # -- AUTH MACHINE service.
   # @default -- see detailed service configuration options below
   authmachine:
+    # -- Per-service resources configuration. Overrides the default setting from `resources` if set.
+    resources: {}
+    # -- Per-service PodDisruptionBudget. Overrides the default setting from `podDisruptionBudget` if set.
+    podDisruptionBudget: {}
+
+  # -- ANTIVIRUS service.
+  # @default -- see detailed service configuration options below
+  antivirus:
     # -- Per-service resources configuration. Overrides the default setting from `resources` if set.
     resources: {}
     # -- Per-service PodDisruptionBudget. Overrides the default setting from `podDisruptionBudget` if set.

--- a/charts/ocis/templates/_common/_tplvalues.tpl
+++ b/charts/ocis/templates/_common/_tplvalues.tpl
@@ -60,6 +60,7 @@ Adds the app names to the scope and set the name of the app based on the input p
   {{- $_ := set .scope "appNameAudit" "audit" -}}
   {{- $_ := set .scope "appNameAuthBasic" "authbasic" -}}
   {{- $_ := set .scope "appNameAuthMachine" "authmachine" -}}
+  {{- $_ := set .scope "appNameAntivirus" "antivirus" -}}
   {{- $_ := set .scope "appNameEventhistory" "eventhistory" -}}
   {{- $_ := set .scope "appNameFrontend" "frontend" -}}
   {{- $_ := set .scope "appNameGateway" "gateway" -}}

--- a/charts/ocis/templates/antivirus/deployment.yaml
+++ b/charts/ocis/templates/antivirus/deployment.yaml
@@ -1,5 +1,6 @@
-{{- include "ocis.appNames" (dict "scope" . "appName" "appNamePostprocessing" "appNameSuffix" "") -}}
-{{- $_ := set . "resources" (default (default (dict) .Values.resources) .Values.services.postprocessing.resources) -}}
+{{ if .Values.features.virusscan.enabled }}
+{{- include "ocis.appNames" (dict "scope" . "appName" "appNameAntivirus" "appNameSuffix" "") -}}
+{{- $_ := set . "resources" (default (default (dict) .Values.resources) .Values.services.audit.resources) -}}
 apiVersion: apps/v1
 kind: Deployment
 metadata:
@@ -11,7 +12,12 @@ spec:
   selector:
     matchLabels:
       app: {{ .appName }}
-  replicas: 1
+  {{- if and (not .Values.autoscaling.enabled) (.Values.replicas) }}
+  replicas: {{ .Values.replicas }}
+  {{- end }}
+  {{- if .Values.deploymentStrategy }}
+  strategy: {{ toYaml .Values.deploymentStrategy | nindent 4 }}
+  {{ end }}
   template:
     metadata:
       labels:
@@ -30,7 +36,7 @@ spec:
           image: {{ template "ocis.image" $ }}
           imagePullPolicy: {{ .Values.image.pullPolicy }}
           command: ["ocis"]
-          args: ["postprocessing", "server"]
+          args: ["antivirus", "server"]
           securityContext:
             runAsNonRoot: true
             runAsUser: {{ .Values.securityContext.runAsUser }}
@@ -39,37 +45,36 @@ spec:
           env:
             - name: MICRO_REGISTRY
               value: kubernetes
-
-            - name: POSTPROCESSING_LOG_COLOR
+            - name: ANTIVIRUS_LOG_COLOR
               value: {{ .Values.logging.color | quote }}
-            - name: POSTPROCESSING_LOG_LEVEL
+            - name: ANTIVIRUS_LOG_LEVEL
               value: {{ .Values.logging.level | quote }}
-            - name: POSTPROCESSING_LOG_PRETTY
+            - name: ANTIVIRUS_LOG_PRETTY
               value: {{ .Values.logging.pretty | quote }}
-
-            # - name: POSTPROCESSING_DEBUG_PPROF
-            #   value: {{ .Values.debug.profiling | quote }}
-
-            # - name: POSTPROCESSING_DEBUG_ADDR
-            #   value: 0.0.0.0:TODO
-
-            {{- if .Values.features.virusscan.enabled }}
-            - name: POSTPROCESSING_STEPS
-              value: "virusscan"
-            {{- end }}
-
-            - name: POSTPROCESSING_EVENTS_ENDPOINT
+            - name: ANTIVIRUS_INFECTED_FILE_HANDLING
+              value: {{ .Values.features.virusscan.infectedFileHandling | quote }}
+            - name: ANTIVIRUS_SCANNER_TYPE
+              value: "icap"
+            - name: ANTIVIRUS_ICAP_TIMEOUT
+              value: {{ .Values.features.virusscan.icap.timeout | quote }}
+            - name: ANTIVIRUS_ICAP_URL
+              value: {{ .Values.features.virusscan.icap.url | quote }}
+            - name: ANTIVIRUS_ICAP_SERVICE
+              value: {{ .Values.features.virusscan.icap.service | quote }}
+            - name: ANTIVIRUS_MAX_SCAN_SIZE
+              value: {{ .Values.features.virusscan.maxScanSize | quote }}
+            - name: ANTIVIRUS_EVENTS_ENDPOINT
             {{- if not .Values.messagingSystem.external.enabled }}
               value: {{ .appNameNats }}:9233
             {{- else }}
               value: {{ .Values.messagingSystem.external.endpoint | quote }}
-            - name: POSTPROCESSING_EVENTS_CLUSTER
+            - name: ANTIVIRUS_EVENTS_CLUSTER
               value: {{ .Values.messagingSystem.external.cluster | quote }}
-            - name: POSTPROCESSING_EVENTS_ENABLE_TLS
+            - name: ANTIVIRUS_EVENTS_ENABLE_TLS
               value: {{ .Values.messagingSystem.external.tls.enabled | quote }}
-            - name: POSTPROCESSING_EVENTS_TLS_INSECURE
+            - name: ANTIVIRUS_EVENTS_TLS_INSECURE
               value: {{ .Values.messagingSystem.external.tls.insecure | quote }}
-            - name: POSTPROCESSING_EVENTS_TLS_ROOT_CA_CERTIFICATE
+            - name: ANTIVIRUS_EVENTS_TLS_ROOT_CA_CERTIFICATE
               {{- if not .Values.messagingSystem.external.tls.certTrusted }}
               value: /etc/ocis/messaging-system-ca/messaging-system-ca.crt
               {{- else }}
@@ -77,22 +82,7 @@ spec:
               {{- end }}
             {{- end }}
 
-          # TODO: This service does not currently provide a debug port, re-enable this once that is implemented
-          # See: https://github.com/owncloud/ocis-charts/issues/111
-          # livenessProbe:
-          #   httpGet:
-          #     path: /healthz
-          #     port: metrics-debug
-          #   timeoutSeconds: 10
-          #   initialDelaySeconds: 60
-          #   periodSeconds: 20
-          #   failureThreshold: 3
-
           resources: {{ toYaml .resources | nindent 12 }}
-          # TODO: This service does not currently provide a debug port, re-enable this once that is implemented
-          # ports:
-          #   - name: metrics-debug
-          #     containerPort: TODO
 
           volumeMounts:
             - name: ocis-config-tmp
@@ -112,3 +102,4 @@ spec:
           {{ else }}
           emptyDir: {}
           {{ end }}
+{{ end }}

--- a/charts/ocis/templates/antivirus/hpa.yaml
+++ b/charts/ocis/templates/antivirus/hpa.yaml
@@ -1,0 +1,21 @@
+{{ if .Values.features.virusscan.enabled }}
+{{- if .Values.autoscaling.enabled }}
+{{- include "ocis.appNames" (dict "scope" . "appName" "appNameAntivirus" "appNameSuffix" "") -}}
+apiVersion: {{ template "common.apiversion.hpa" . }}
+kind: HorizontalPodAutoscaler
+metadata:
+  name: {{ .appName }}
+  namespace: {{ template "ocis.namespace" . }}
+  labels:
+    {{- include "ocis.labels" . | nindent 4 }}
+spec:
+  scaleTargetRef:
+    apiVersion: apps/v1
+    kind: Deployment
+    name: {{ .appName }}
+  minReplicas: {{ .Values.autoscaling.minReplicas }}
+  maxReplicas: {{ .Values.autoscaling.maxReplicas }}
+  metrics:
+{{ toYaml .Values.autoscaling.metrics | indent 4 }}
+{{- end }}
+{{- end }}

--- a/charts/ocis/templates/antivirus/pdb.yaml
+++ b/charts/ocis/templates/antivirus/pdb.yaml
@@ -1,0 +1,4 @@
+{{ if .Values.features.virusscan.enabled }}
+{{- include "ocis.appNames" (dict "scope" . "appName" "appNameAntivirus" "appNameSuffix" "") -}}
+{{ include "ocis.pdb" . }}
+{{ end }}

--- a/charts/ocis/templates/search/deployment.yaml
+++ b/charts/ocis/templates/search/deployment.yaml
@@ -115,6 +115,9 @@ spec:
                   name: {{ .Values.secretRefs.machineAuthApiKeySecretRef }}
                   key: machine-auth-api-key
 
+            - name: OCIS_ASYNC_UPLOADS
+              value: "true"
+
           livenessProbe:
             httpGet:
               path: /healthz

--- a/charts/ocis/templates/storageusers/deployment.yaml
+++ b/charts/ocis/templates/storageusers/deployment.yaml
@@ -163,6 +163,12 @@ spec:
               value: {{ .Values.features.quotas.max }}
             {{- end }}
 
+            - name: OCIS_ASYNC_UPLOADS
+              value: "true"
+
+            - name: STORAGE_USERS_DATA_GATEWAY_URL
+              value: "http://{{ .appNameFrontend }}:9140/data/"
+
           livenessProbe:
             httpGet:
               path: /healthz

--- a/charts/ocis/values.yaml
+++ b/charts/ocis/values.yaml
@@ -291,9 +291,13 @@ features:
   virusscan:
     # -- Enabled virus scanning
     enabled: false
-    # -- Define what should happen with infected files
+    # -- Define what should happen with infected files. upported options are: 'delete', 'continue' and 'abort '. 
+    # Delete will delete the file. 
+    # Continue will mark the file as infected but continues further processing. 
+    # Abort will keep the file in the uploads folder for further admin inspection and will not move it to its final destination.
     infectedFileHandling: delete
-    # -- Sets a maximum file size for scans
+    # -- Sets a maximum file size for scans. Only this many bytes of a file will be scanned. 0 means unlimited and is the default. 
+    # Usable common abbreviations: [KB, KiB, GB, GiB, TB, TiB, PB, PiB, EB, EiB], example: 2GB.
     maxScanSize: 
     # -- Define icap parameters
     icap:

--- a/charts/ocis/values.yaml
+++ b/charts/ocis/values.yaml
@@ -68,7 +68,7 @@ store:
   type: nats-js
   # -- Provide a list of comma-separated addresses of `etcd`, `redis`, `redis-sentinel` or `nats-js` servers here
   # if the proper store is selected
-  addresses: 
+  addresses:
     - "{{ .appNameNats }}:9233"
 
 messagingSystem:
@@ -190,14 +190,14 @@ features:
       # Set to `username` if the claim specified in `...oidc.userIDClaim` holds the value of the ldap user attribute specified in `...ldap.user.schema.userName`.
       userIDClaimAttributeMapping: userid
 
-      # -- Configure OIDC role assignment. If activated, oCIS will read the role assigment from the OIDC token, see 
+      # -- Configure OIDC role assignment. If activated, oCIS will read the role assigment from the OIDC token, see
       # xref:{s-path}/proxy.adoc#automatic-role-assignments[Automatic Role Assignments]
-      roleAssignment: 
+      roleAssignment:
         enabled: false
         # -- The name of the OIDC claim holding the role assignment
         claim: roles
         # -- Configure the mapping for the role assignment
-        mapping: 
+        mapping:
           admin: ocisAdmin
           user: ocisUser
           spaceadmin: ocisSpaceAdmin
@@ -291,21 +291,21 @@ features:
   virusscan:
     # -- Enabled virus scanning
     enabled: false
-    # -- Define what should happen with infected files. upported options are: 'delete', 'continue' and 'abort '. 
-    # Delete will delete the file. 
-    # Continue will mark the file as infected but continues further processing. 
+    # -- Define what should happen with infected files. Supported options are: 'delete', 'continue' and 'abort '.
+    # Delete will delete the file.
+    # Continue will mark the file as infected but continues further processing.
     # Abort will keep the file in the uploads folder for further admin inspection and will not move it to its final destination.
     infectedFileHandling: delete
-    # -- Sets a maximum file size for scans. Only this many bytes of a file will be scanned. 0 means unlimited and is the default. 
+    # -- Sets a maximum file size for scans. Only this many bytes of a file will be scanned. 0 means unlimited and is the default.
     # Usable common abbreviations: [KB, KiB, GB, GiB, TB, TiB, PB, PiB, EB, EiB], example: 2GB.
-    maxScanSize: 
+    maxScanSize:
     # -- Define icap parameters
     icap:
       # -- Sets the timeout for icap scans
       timeout: 300
       # -- Sets the icap url
       url: icap://127.0.0.1:1344
-      # -- Sets the service to be used in icap 
+      # -- Sets the service to be used in icap
       service: avscan
 
 # Ingress for oCIS.
@@ -510,7 +510,7 @@ services:
     # -- Per-service PodDisruptionBudget. Overrides the default setting from `podDisruptionBudget` if set.
     podDisruptionBudget: {}
 
-  # -- ANTIVIRUS service.
+  # -- ANTIVIRUS service. Not used if `features.virusscan.enabled` equals `false`.
   # @default -- see detailed service configuration options below
   antivirus:
     # -- Per-service resources configuration. Overrides the default setting from `resources` if set.
@@ -525,9 +525,9 @@ services:
     resources: {}
     # -- Per-service store configuration for the eventhistory service. Overrides the default setting from `store` if set.
     store: {}
-      # -- Configure the store type for the eventhistory service. Might be `memory`, `ocmem`, `etcd`, `redis`, 
+      # -- Configure the store type for the eventhistory service. Might be `memory`, `ocmem`, `etcd`, `redis`,
       # `redis-sentinel`, `nats-js` or `noop`
-      #type: 
+      #type:
       # -- Provide a list of comma-separated addresses of `etcd`, `redis`, `redis-sentinel` or `nats-js` servers here
       # if the proper store is selected
       # addresses: []
@@ -962,12 +962,12 @@ services:
     resources: {}
     # -- Per-service store configuration for the userlog service. Overrides the default setting from `store` if set.
     store: {}
-      # -- Configure the store type for the userlog service. Might be `memory`, `ocmem`, `etcd`, `redis`, 
+      # -- Configure the store type for the userlog service. Might be `memory`, `ocmem`, `etcd`, `redis`,
       # `redis-sentinel`, `nats-js` or `noop`
-      # type: 
+      # type:
       # -- Provide a list of comma-separated addresses of `etcd`, `redis`, `redis-sentinel` or `nats-js` servers here
       # if the proper store is selected
-      # addresses: 
+      # addresses:
         # - "{{ .appNameNats }}:9233"
     # -- Per-service PodDisruptionBudget. Overrides the default setting from `podDisruptionBudget` if set.
     podDisruptionBudget: {}

--- a/charts/ocis/values.yaml
+++ b/charts/ocis/values.yaml
@@ -287,6 +287,22 @@ features:
     #   71881883-1768-46bd-a24d-a356a2afdf7f: 100000000000
     #   # Space Administrator Role set to 100GB
     #   2aadd357-682c-406b-8874-293091995fdd: 100000000000
+  # Define virus scanning
+  virusscan:
+    # -- Enabled virus scanning
+    enabled: false
+    # -- Define what should happen with infected files
+    infectedFileHandling: delete
+    # -- Sets a maximum file size for scans
+    maxScanSize: 
+    # -- Define icap parameters
+    icap:
+      # -- Sets the timeout for icap scans
+      timeout: 300
+      # -- Sets the icap url
+      url: icap://127.0.0.1:1344
+      # -- Sets the service to be used in icap 
+      service: avscan
 
 # Ingress for oCIS.
 ingress:
@@ -485,6 +501,14 @@ services:
   # -- AUTH MACHINE service.
   # @default -- see detailed service configuration options below
   authmachine:
+    # -- Per-service resources configuration. Overrides the default setting from `resources` if set.
+    resources: {}
+    # -- Per-service PodDisruptionBudget. Overrides the default setting from `podDisruptionBudget` if set.
+    podDisruptionBudget: {}
+
+  # -- ANTIVIRUS service.
+  # @default -- see detailed service configuration options below
+  antivirus:
     # -- Per-service resources configuration. Overrides the default setting from `resources` if set.
     resources: {}
     # -- Per-service PodDisruptionBudget. Overrides the default setting from `podDisruptionBudget` if set.


### PR DESCRIPTION
## Description
This PR adds support for the new antivirus service

## Related Issue
- Fixes #187

## Motivation and Context
Feature request

## How Has This Been Tested?
Tested with `helm template` and `helm upgrade --install` and the following own values yaml:

```YAML
replicas: 1

externalDomain: ocis.owncloud.test
ingress:
  enabled: true
  annotations:
    nginx.ingress.kubernetes.io/proxy-body-size: 1024m
  tls:
    - hosts:
        - ocis.owncloud.test
insecure:
  # disables ssl certificate checking for connections to the openID connect identity provider.
  # Not recommended for production setups, but we don't have valid certificates in minikube
  oidcIdpInsecure: true
  # disables ssl certificate checking for connections to the oCIS http apis.
  # Not recommended for production setups, but we don't have valid certificates in minikube
  ocisHttpApiInsecure: true

features:
  virusscan:
    enabled: true
    icap:
      timeout: 3000
      url: icap://host.k3d.internal:1344

podDisruptionBudget: 
  # -- Sets the maxUnavailable or the global PodDisruptionBudget.
  maxUnavailable: 1
# logging:
#   level: debug

image:
  repository: owncloud/ocis
  tag: latest
  pullPolicy: Always
```

## Types of changes
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Technical debt
- [ ] Tests only (no source changes)

## Checklist:
- [ ] Code changes
- [ ] Unit tests added
- [ ] Acceptance tests added
- [x] Documentation generated (`make docs`) and committed
- [ ] Documentation ticket raised: <link>
- [ ] Documentation PR created: <link>
