### PR TITLE
don't scale postprocessing, because it is currently not scalable

### DIFF
--- a/charts/ocis/docs/values-desc-table.adoc
+++ b/charts/ocis/docs/values-desc-table.adoc
@@ -1422,12 +1422,6 @@ a| [subs=-attributes]
 a| [subs=-attributes]
 see detailed service configuration options below
 | POSTPROCESSING service.
-| services.postprocessing.autoscaling
-a| [subs=-attributes]
-+object+
-a| [subs=-attributes]
-`{}`
-| Per-service autoscaling. Overrides the default setting from `autoscaling` if set.
 | services.postprocessing.resources
 a| [subs=-attributes]
 +object+

--- a/charts/ocis/docs/values.adoc.yaml
+++ b/charts/ocis/docs/values.adoc.yaml
@@ -820,8 +820,6 @@ services:
   postprocessing:
     # -- Per-service resources configuration. Overrides the default setting from `resources` if set.
     resources: {}
-    # -- Per-service autoscaling. Overrides the default setting from `autoscaling` if set.
-    autoscaling: {}
 
   # -- PROXY service.
   # @default -- see detailed service configuration options below

--- a/charts/ocis/templates/postprocessing/deployment.yaml
+++ b/charts/ocis/templates/postprocessing/deployment.yaml
@@ -5,9 +5,7 @@ kind: Deployment
 {{ include "ocis.metadata" . }}
 spec:
   {{- include "ocis.selector" . | nindent 2 }}
-  {{- if and (not .Values.autoscaling.enabled) (.Values.replicas) }}
-  replicas: {{ .Values.replicas }}
-  {{- end }}
+  replicas: 1 #TODO: https://github.com/owncloud/ocis-charts/issues/15
   template:
     {{- include "ocis.templateMetadata" (dict "scope" $ "configCheck" false) | nindent 4 }}
     spec:

--- a/charts/ocis/templates/postprocessing/hpa.yaml
+++ b/charts/ocis/templates/postprocessing/hpa.yaml
@@ -1,3 +1,0 @@
-{{- include "ocis.appNames" (dict "scope" . "appName" "appNamePostprocessing" "appNameSuffix" "") -}}
-{{ include "ocis.hpa" . }}
-{{- $_ := set . "autoscaling" (default (default (dict) .Values.autoscaling) .Values.services.postprocessing.autoscaling) -}}

--- a/charts/ocis/values.yaml
+++ b/charts/ocis/values.yaml
@@ -819,8 +819,6 @@ services:
   postprocessing:
     # -- Per-service resources configuration. Overrides the default setting from `resources` if set.
     resources: {}
-    # -- Per-service autoscaling. Overrides the default setting from `autoscaling` if set.
-    autoscaling: {}
 
   # -- PROXY service.
   # @default -- see detailed service configuration options below


### PR DESCRIPTION
## Description
don't scale postprocessing, because it is currenlty not scalable. See https://github.com/owncloud/ocis/blob/26a2db371c0609757337b93f92827ed88227fd64/services/postprocessing/pkg/service/service.go#L42

## Related Issue
- Fixes bugs that arise when scaling postprocessing (stuck files, weird behaviour)

## Motivation and Context

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
- run in minikube

## Screenshots (if appropriate):

## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [x] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Technical debt
- [ ] Tests only (no source changes)

## Checklist:
- [x] Code changes
- [ ] Unit tests added
- [ ] Acceptance tests added
- [x] Documentation generated (`make docs`) and committed
- [ ] Documentation ticket raised: <link>
- [ ] Documentation PR created: <link>
