### PR TITLE
fix ci by not using kubernetes 1.27 for templating

### DIFF
--- a/.drone.star
+++ b/.drone.star
@@ -60,7 +60,7 @@ def linting(ctx):
                 "name": "helm template",
                 "image": "owncloudci/alpine:latest",
                 "commands": [
-                    "helm template charts/ocis -f 'charts/ocis/ci/values_pre_1.25.0.yaml' > charts/ocis/ci/templated.yaml",
+                    "helm template --kube-version 1.26.0 charts/ocis -f 'charts/ocis/ci/values_pre_1.25.0.yaml' > charts/ocis/ci/templated.yaml",
                 ],
             },
             {

--- a/Makefile
+++ b/Makefile
@@ -20,7 +20,7 @@ clean:
 lint: $(KUBE_LINTER)
 	# TODO: use helm from bingo
 	helm lint charts/ocis
-	helm template charts/ocis -f 'charts/ocis/ci/values_pre_1.25.0.yaml' > charts/ocis/ci/templated.yaml
+	helm template --kube-version 1.26.0 charts/ocis -f 'charts/ocis/ci/values_pre_1.25.0.yaml' > charts/ocis/ci/templated.yaml
 	$(KUBE_LINTER) lint charts/ocis/ci/templated.yaml
 
 


### PR DESCRIPTION
## Description
Kubernetes 1.27 was released and broke our `helm templating` step in the CI, since we not yet support 1.27.
Unit we did https://github.com/owncloud/ocis-charts/issues/261 we'll pin the CI to use 1.27 (and should keep the pinning after that too, so that it won't happen for 1.28, too)

## Related Issue
- related to https://github.com/owncloud/ocis-charts/issues/261

## Motivation and Context
Fix CI

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
- CI

## Screenshots (if appropriate):

## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Technical debt
- [ ] Tests only (no source changes)

## Checklist:
- [x] Code changes
- [ ] Unit tests added
- [ ] Acceptance tests added
- [ ] Documentation generated (`make docs`) and committed
- [ ] Documentation ticket raised: <link>
- [ ] Documentation PR created: <link>
