### PR TITLE
fix caches configuration for oCIS 3.0.0-rc.3

### DIFF
--- a/charts/ocis/templates/frontend/deployment.yaml
+++ b/charts/ocis/templates/frontend/deployment.yaml
@@ -82,10 +82,10 @@ spec:
               value: {{ .Values.features.sharing.users.resharing | quote }}
 
             # cache
-            - name: FRONTEND_OCS_RESOURCE_INFO_CACHE_STORE
+            - name: FRONTEND_OCS_STAT_CACHE_STORE
               value: {{ .Values.cache.type | quote }}
             {{- if ne .Values.cache.type "noop" }}
-            - name: FRONTEND_OCS_RESOURCE_INFO_CACHE_STORE_NODES
+            - name: FRONTEND_OCS_STAT_CACHE_STORE_NODES
               value: {{ join "," .Values.cache.nodes | quote }}
             {{- end }}
 

--- a/charts/ocis/templates/gateway/deployment.yaml
+++ b/charts/ocis/templates/gateway/deployment.yaml
@@ -86,8 +86,14 @@ spec:
 
             # cache
             # the stat cache is disabled for now for performance reasons, see https://github.com/owncloud/ocis-charts/issues/214
-            - name: GATEWAY_CACHE_STORE
+            - name: GATEWAY_STAT_CACHE_STORE
               value: noop
+            # provider cache in kubernetes defaults to noop because we might have regularily changing ip addresses
+            - name: GATEWAY_PROVIDER_CACHE_STORE
+              value: noop
+            # create home cache defaults to memory so we don't put too much load on our shared cache
+            - name: GATEWAY_CREATE_HOME_CACHE_STORE
+              value: memory
 
             - name: GATEWAY_STORAGE_USERS_MOUNT_ID
               valueFrom:


### PR DESCRIPTION
## Description
fixes caches configuration for oCIS 3.0.0-rc.3

## Related Issue
- fixes caching configuration, since we used variables that no longer exists

## Motivation and Context

## How Has This Been Tested?
- in minikube

## Screenshots (if appropriate):

## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Technical debt
- [ ] Tests only (no source changes)

## Checklist:
- [x] Code changes
- [ ] Unit tests added
- [ ] Acceptance tests added
- [ ] Documentation generated (`make docs`) and committed
- [ ] Documentation ticket raised: <link>
- [ ] Documentation PR created: <link>
