### PR TITLE
allow to make use of ldap refint

### DIFF
--- a/charts/ocis/docs/values-desc-table.adoc
+++ b/charts/ocis/docs/values-desc-table.adoc
@@ -312,6 +312,12 @@ a| [subs=-attributes]
 a| [subs=-attributes]
 `[]`
 | If the LDAP server is set to writable in general, some user attributes can be restricted to read only in the UI. Note: This only disables editing in the UI. The readonly permissions need to be enforced in the LDAP server itself.
+| features.externalUserManagement.ldap.refintEnabled
+a| [subs=-attributes]
++bool+
+a| [subs=-attributes]
+`false`
+| Signals that the LDAP server has the refint plugin enabled, which makes some actions not needed.
 | features.externalUserManagement.ldap.uri
 a| [subs=-attributes]
 +string+

--- a/charts/ocis/docs/values.adoc.yaml
+++ b/charts/ocis/docs/values.adoc.yaml
@@ -235,6 +235,8 @@ features:
       # The password for the user needs to be set in the secret referenced by `secretRefs.ldapSecretRef` as `reva-ldap-bind-password`.
       # The user needs to have permission to list users and groups.
       bindDN: uid=ocis,ou=system-users,dc=owncloud,dc=test
+      # -- Signals that the LDAP server has the refint plugin enabled, which makes some actions not needed.
+      refintEnabled: false
       user:
         schema:
           # -- LDAP Attribute to use as the unique id for users. This should be a stable globally unique id like a UUID.

--- a/charts/ocis/templates/graph/deployment.yaml
+++ b/charts/ocis/templates/graph/deployment.yaml
@@ -75,6 +75,9 @@ spec:
             - name: LDAP_INSECURE
               value: {{ .Values.features.externalUserManagement.ldap.insecure | quote }}
 
+            - name: GRAPH_LDAP_REFINT_ENABLED
+              value: {{ .Values.features.externalUserManagement.ldap.refintEnabled | quote }}
+
             - name: LDAP_USER_BASE_DN
               value: {{ .Values.features.externalUserManagement.ldap.user.baseDN | quote }}
             - name: LDAP_GROUP_BASE_DN

--- a/charts/ocis/values.yaml
+++ b/charts/ocis/values.yaml
@@ -234,6 +234,8 @@ features:
       # The password for the user needs to be set in the secret referenced by `secretRefs.ldapSecretRef` as `reva-ldap-bind-password`.
       # The user needs to have permission to list users and groups.
       bindDN: uid=ocis,ou=system-users,dc=owncloud,dc=test
+      # -- Signals that the LDAP server has the refint plugin enabled, which makes some actions not needed.
+      refintEnabled: false
       user:
         schema:
           # -- LDAP Attribute to use as the unique id for users. This should be a stable globally unique id like a UUID.


### PR DESCRIPTION
## Description
allow to make use of ldap refint when using external user mangagement

## Related Issue
- Fixes #207

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
- minikube with openldap

## Screenshots (if appropriate):

## Types of changes
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Technical debt
- [ ] Tests only (no source changes)

## Checklist:
- [x] Code changes
- [ ] Unit tests added
- [ ] Acceptance tests added
- [x] Documentation generated (`make docs`) and committed
- [ ] Documentation ticket raised: <link>
- [ ] Documentation PR created: <link>
