### PR TITLE
add support for readonly user attributes

### DIFF
--- a/charts/ocis/docs/values-desc-table.adoc
+++ b/charts/ocis/docs/values-desc-table.adoc
@@ -306,6 +306,12 @@ a| [subs=-attributes]
 a| [subs=-attributes]
 `false`
 | For self signed certificates, consider to put the CA cert of the LDAP secure server into the secret referenced by "ldapCaRef" Not recommended for production installations.
+| features.externalUserManagement.ldap.readOnlyAttributes
+a| [subs=-attributes]
++list+
+a| [subs=-attributes]
+`[]`
+| If the LDAP server is set to writable in general, some user attributes can be restricted to read only in the UI. Note: This only disables editing in the UI. The readonly permissions need to be enforced in the LDAP server itself.
 | features.externalUserManagement.ldap.uri
 a| [subs=-attributes]
 +string+
@@ -377,7 +383,7 @@ a| [subs=-attributes]
 +bool+
 a| [subs=-attributes]
 `true`
-| Writeable configures if oCIS is allowed to write to the LDAP server, to eg. create users.
+| Writeable configures if oCIS is allowed to write to the LDAP server, to eg. create or edit users.
 | features.externalUserManagement.oidc.issuerURI
 a| [subs=-attributes]
 +string+

--- a/charts/ocis/docs/values.adoc.yaml
+++ b/charts/ocis/docs/values.adoc.yaml
@@ -210,8 +210,18 @@ features:
 
     # LDAP related settings.
     ldap:
-      # -- Writeable configures if oCIS is allowed to write to the LDAP server, to eg. create users.
+      # -- Writeable configures if oCIS is allowed to write to the LDAP server, to eg. create or edit users.
       writeable: true
+      # -- If the LDAP server is set to writable in general, some user attributes can be restricted to read only in the UI.
+      # Note: This only disables editing in the UI. The readonly permissions need to be enforced in the LDAP server itself.
+      readOnlyAttributes: []
+        # - user.onPremisesSamAccountName # username
+        # - user.displayName # display name
+        # - user.mail # mail
+        # - user.passwordProfile # password
+        # - user.appRoleAssignments # role
+        # - user.accountEnabled # login allowed
+        # - drive.quota # quota
       # -- URI to connect to the LDAP secure server.
       uri: ldaps://ldaps.owncloud.test
       # -- Set only to false, if the certificate of your LDAP secure service is not trusted.

--- a/charts/ocis/templates/frontend/deployment.yaml
+++ b/charts/ocis/templates/frontend/deployment.yaml
@@ -47,6 +47,10 @@ spec:
             - name: REVA_GATEWAY
               value: {{ .appNameGateway }}:9142
 
+            {{- if .Values.features.externalUserManagement.enabled }}
+            - name: FRONTEND_READONLY_USER_ATTRIBUTES
+              value: {{ tpl (join "," .Values.features.externalUserManagement.ldap.readOnlyAttributes) . | quote }}
+            {{- end }}
             - name: FRONTEND_JWT_SECRET
               valueFrom:
                 secretKeyRef:

--- a/charts/ocis/values.yaml
+++ b/charts/ocis/values.yaml
@@ -209,8 +209,18 @@ features:
 
     # LDAP related settings.
     ldap:
-      # -- Writeable configures if oCIS is allowed to write to the LDAP server, to eg. create users.
+      # -- Writeable configures if oCIS is allowed to write to the LDAP server, to eg. create or edit users.
       writeable: true
+      # -- If the LDAP server is set to writable in general, some user attributes can be restricted to read only in the UI.
+      # Note: This only disables editing in the UI. The readonly permissions need to be enforced in the LDAP server itself.
+      readOnlyAttributes: []
+        # - user.onPremisesSamAccountName # username
+        # - user.displayName # display name
+        # - user.mail # mail
+        # - user.passwordProfile # password
+        # - user.appRoleAssignments # role
+        # - user.accountEnabled # login allowed
+        # - drive.quota # quota
       # -- URI to connect to the LDAP secure server.
       uri: ldaps://ldaps.owncloud.test
       # -- Set only to false, if the certificate of your LDAP secure service is not trusted.


### PR DESCRIPTION
## Description
adds support for configuring readonly user attributes when using external usermanagement


## Related Issue
- Fixes #209

## Motivation and Context


## How Has This Been Tested?
Started ocis in minikube with external user management enabled.
Querying the capabilities: `curl -k 'https://ocis.kube.owncloud.test/ocs/v1.php/cloud/capabilities?format=json' | jq .`

Result:
```
...
        "graph": {
          "personal-data-export": true,
          "read_only_user_attributes": [
            "user.onPremisesSamAccountName",
            "user.displayName",
            "user.mail",
            "user.passwordProfile",
            "user.appRoleAssignments",
            "user.accountEnabled",
            "drive.quota"
          ]
        },
...
```

## Screenshots (if appropriate):

## Types of changes
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Technical debt
- [ ] Tests only (no source changes)

## Checklist:
- [x] Code changes
- [ ] Unit tests added
- [ ] Acceptance tests added
- [x] Documentation generated (`make docs`) and committed
- [ ] Documentation ticket raised: <link>
- [ ] Documentation PR created: <link>
