### PR TITLE
skip client id on backchannel logout when external usermanagement is used

### DIFF
--- a/charts/ocis/templates/proxy/deployment.yaml
+++ b/charts/ocis/templates/proxy/deployment.yaml
@@ -59,6 +59,9 @@ spec:
               value: {{ .Values.features.externalUserManagement.oidc.userIDClaim | quote }}
             - name: PROXY_USER_CS3_CLAIM
               value: {{ .Values.features.externalUserManagement.oidc.userIDClaimAttributeMapping | quote }}
+
+            - name: PROXY_OIDC_SKIP_CLIENT_ID_CHECK
+              value: "true"
             {{- end }}
 
             - name: PROXY_TLS


### PR DESCRIPTION
## Description
skip client id check for backchannel logout when external user managment is used

## Related Issue
- https://github.com/owncloud/ocis/issues/6149

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
- none


## Screenshots (if appropriate):

## Types of changes
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Technical debt
- [ ] Tests only (no source changes)

## Checklist:
- [x] Code changes
- [ ] Unit tests added
- [ ] Acceptance tests added
- [ ] Documentation generated (`make docs`) and committed
- [ ] Documentation ticket raised: <link>
- [ ] Documentation PR created: <link>
