### PR TITLE
Comment out unused tracing env variables and link to potential ocis implementation tickets

### DIFF
--- a/charts/ocis/templates/antivirus/deployment.yaml
+++ b/charts/ocis/templates/antivirus/deployment.yaml
@@ -38,14 +38,15 @@ spec:
             - name: ANTIVIRUS_DEBUG_PPROF
               value: {{ .Values.debug.profiling | quote }}
 
-            - name: ANTIVIRUS_TRACING_ENABLED
-              value: "{{ .Values.tracing.enabled }}"
-            - name: ANTIVIRUS_TRACING_TYPE
-              value: {{ .Values.tracing.type | quote }}
-            - name: ANTIVIRUS_TRACING_ENDPOINT
-              value: {{ .Values.tracing.endpoint | quote }}
-            - name: ANTIVIRUS_TRACING_COLLECTOR
-              value: {{ .Values.tracing.collector | quote }}
+            # Tracing not yet implemented: https://github.com/owncloud/ocis/issues/6171
+            # - name: ANTIVIRUS_TRACING_ENABLED
+            #   value: "{{ .Values.tracing.enabled }}"
+            # - name: ANTIVIRUS_TRACING_TYPE
+            #   value: {{ .Values.tracing.type | quote }}
+            # - name: ANTIVIRUS_TRACING_ENDPOINT
+            #   value: {{ .Values.tracing.endpoint | quote }}
+            # - name: ANTIVIRUS_TRACING_COLLECTOR
+            #   value: {{ .Values.tracing.collector | quote }}
 
             - name: ANTIVIRUS_INFECTED_FILE_HANDLING
               value: {{ .Values.features.virusscan.infectedFileHandling | quote }}

--- a/charts/ocis/templates/audit/deployment.yaml
+++ b/charts/ocis/templates/audit/deployment.yaml
@@ -33,14 +33,15 @@ spec:
             - name: AUDIT_LOG_PRETTY
               value: {{ .Values.logging.pretty | quote }}
 
-            - name: AUDIT_TRACING_ENABLED
-              value: "{{ .Values.tracing.enabled }}"
-            - name: AUDIT_TRACING_TYPE
-              value: {{ .Values.tracing.type | quote }}
-            - name: AUDIT_TRACING_ENDPOINT
-              value: {{ .Values.tracing.endpoint | quote }}
-            - name: AUDIT_TRACING_COLLECTOR
-              value: {{ .Values.tracing.collector | quote }}
+            # Tracing not yet implemented: https://github.com/owncloud/ocis/issues/6172
+            # - name: AUDIT_TRACING_ENABLED
+            #   value: "{{ .Values.tracing.enabled }}"
+            # - name: AUDIT_TRACING_TYPE
+            #   value: {{ .Values.tracing.type | quote }}
+            # - name: AUDIT_TRACING_ENDPOINT
+            #   value: {{ .Values.tracing.endpoint | quote }}
+            # - name: AUDIT_TRACING_COLLECTOR
+            #   value: {{ .Values.tracing.collector | quote }}
 
             - name: AUDIT_EVENTS_ENDPOINT
             {{- if not .Values.messagingSystem.external.enabled }}

--- a/charts/ocis/templates/eventhistory/deployment.yaml
+++ b/charts/ocis/templates/eventhistory/deployment.yaml
@@ -34,14 +34,15 @@ spec:
             - name: EVENTHISTORY_LOG_PRETTY
               value: {{ .Values.logging.pretty | quote }}
 
-            - name: EVENTHISTORY_TRACING_ENABLED
-              value: "{{ .Values.tracing.enabled }}"
-            - name: EVENTHISTORY_TRACING_TYPE
-              value: {{ .Values.tracing.type | quote }}
-            - name: EVENTHISTORY_TRACING_ENDPOINT
-              value: {{ .Values.tracing.endpoint | quote }}
-            - name: EVENTHISTORY_TRACING_COLLECTOR
-              value: {{ .Values.tracing.collector | quote }}
+            # Tracing not yet implemented: https://github.com/owncloud/ocis/issues/6173
+            # - name: EVENTHISTORY_TRACING_ENABLED
+            #   value: "{{ .Values.tracing.enabled }}"
+            # - name: EVENTHISTORY_TRACING_TYPE
+            #   value: {{ .Values.tracing.type | quote }}
+            # - name: EVENTHISTORY_TRACING_ENDPOINT
+            #   value: {{ .Values.tracing.endpoint | quote }}
+            # - name: EVENTHISTORY_TRACING_COLLECTOR
+            #   value: {{ .Values.tracing.collector | quote }}
 
             - name: EVENTHISTORY_DEBUG_PPROF
               value: {{ .Values.debug.profiling | quote }}

--- a/charts/ocis/templates/nats/deployment.yaml
+++ b/charts/ocis/templates/nats/deployment.yaml
@@ -40,14 +40,15 @@ spec:
             - name: NATS_LOG_PRETTY
               value: {{ .Values.logging.pretty | quote }}
 
-            - name: NATS_TRACING_ENABLED
-              value: "{{ .Values.tracing.enabled }}"
-            - name: NATS_TRACING_TYPE
-              value: {{ .Values.tracing.type | quote }}
-            - name: NATS_TRACING_ENDPOINT
-              value: {{ .Values.tracing.endpoint | quote }}
-            - name: NATS_TRACING_COLLECTOR
-              value: {{ .Values.tracing.collector | quote }}
+            # Tracing not yet implemented: https://github.com/owncloud/ocis/issues/6174
+            # - name: NATS_TRACING_ENABLED
+            #   value: "{{ .Values.tracing.enabled }}"
+            # - name: NATS_TRACING_TYPE
+            #   value: {{ .Values.tracing.type | quote }}
+            # - name: NATS_TRACING_ENDPOINT
+            #   value: {{ .Values.tracing.endpoint | quote }}
+            # - name: NATS_TRACING_COLLECTOR
+            #   value: {{ .Values.tracing.collector | quote }}
 
             # - name: NATS_DEBUG_PPROF
             #   value: {{ .Values.debug.profiling | quote }}

--- a/charts/ocis/templates/notifications/deployment.yaml
+++ b/charts/ocis/templates/notifications/deployment.yaml
@@ -31,14 +31,15 @@ spec:
             - name: NOTIFICATIONS_LOG_PRETTY
               value: {{ .Values.logging.pretty | quote }}
 
-            - name: NOTIFICATIONS_TRACING_ENABLED
-              value: "{{ .Values.tracing.enabled }}"
-            - name: NOTIFICATIONS_TRACING_TYPE
-              value: {{ .Values.tracing.type | quote }}
-            - name: NOTIFICATIONS_TRACING_ENDPOINT
-              value: {{ .Values.tracing.endpoint | quote }}
-            - name: NOTIFICATIONS_TRACING_COLLECTOR
-              value: {{ .Values.tracing.collector | quote }}
+            # Tracing not yet implemented: https://github.com/owncloud/ocis/issues/6175
+            # - name: NOTIFICATIONS_TRACING_ENABLED
+            #   value: "{{ .Values.tracing.enabled }}"
+            # - name: NOTIFICATIONS_TRACING_TYPE
+            #   value: {{ .Values.tracing.type | quote }}
+            # - name: NOTIFICATIONS_TRACING_ENDPOINT
+            #   value: {{ .Values.tracing.endpoint | quote }}
+            # - name: NOTIFICATIONS_TRACING_COLLECTOR
+            #   value: {{ .Values.tracing.collector | quote }}
 
             # - name: NOTIFICATIONS_DEBUG_PPROF
             #   value: {{ .Values.debug.profiling | quote }}

--- a/charts/ocis/templates/postprocessing/deployment.yaml
+++ b/charts/ocis/templates/postprocessing/deployment.yaml
@@ -30,14 +30,15 @@ spec:
             - name: POSTPROCESSING_LOG_PRETTY
               value: {{ .Values.logging.pretty | quote }}
 
-            - name: POSTPROCESSING_TRACING_ENABLED
-              value: "{{ .Values.tracing.enabled }}"
-            - name: POSTPROCESSING_TRACING_TYPE
-              value: {{ .Values.tracing.type | quote }}
-            - name: POSTPROCESSING_TRACING_ENDPOINT
-              value: {{ .Values.tracing.endpoint | quote }}
-            - name: POSTPROCESSING_TRACING_COLLECTOR
-              value: {{ .Values.tracing.collector | quote }}
+            # Tracing not yet implemented: https://github.com/owncloud/ocis/issues/6176
+            # - name: POSTPROCESSING_TRACING_ENABLED
+            #   value: "{{ .Values.tracing.enabled }}"
+            # - name: POSTPROCESSING_TRACING_TYPE
+            #   value: {{ .Values.tracing.type | quote }}
+            # - name: POSTPROCESSING_TRACING_ENDPOINT
+            #   value: {{ .Values.tracing.endpoint | quote }}
+            # - name: POSTPROCESSING_TRACING_COLLECTOR
+            #   value: {{ .Values.tracing.collector | quote }}
 
             # - name: POSTPROCESSING_DEBUG_PPROF
             #   value: {{ .Values.debug.profiling | quote }}

--- a/charts/ocis/templates/userlog/deployment.yaml
+++ b/charts/ocis/templates/userlog/deployment.yaml
@@ -34,14 +34,15 @@ spec:
             - name: USERLOG_LOG_PRETTY
               value: {{ .Values.logging.pretty | quote }}
 
-            - name: USERLOG_TRACING_ENABLED
-              value: "{{ .Values.tracing.enabled }}"
-            - name: USERLOG_TRACING_TYPE
-              value: {{ .Values.tracing.type | quote }}
-            - name: USERLOG_TRACING_ENDPOINT
-              value: {{ .Values.tracing.endpoint | quote }}
-            - name: USERLOG_TRACING_COLLECTOR
-              value: {{ .Values.tracing.collector | quote }}
+            # Tracing not yet implemented: https://github.com/owncloud/ocis/issues/6177
+            # - name: USERLOG_TRACING_ENABLED
+            #   value: "{{ .Values.tracing.enabled }}"
+            # - name: USERLOG_TRACING_TYPE
+            #   value: {{ .Values.tracing.type | quote }}
+            # - name: USERLOG_TRACING_ENDPOINT
+            #   value: {{ .Values.tracing.endpoint | quote }}
+            # - name: USERLOG_TRACING_COLLECTOR
+            #   value: {{ .Values.tracing.collector | quote }}
 
             # - name: USERLOG_DEBUG_PPROF
             #   value: {{ .Values.debug.profiling | quote }}


### PR DESCRIPTION
This finishes up the last part of #202 with not having unused environment variables in the deployment templates, but at the same time links to possible implementation tickets for ocis which should result in either activating tracing or removing the commented out sections.

Fixes #202

Related issues:
https://github.com/owncloud/ocis/issues/6171
https://github.com/owncloud/ocis/issues/6172
https://github.com/owncloud/ocis/issues/6173
https://github.com/owncloud/ocis/issues/6174
https://github.com/owncloud/ocis/issues/6175
https://github.com/owncloud/ocis/issues/6176
https://github.com/owncloud/ocis/issues/6177
