### PR TITLE
Add git-excluded directory for own value files

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -7,3 +7,4 @@
 /helmfile.yaml
 .drone.yml
 **/ci/templated.yaml
+ownconfigs/*


### PR DESCRIPTION
## Description
With https://github.com/owncloud/ocis-charts/pull/234/files we included the `deployments` directory into git which was formerly excluded and could hold own value files to keep them from being accidentially commited. This PR adds a new excluded directory `ownconfigs`. To offer what `deployments` formerly did.

## Motivation and Context
Convenience

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Technical debt
- [ ] Tests only (no source changes)

## Checklist:
- [ ] Code changes
- [ ] Unit tests added
- [ ] Acceptance tests added
- [ ] Documentation generated (`make docs`) and committed
- [ ] Documentation ticket raised: <link>
- [ ] Documentation PR created: <link>
