### PR TITLE
Add prometheus service monitor

### DIFF
--- a/charts/ocis/docs/values-desc-table.adoc
+++ b/charts/ocis/docs/values-desc-table.adoc
@@ -654,6 +654,18 @@ a| [subs=-attributes]
 a| [subs=-attributes]
 `false`
 | For self signed certificates, consider to put the CA cert of the messaging system secure server into the secret referenced by "messagingSystemCaRef" Not recommended for production installations.
+| monitoring
+a| [subs=-attributes]
++object+
+a| [subs=-attributes]
+`{"enabled":false}`
+| Service monitoring configuration.
+| monitoring.enabled
+a| [subs=-attributes]
++bool+
+a| [subs=-attributes]
+`false`
+| Enable service monitoring.
 | namespaceOverride
 a| [subs=-attributes]
 +string+

--- a/charts/ocis/docs/values.adoc.yaml
+++ b/charts/ocis/docs/values.adoc.yaml
@@ -1205,3 +1205,9 @@ services:
     # -- Per-service PodDisruptionBudget. Overrides the default setting from `podDisruptionBudget` if set.
     podDisruptionBudget: {}
 
+
+# -- Service monitoring configuration.
+monitoring:
+  # -- Enable service monitoring.
+  enabled: false
+

--- a/charts/ocis/templates/antivirus/deployment.yaml
+++ b/charts/ocis/templates/antivirus/deployment.yaml
@@ -67,6 +67,17 @@ spec:
               value: "" # no cert needed
               {{- end }}
             {{- end }}
+            - name: ANTIVIRUS_DEBUG_ADDR
+              value: 0.0.0.0:9277
+
+          livenessProbe:
+            httpGet:
+              path: /healthz
+              port: metrics-debug
+            timeoutSeconds: 10
+            initialDelaySeconds: 60
+            periodSeconds: 20
+            failureThreshold: 3
 
           {{- include "ocis.livenessProbe" . | nindent 10 }}
 

--- a/charts/ocis/templates/monitoring/servicemonitor.yaml
+++ b/charts/ocis/templates/monitoring/servicemonitor.yaml
@@ -1,0 +1,17 @@
+{{ if .Values.monitoring.enabled }}
+---
+apiVersion: monitoring.coreos.com/v1
+kind: ServiceMonitor
+metadata:
+  name: ocis-metrics
+  namespace: {{ template "ocis.namespace" . }}
+spec:
+  selector:
+    matchLabels:
+      ocis-metrics: enabled
+  endpoints:
+    - port: metrics-debug
+      interval: "60s"
+      scrapeTimeout: "60s"
+      path: /metrics
+{{ end }}

--- a/charts/ocis/values.yaml
+++ b/charts/ocis/values.yaml
@@ -1203,3 +1203,9 @@ services:
     resources: {}
     # -- Per-service PodDisruptionBudget. Overrides the default setting from `podDisruptionBudget` if set.
     podDisruptionBudget: {}
+
+
+# -- Service monitoring configuration.
+monitoring:
+  # -- Enable service monitoring.
+  enabled: false


### PR DESCRIPTION
## Description
Add a prometheus ServiceMonitor for scraping metrics and checking service availability.

Also added a service manifest and port definition to scrape the antivirus service.

Note: There are a bunch of ocis services which do not yet have the metrics/debug endpoint running.
- audit
- idm
- policies
- eventhistory
- nats
- postprocessing
- notifications
- userlog

## Related Issue
- Fixes #162 

## How Has This Been Tested?
Tested on my local k3s cluster.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Technical debt
- [ ] Tests only (no source changes)

## Checklist:
<!-- Tick the checkboxes when done. -->
<!-- Raise documentation ticket in https://github.com/owncloud/docs-ocis/issues -->
<!-- or create documentation PR in https://github.com/owncloud/docs-ocis/tree/master/modules/ROOT/pages/deployment/container>
- [x] Code changes
- [ ] Unit tests added
- [ ] Acceptance tests added
- [ ] Documentation generated (`make docs`) and committed
- [ ] Documentation ticket raised: <link>
- [ ] Documentation PR created: <link>
