### PR TITLE
expose sharing settings for public links and user search

### DIFF
--- a/charts/ocis/docs/values-desc-table.adoc
+++ b/charts/ocis/docs/values-desc-table.adoc
@@ -474,6 +474,18 @@ a| [subs=-attributes]
 a| [subs=-attributes]
 `nil`
 | Define the roles by specifying a name of a ConfigMap which already contains the the role description (might also be defined in the `extraResources` section). The ConfigMap needs to contain a file named `custom-roles.json` which holds the role description in JSON format Please note that you have to restart the settings service manually if you change the content of you ConfigMap.
+| features.sharing.publiclink.writeableShareMustHavePassword
+a| [subs=-attributes]
++bool+
+a| [subs=-attributes]
+`false`
+| Enforce a password on writable public link shares.
+| features.sharing.users.search.minLengthLimit
+a| [subs=-attributes]
++int+
+a| [subs=-attributes]
+`3`
+| Minimum number of characters to enter before a client should start a search for Share receivers. This setting can be used to customize the user experience if e.g too many results are displayed.
 | features.virusscan.enabled
 a| [subs=-attributes]
 +bool+

--- a/charts/ocis/docs/values.adoc.yaml
+++ b/charts/ocis/docs/values.adoc.yaml
@@ -120,6 +120,19 @@ features:
       authentication: none
       # -- Encryption method for the SMTP communication. Possible values are ‘starttls’, ‘ssl’, ‘ssltls’, ‘tls’ and ‘none’.
       encryption: none
+  # Sharing related settings
+  sharing:
+    # Sharing with users related settings
+    users:
+      # Search settings for finding users to share with.
+      search:
+        # -- Minimum number of characters to enter before a client should start a search for Share receivers.
+        # This setting can be used to customize the user experience if e.g too many results are displayed.
+        minLengthLimit: 3
+    # Sharing per public link related setings
+    publiclink:
+      # -- Enforce a password on writable public link shares.
+      writeableShareMustHavePassword: false
   # Apps integration
   appsIntegration:
     # -- Enables the apps integration.

--- a/charts/ocis/templates/frontend/deployment.yaml
+++ b/charts/ocis/templates/frontend/deployment.yaml
@@ -63,6 +63,12 @@ spec:
             - name: FRONTEND_ARCHIVER_INSECURE
               value: {{ .Values.insecure.ocisHttpApiInsecure | quote }}
 
+            - name: FRONTEND_OCS_PUBLIC_WRITEABLE_SHARE_MUST_HAVE_PASSWORD
+              value: {{ .Values.features.sharing.publiclink.writeableShareMustHavePassword | quote }}
+
+            - name: FRONTEND_SEARCH_MIN_LENGTH
+              value: {{ .Values.features.sharing.users.search.minLengthLimit | quote }}
+
             # cache
             - name: FRONTEND_OCS_RESOURCE_INFO_CACHE_STORE
               value: {{ .Values.cache.type | quote }}

--- a/charts/ocis/templates/sharing/deployment.yaml
+++ b/charts/ocis/templates/sharing/deployment.yaml
@@ -68,6 +68,9 @@ spec:
                   name: {{ .Values.secretRefs.jwtSecretRef }}
                   key: jwt-secret
 
+            - name: SHARING_PUBLIC_WRITEABLE_SHARE_MUST_HAVE_PASSWORD
+              value: {{ .Values.features.sharing.publiclink.writeableShareMustHavePassword | quote }}
+
             # user sharing
             - name: SHARING_USER_DRIVER
               value: jsoncs3

--- a/charts/ocis/values.yaml
+++ b/charts/ocis/values.yaml
@@ -119,6 +119,19 @@ features:
       authentication: none
       # -- Encryption method for the SMTP communication. Possible values are ‘starttls’, ‘ssl’, ‘ssltls’, ‘tls’ and ‘none’.
       encryption: none
+  # Sharing related settings
+  sharing:
+    # Sharing with users related settings
+    users:
+      # Search settings for finding users to share with.
+      search:
+        # -- Minimum number of characters to enter before a client should start a search for Share receivers.
+        # This setting can be used to customize the user experience if e.g too many results are displayed.
+        minLengthLimit: 3
+    # Sharing per public link related setings
+    publiclink:
+      # -- Enforce a password on writable public link shares.
+      writeableShareMustHavePassword: false
   # Apps integration
   appsIntegration:
     # -- Enables the apps integration.


### PR DESCRIPTION
## Description
expose sharing related settings for:
- public link password enforement
- user share search minimum characters

## Related Issue
- Fixes #208

## Motivation and Context
customize sharing

## How Has This Been Tested?
- minikube
  - search for user 
  - create editor public link 

## Screenshots (if appropriate):

## Types of changes
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Technical debt
- [ ] Tests only (no source changes)

## Checklist:
- [x] Code changes
- [ ] Unit tests added
- [ ] Acceptance tests added
- [x] Documentation generated (`make docs`) and committed
- [ ] Documentation ticket raised: <link>
- [ ] Documentation PR created: <link>
