### PR TITLE
Add a warning to the documentation for upload cleanup job to prevent cancelling unfinished uploads

### DIFF
--- a/charts/ocis/docs/values-desc-table.adoc
+++ b/charts/ocis/docs/values-desc-table.adoc
@@ -1565,7 +1565,7 @@ a| [subs=-attributes]
 +int+
 a| [subs=-attributes]
 `86400`
-| Duration in seconds after which uploads will expire.
+| Duration in seconds after which uploads will expire.    WARNING: Setting this to a low number will lead to uploads being cancelled before they are finished and returning a 403 to the user.
 | services.storageusers.maintenance.purgeExpiredTrashBinItems.enabled
 a| [subs=-attributes]
 +bool+

--- a/charts/ocis/docs/values.adoc.yaml
+++ b/charts/ocis/docs/values.adoc.yaml
@@ -1014,6 +1014,7 @@ services:
         # -- Cron pattern for the job to be run. Defaults to every minute.
         schedule: "* * * * *"
         # -- Duration in seconds after which uploads will expire.
+        #    WARNING: Setting this to a low number will lead to uploads being cancelled before they are finished and returning a 403 to the user.
         uploadExpiration: 86400
       # Expired trash bin items can be cleaned up automatically by enabling the purge exired trash bin items job.
       purgeExpiredTrashBinItems:

--- a/charts/ocis/values.yaml
+++ b/charts/ocis/values.yaml
@@ -1013,6 +1013,7 @@ services:
         # -- Cron pattern for the job to be run. Defaults to every minute.
         schedule: "* * * * *"
         # -- Duration in seconds after which uploads will expire.
+        #    WARNING: Setting this to a low number will lead to uploads being cancelled before they are finished and returning a 403 to the user.
         uploadExpiration: 86400
       # Expired trash bin items can be cleaned up automatically by enabling the purge exired trash bin items job.
       purgeExpiredTrashBinItems:


### PR DESCRIPTION
Ran into the problem of getting large uploads cancelled when debugging another issue, and went down a rabbit hole of trying to figure out why uploads were cancelled before realizing that I had this setting set to low in my helmfile for specifically testing the maintenance job.

Adding a warning so others might avoid doing something stupid.