### PR TITLE
dont scale the search service because it is not scalable right now

### DIFF
--- a/charts/ocis/templates/search/deployment.yaml
+++ b/charts/ocis/templates/search/deployment.yaml
@@ -11,9 +11,7 @@ spec:
   selector:
     matchLabels:
       app: {{ .appName }}
-  {{- if and (not .Values.autoscaling.enabled) (.Values.replicas) }}
-  replicas: {{ .Values.replicas }}
-  {{- end }}
+  replicas: 1 #TODO: https://github.com/owncloud/ocis-charts/issues/15
   {{- if .Values.deploymentStrategy }}
   strategy: {{ toYaml .Values.deploymentStrategy | nindent 4 }}
   {{ end }}

--- a/charts/ocis/templates/search/hpa.yaml
+++ b/charts/ocis/templates/search/hpa.yaml
@@ -1,2 +1,0 @@
-{{- include "ocis.appNames" (dict "scope" . "appName" "appNameSearch" "appNameSuffix" "") -}}
-{{ include "ocis.hpa" . }}

--- a/charts/ocis/templates/search/pdb.yaml
+++ b/charts/ocis/templates/search/pdb.yaml
@@ -1,2 +1,0 @@
-{{- include "ocis.appNames" (dict "scope" . "appName" "appNameSearch" "appNameSuffix" "") -}}
-{{ include "ocis.pdb" . }}


### PR DESCRIPTION
## Description
Dont scale the search. It's not scalable right now.


## Related Issue
<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->
- mentioned in #15

## Motivation and Context
If one scales the search, pods will fail to start.

## How Has This Been Tested?
- -

## Screenshots (if appropriate):

## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [x] Technical debt
- [ ] Tests only (no source changes)

## Checklist:
- [x] Code changes
- [ ] Unit tests added
- [ ] Acceptance tests added
- [ ] Documentation generated (`make docs`) and committed
- [ ] Documentation ticket raised: <link>
- [ ] Documentation PR created: <link>
