### PR TITLE
Define app registry endpoint only when enabled

### DIFF
--- a/charts/ocis/templates/gateway/deployment.yaml
+++ b/charts/ocis/templates/gateway/deployment.yaml
@@ -91,8 +91,10 @@ spec:
             - name: GATEWAY_STORAGE_SHARES_ENDPOINT
               value: {{ .appNameStorageShares }}:9154
 
+            {{- if .Values.features.appsIntegration.enabled }}
             - name: GATEWAY_APP_REGISTRY_ENDPOINT
               value: {{ .appNameAppRegistry }}:9242
+            {{- end }}
 
             # cache
             - name: GATEWAY_CACHE_STORE


### PR DESCRIPTION
## Description
I found an error in the logs that the frontend could not communicate with the appregistry even though it wasn't actived, so I search the charm and found one place where the host is set even though not enabled. This PR fixed this issue.

## Motivation and Context
Bug fix

## How Has This Been Tested?
Tested with `helm template`

## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Technical debt
- [ ] Tests only (no source changes)

## Checklist:
- [x] Code changes
- [ ] Unit tests added
- [ ] Acceptance tests added
- [ ] Documentation generated (`make docs`) and committed
- [ ] Documentation ticket raised: <link>
- [ ] Documentation PR created: <link>
