### PR TITLE
don't disable appregistry to prevent failing /app/list requests in oC Web

### DIFF
--- a/charts/ocis/templates/appregistry/config.yaml
+++ b/charts/ocis/templates/appregistry/config.yaml
@@ -1,4 +1,3 @@
-{{- if .Values.features.appsIntegration.enabled }}
 {{- include "ocis.appNames" (dict "scope" . "appName" "appNameAppRegistry" "appNameSuffix" "") -}}
 apiVersion: v1
 kind: ConfigMap
@@ -14,5 +13,4 @@ data:
     app_registry:
       mimetypes:
 {{- toYaml .Values.features.appsIntegration.mimetypes | nindent 6 }}
-{{- end }}
 {{- end }}

--- a/charts/ocis/templates/appregistry/deployment.yaml
+++ b/charts/ocis/templates/appregistry/deployment.yaml
@@ -1,4 +1,3 @@
-{{ if .Values.features.appsIntegration.enabled }}
 {{- include "ocis.appNames" (dict "scope" . "appName" "appNameAppRegistry" "appNameSuffix" "") -}}
 {{- $_ := set . "resources" (default (default (dict) .Values.resources) .Values.services.appregistry.resources) -}}
 apiVersion: apps/v1
@@ -100,4 +99,3 @@ spec:
         - name: configs
           configMap:
             name: {{ .appName }}-config
-{{ end }}

--- a/charts/ocis/templates/appregistry/service.yaml
+++ b/charts/ocis/templates/appregistry/service.yaml
@@ -1,4 +1,3 @@
-{{ if .Values.features.appsIntegration.enabled }}
 {{- include "ocis.appNames" (dict "scope" . "appName" "appNameAppRegistry" "appNameSuffix" "") -}}
 apiVersion: v1
 kind: Service
@@ -19,4 +18,3 @@ spec:
     - name: metrics-debug
       port: 9243
       protocol: TCP
-{{ end }}


### PR DESCRIPTION
## Description
don't disable the app registry when not in use to disable failing /app/list requests by eg. ownCloud Web

## Related Issue
- Fixes #172

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
- -

## Screenshots (if appropriate):

## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Technical debt
- [ ] Tests only (no source changes)

## Checklist:
- [x] Code changes
- [ ] Unit tests added
- [ ] Acceptance tests added
- [ ] Documentation generated (`make docs`) and committed
- [ ] Documentation ticket raised: <link>
- [ ] Documentation PR created: <link>
