### PR TITLE
Updated Proxy and Values

### DIFF
--- a/charts/ocis/templates/proxy/deployment.yaml
+++ b/charts/ocis/templates/proxy/deployment.yaml
@@ -60,6 +60,9 @@ spec:
             - name: PROXY_USER_CS3_CLAIM
               value: {{ .Values.features.externalUserManagement.oidc.userIDClaimAttributeMapping | quote }}
 
+            - name: PROXY_OIDC_ACCESS_TOKEN_VERIFY_METHOD
+              value: {{ .Values.features.externalUserManagement.oidc.accessTokenVerifyMethod | quote }}
+
             - name: PROXY_OIDC_SKIP_CLIENT_ID_CHECK
               value: "true"
             {{- end }}

--- a/charts/ocis/values.yaml
+++ b/charts/ocis/values.yaml
@@ -203,6 +203,10 @@ features:
       # Set to `username` if the claim specified in `...oidc.userIDClaim` holds the value of the ldap user attribute specified in `...ldap.user.schema.userName`.
       userIDClaimAttributeMapping: userid
 
+      # -- OIDC Acces Token Verify Method
+      # Set to "jwt" or "none"
+      accessTokenVerifyMethod: "none"
+
       # -- Configure OIDC role assignment. If activated, oCIS will read the role assigment from the OIDC token, see
       # xref:{s-path}/proxy.adoc#automatic-role-assignments[Automatic Role Assignments]
       roleAssignment:


### PR DESCRIPTION
Allow user to set PROXY_OIDC_ACCESS_TOKEN_VERIFY_METHOD for proxy deployment



## Description
In the proxy service, the `PROXY_OIDC_ACCESS_TOKEN_VERIFY_METHOD` env var, allow user to set a verify method for OICS Access token verification.

At this time, there is no possibility for user to set change this env var in the charts.

This modification add a new key to the default `values.yml` under the  `features.externalUserManagement.oidc.accessTokenVerifyMethod` section.
The corresponding key to the `templates/proxy/deployment.yaml` is now added inside the flow control block 
`{{- if .Values.features.externalUserManagement.enabled }}`

## Related Issue
<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->
- Fixes No issue

## Motivation and Context
I'm currently using this chart at work, but our OIDC product `CAS`, only work when this settings is set to `none`, and the chart cannot allow us to add this key without loosing changes on charts update.


## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
- Chart generation with verify method set to "none" in values.yml:
_values.yaml_
```yaml
...
      # -- OIDC Acces Token Verify Method
      # Set to "jwt" or "none"
      accessTokenVerifyMethod: "none"
...
```
```yaml
# helm template ocis ./ocis-charts/charts/ocis --values values.yaml | grep VERIFY_METHOD -C 3`  
          - name: PROXY_USER_CS3_CLAIM
              value: "userid"

            - name: PROXY_OIDC_ACCESS_TOKEN_VERIFY_METHOD
              value: "none"

            - name: PROXY_OIDC_SKIP_CLIENT_ID_CHECK
```
- Chart generation with verify method set to "jwt" in values.yml:
_values.yaml_
```yaml
...
      # -- OIDC Acces Token Verify Method
      # Set to "jwt" or "none"
      accessTokenVerifyMethod: "jwt"
...
```
```yaml
# helm template ocis ./ocis-charts/charts/ocis --values values.yaml | grep VERIFY_METHOD -C 3
            - name: PROXY_USER_CS3_CLAIM
              value: "userid"

            - name: PROXY_OIDC_ACCESS_TOKEN_VERIFY_METHOD
              value: "jwt"

            - name: PROXY_OIDC_SKIP_CLIENT_ID_CHECK
```
- In the env of the `proxy` pod:
```bash
~ $ env | grep OIDC_ACCESS_TOKEN
PROXY_OIDC_ACCESS_TOKEN_VERIFY_METHOD=none
~ $ 
```
## Screenshots (if appropriate):
_None_
## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Technical debt
- [ ] Tests only (no source changes)

## Checklist:
<!-- Tick the checkboxes when done. -->
<!-- Raise documentation ticket in https://github.com/owncloud/docs-ocis/issues -->
<!-- or create documentation PR in https://github.com/owncloud/docs-ocis/tree/master/modules/ROOT/pages/deployment/container>
- [ ] Code changes
- [ ] Unit tests added
- [ ] Acceptance tests added
- [ ] Documentation generated (`make docs`) and committed
- [ ] Documentation ticket raised: <link>
- [ ] Documentation PR created: <link>
