### PR TITLE
Make it possible to add labels per service.

### DIFF
--- a/charts/ocis/docs/values-desc-table.adoc
+++ b/charts/ocis/docs/values-desc-table.adoc
@@ -948,6 +948,12 @@ a| [subs=-attributes]
 a| [subs=-attributes]
 `{}`
 | Per-service autoscaling. Overrides the default setting from `autoscaling` if set.
+| services.antivirus.extraLabels
+a| [subs=-attributes]
++object+
+a| [subs=-attributes]
+`{}`
+| Per-service custom labels
 | services.antivirus.podDisruptionBudget
 a| [subs=-attributes]
 +object+
@@ -972,6 +978,12 @@ a| [subs=-attributes]
 a| [subs=-attributes]
 `{}`
 | Affinity settings for the approvider service.
+| services.appprovider.extraLabels
+a| [subs=-attributes]
++object+
+a| [subs=-attributes]
+`{}`
+| Per-service custom labels
 | services.appprovider.resources
 a| [subs=-attributes]
 +object+
@@ -990,6 +1002,12 @@ a| [subs=-attributes]
 a| [subs=-attributes]
 `{}`
 | Affinity settings for the appregistry service. See the documentation of this setting in approvider for examples.
+| services.appregistry.extraLabels
+a| [subs=-attributes]
++object+
+a| [subs=-attributes]
+`{}`
+| Per-service custom labels
 | services.appregistry.resources
 a| [subs=-attributes]
 +object+
@@ -1014,6 +1032,12 @@ a| [subs=-attributes]
 a| [subs=-attributes]
 `{}`
 | Per-service autoscaling. Overrides the default setting from `autoscaling` if set.
+| services.audit.extraLabels
+a| [subs=-attributes]
++object+
+a| [subs=-attributes]
+`{}`
+| Per-service custom labels
 | services.audit.podDisruptionBudget
 a| [subs=-attributes]
 +object+
@@ -1044,6 +1068,12 @@ a| [subs=-attributes]
 a| [subs=-attributes]
 `{}`
 | Per-service autoscaling. Overrides the default setting from `autoscaling` if set.
+| services.authbasic.extraLabels
+a| [subs=-attributes]
++object+
+a| [subs=-attributes]
+`{}`
+| Per-service custom labels
 | services.authbasic.podDisruptionBudget
 a| [subs=-attributes]
 +object+
@@ -1074,6 +1104,12 @@ a| [subs=-attributes]
 a| [subs=-attributes]
 `{}`
 | Per-service autoscaling. Overrides the default setting from `autoscaling` if set.
+| services.authmachine.extraLabels
+a| [subs=-attributes]
++object+
+a| [subs=-attributes]
+`{}`
+| Per-service custom labels
 | services.authmachine.podDisruptionBudget
 a| [subs=-attributes]
 +object+
@@ -1104,6 +1140,12 @@ a| [subs=-attributes]
 a| [subs=-attributes]
 `{}`
 | Per-service autoscaling. Overrides the default setting from `autoscaling` if set.
+| services.eventhistory.extraLabels
+a| [subs=-attributes]
++object+
+a| [subs=-attributes]
+`{}`
+| Per-service custom labels
 | services.eventhistory.podDisruptionBudget
 a| [subs=-attributes]
 +object+
@@ -1140,6 +1182,12 @@ a| [subs=-attributes]
 a| [subs=-attributes]
 `{}`
 | Per-service autoscaling. Overrides the default setting from `autoscaling` if set.
+| services.frontend.extraLabels
+a| [subs=-attributes]
++object+
+a| [subs=-attributes]
+`{}`
+| Per-service custom labels
 | services.frontend.podDisruptionBudget
 a| [subs=-attributes]
 +object+
@@ -1170,6 +1218,12 @@ a| [subs=-attributes]
 a| [subs=-attributes]
 `{}`
 | Per-service autoscaling. Overrides the default setting from `autoscaling` if set.
+| services.gateway.extraLabels
+a| [subs=-attributes]
++object+
+a| [subs=-attributes]
+`{}`
+| Per-service custom labels
 | services.gateway.podDisruptionBudget
 a| [subs=-attributes]
 +object+
@@ -1200,6 +1254,12 @@ a| [subs=-attributes]
 a| [subs=-attributes]
 `{}`
 | Per-service autoscaling. Overrides the default setting from `autoscaling` if set.
+| services.graph.extraLabels
+a| [subs=-attributes]
++object+
+a| [subs=-attributes]
+`{}`
+| Per-service custom labels
 | services.graph.podDisruptionBudget
 a| [subs=-attributes]
 +object+
@@ -1230,6 +1290,12 @@ a| [subs=-attributes]
 a| [subs=-attributes]
 `{}`
 | Per-service autoscaling. Overrides the default setting from `autoscaling` if set.
+| services.groups.extraLabels
+a| [subs=-attributes]
++object+
+a| [subs=-attributes]
+`{}`
+| Per-service custom labels
 | services.groups.podDisruptionBudget
 a| [subs=-attributes]
 +object+
@@ -1254,6 +1320,12 @@ a| [subs=-attributes]
 a| [subs=-attributes]
 `{}`
 | Affinity settings for the idm service. See the documentation of this setting in approvider for examples.
+| services.idm.extraLabels
+a| [subs=-attributes]
++object+
+a| [subs=-attributes]
+`{}`
+| Per-service custom labels
 | services.idm.persistence
 a| [subs=-attributes]
 +object+
@@ -1332,6 +1404,12 @@ a| [subs=-attributes]
 a| [subs=-attributes]
 `{}`
 | Affinity settings for the idp service. See the documentation of this setting in approvider for examples.
+| services.idp.extraLabels
+a| [subs=-attributes]
++object+
+a| [subs=-attributes]
+`{}`
+| Per-service custom labels
 | services.idp.resources
 a| [subs=-attributes]
 +object+
@@ -1350,6 +1428,12 @@ a| [subs=-attributes]
 a| [subs=-attributes]
 `{}`
 | Affinity settings for the nats service. See the documentation of this setting in approvider for examples.
+| services.nats.extraLabels
+a| [subs=-attributes]
++object+
+a| [subs=-attributes]
+`{}`
+| Per-service custom labels
 | services.nats.persistence
 a| [subs=-attributes]
 +object+
@@ -1434,6 +1518,12 @@ a| [subs=-attributes]
 a| [subs=-attributes]
 `{}`
 | Per-service autoscaling. Overrides the default setting from `autoscaling` if set.
+| services.notifications.extraLabels
+a| [subs=-attributes]
++object+
+a| [subs=-attributes]
+`{}`
+| Per-service custom labels
 | services.notifications.podDisruptionBudget
 a| [subs=-attributes]
 +object+
@@ -1464,6 +1554,12 @@ a| [subs=-attributes]
 a| [subs=-attributes]
 `{}`
 | Per-service autoscaling. Overrides the default setting from `autoscaling` if set.
+| services.ocdav.extraLabels
+a| [subs=-attributes]
++object+
+a| [subs=-attributes]
+`{}`
+| Per-service custom labels
 | services.ocdav.podDisruptionBudget
 a| [subs=-attributes]
 +object+
@@ -1494,6 +1590,12 @@ a| [subs=-attributes]
 a| [subs=-attributes]
 `{}`
 | Per-service autoscaling. Overrides the default setting from `autoscaling` if set.
+| services.ocs.extraLabels
+a| [subs=-attributes]
++object+
+a| [subs=-attributes]
+`{}`
+| Per-service custom labels
 | services.ocs.podDisruptionBudget
 a| [subs=-attributes]
 +object+
@@ -1524,6 +1626,12 @@ a| [subs=-attributes]
 a| [subs=-attributes]
 `{}`
 | Per-service autoscaling. Overrides the default setting from `autoscaling` if set.
+| services.policies.extraLabels
+a| [subs=-attributes]
++object+
+a| [subs=-attributes]
+`{}`
+| Per-service custom labels
 | services.postprocessing
 a| [subs=-attributes]
 +object+
@@ -1536,6 +1644,12 @@ a| [subs=-attributes]
 a| [subs=-attributes]
 `{}`
 | Affinity settings for the postprocessing service. See the documentation of this setting in approvider for examples.
+| services.postprocessing.extraLabels
+a| [subs=-attributes]
++object+
+a| [subs=-attributes]
+`{}`
+| Per-service custom labels
 | services.postprocessing.resources
 a| [subs=-attributes]
 +object+
@@ -1560,6 +1674,12 @@ a| [subs=-attributes]
 a| [subs=-attributes]
 `{}`
 | Per-service autoscaling. Overrides the default setting from `autoscaling` if set.
+| services.proxy.extraLabels
+a| [subs=-attributes]
++object+
+a| [subs=-attributes]
+`{}`
+| Per-service custom labels
 | services.proxy.podDisruptionBudget
 a| [subs=-attributes]
 +object+
@@ -1584,6 +1704,12 @@ a| [subs=-attributes]
 a| [subs=-attributes]
 `{}`
 | Affinity settings for the search service. See the documentation of this setting in approvider for examples.
+| services.search.extraLabels
+a| [subs=-attributes]
++object+
+a| [subs=-attributes]
+`{}`
+| Per-service custom labels
 | services.search.extractor
 a| [subs=-attributes]
 +object+
@@ -1692,6 +1818,12 @@ a| [subs=-attributes]
 a| [subs=-attributes]
 `{}`
 | Per-service autoscaling. Overrides the default setting from `autoscaling` if set.
+| services.settings.extraLabels
+a| [subs=-attributes]
++object+
+a| [subs=-attributes]
+`{}`
+| Per-service custom labels
 | services.settings.podDisruptionBudget
 a| [subs=-attributes]
 +object+
@@ -1716,6 +1848,12 @@ a| [subs=-attributes]
 a| [subs=-attributes]
 `{}`
 | Affinity settings for the sharing service. See the documentation of this setting in approvider for examples.
+| services.sharing.extraLabels
+a| [subs=-attributes]
++object+
+a| [subs=-attributes]
+`{}`
+| Per-service custom labels
 | services.sharing.podDisruptionBudget
 a| [subs=-attributes]
 +object+
@@ -1746,6 +1884,12 @@ a| [subs=-attributes]
 a| [subs=-attributes]
 `{}`
 | Per-service autoscaling. Overrides the default setting from `autoscaling` if set.
+| services.storagepubliclink.extraLabels
+a| [subs=-attributes]
++object+
+a| [subs=-attributes]
+`{}`
+| Per-service custom labels
 | services.storagepubliclink.podDisruptionBudget
 a| [subs=-attributes]
 +object+
@@ -1776,6 +1920,12 @@ a| [subs=-attributes]
 a| [subs=-attributes]
 `{}`
 | Per-service autoscaling. Overrides the default setting from `autoscaling` if set.
+| services.storageshares.extraLabels
+a| [subs=-attributes]
++object+
+a| [subs=-attributes]
+`{}`
+| Per-service custom labels
 | services.storageshares.podDisruptionBudget
 a| [subs=-attributes]
 +object+
@@ -1806,6 +1956,12 @@ a| [subs=-attributes]
 a| [subs=-attributes]
 `{}`
 | Per-service autoscaling. Overrides the default setting from `autoscaling` if set.
+| services.storagesystem.extraLabels
+a| [subs=-attributes]
++object+
+a| [subs=-attributes]
+`{}`
+| Per-service custom labels
 | services.storagesystem.persistence
 a| [subs=-attributes]
 +object+
@@ -1896,6 +2052,12 @@ a| [subs=-attributes]
 a| [subs=-attributes]
 `{}`
 | Per-service autoscaling. Overrides the default setting from `autoscaling` if set.
+| services.storageusers.extraLabels
+a| [subs=-attributes]
++object+
+a| [subs=-attributes]
+`{}`
+| Per-service custom labels
 | services.storageusers.maintenance.cleanUpExpiredUploads.enabled
 a| [subs=-attributes]
 +bool+
@@ -2076,6 +2238,12 @@ a| [subs=-attributes]
 a| [subs=-attributes]
 `{}`
 | Affinity settings for the store service. See the documentation of this setting in approvider for examples.
+| services.store.extraLabels
+a| [subs=-attributes]
++object+
+a| [subs=-attributes]
+`{}`
+| Per-service custom labels
 | services.store.persistence
 a| [subs=-attributes]
 +object+
@@ -2160,6 +2328,12 @@ a| [subs=-attributes]
 a| [subs=-attributes]
 `{}`
 | Per-service autoscaling. Overrides the default setting from `autoscaling` if set.
+| services.thumbnails.extraLabels
+a| [subs=-attributes]
++object+
+a| [subs=-attributes]
+`{}`
+| Per-service custom labels
 | services.thumbnails.maintenance
 a| [subs=-attributes]
 +object+
@@ -2280,6 +2454,12 @@ a| [subs=-attributes]
 a| [subs=-attributes]
 `{}`
 | Per-service autoscaling. Overrides the default setting from `autoscaling` if set.
+| services.userlog.extraLabels
+a| [subs=-attributes]
++object+
+a| [subs=-attributes]
+`{}`
+| Per-service custom labels
 | services.userlog.podDisruptionBudget
 a| [subs=-attributes]
 +object+
@@ -2316,6 +2496,12 @@ a| [subs=-attributes]
 a| [subs=-attributes]
 `{}`
 | Per-service autoscaling. Overrides the default setting from `autoscaling` if set.
+| services.users.extraLabels
+a| [subs=-attributes]
++object+
+a| [subs=-attributes]
+`{}`
+| Per-service custom labels
 | services.users.podDisruptionBudget
 a| [subs=-attributes]
 +object+
@@ -2430,6 +2616,12 @@ a| [subs=-attributes]
 a| [subs=-attributes]
 `""`
 | URL to load themes from. Will be prepended to the theme path. Defaults to the value of "externalDomain".
+| services.web.extraLabels
+a| [subs=-attributes]
++object+
+a| [subs=-attributes]
+`{}`
+| Per-service custom labels
 | services.web.persistence
 a| [subs=-attributes]
 +object+
@@ -2520,6 +2712,12 @@ a| [subs=-attributes]
 a| [subs=-attributes]
 `{}`
 | Per-service autoscaling. Overrides the default setting from `autoscaling` if set.
+| services.webdav.extraLabels
+a| [subs=-attributes]
++object+
+a| [subs=-attributes]
+`{}`
+| Per-service custom labels
 | services.webdav.podDisruptionBudget
 a| [subs=-attributes]
 +object+

--- a/charts/ocis/docs/values.adoc.yaml
+++ b/charts/ocis/docs/values.adoc.yaml
@@ -1,3 +1,4 @@
+
 ---
 # Image for oCIS services
 image:
@@ -1463,3 +1464,4 @@ monitoring:
   interval: 60s
   # -- Scrape timeout.
   scrapeTimeout: 60s
+

--- a/charts/ocis/docs/values.adoc.yaml
+++ b/charts/ocis/docs/values.adoc.yaml
@@ -1,4 +1,3 @@
-
 ---
 # Image for oCIS services
 image:
@@ -625,6 +624,8 @@ services:
     #       topologyKey: "kubernetes.io/hostname"
     #
     # Do note that the value will be different for each service.
+    # -- Per-service custom labels
+    extraLabels: {}
 
   # -- APP REGISTRY service. Not used if `features.appsIntegration.enabled` equals `false`.
   # @default -- see detailed service configuration options below
@@ -633,6 +634,8 @@ services:
     resources: {}
     # -- Affinity settings for the appregistry service. See the documentation of this setting in approvider for examples.
     affinity: {}
+    # -- Per-service custom labels
+    extraLabels: {}
 
   # -- AUDIT service.
   # @default -- see detailed service configuration options below
@@ -645,6 +648,8 @@ services:
     autoscaling: {}
     # -- Affinity settings for the audit service. See the documentation of this setting in approvider for examples.
     affinity: {}
+    # -- Per-service custom labels
+    extraLabels: {}
 
   # -- AUTH BASIC service. Not used if `features.externalUserManagement.enabled` equals `true`.
   # @default -- see detailed service configuration options below
@@ -657,6 +662,8 @@ services:
     autoscaling: {}
     # -- Affinity settings for the authbasic service. See the documentation of this setting in approvider for examples.
     affinity: {}
+    # -- Per-service custom labels
+    extraLabels: {}
 
   # -- AUTH MACHINE service.
   # @default -- see detailed service configuration options below
@@ -669,6 +676,8 @@ services:
     autoscaling: {}
     # -- Affinity settings for the authmachine service. See the documentation of this setting in approvider for examples.
     affinity: {}
+    # -- Per-service custom labels
+    extraLabels: {}
 
   # -- ANTIVIRUS service. Not used if `features.virusscan.enabled` equals `false`.
   # @default -- see detailed service configuration options below
@@ -681,6 +690,8 @@ services:
     autoscaling: {}
     # -- Affinity settings for the antivirus service. See the documentation of this setting in approvider for examples.
     affinity: {}
+    # -- Per-service custom labels
+    extraLabels: {}
 
   # -- EVENT HISTORY service.
   # @default -- see detailed service configuration options below
@@ -703,6 +714,8 @@ services:
     autoscaling: {}
     # -- Affinity settings for the eventhistory service. See the documentation of this setting in approvider for examples.
     affinity: {}
+    # -- Per-service custom labels
+    extraLabels: {}
 
   # -- FRONTEND service.
   # @default -- see detailed service configuration options below
@@ -715,6 +728,8 @@ services:
     autoscaling: {}
     # -- Affinity settings for the frontend service. See the documentation of this setting in approvider for examples.
     affinity: {}
+    # -- Per-service custom labels
+    extraLabels: {}
 
   # -- GATEWAY service.
   # @default -- see detailed service configuration options below
@@ -727,6 +742,8 @@ services:
     autoscaling: {}
     # -- Affinity settings for the gateway service. See the documentation of this setting in approvider for examples.
     affinity: {}
+    # -- Per-service custom labels
+    extraLabels: {}
 
   # -- GRAPH service.
   # @default -- see detailed service configuration options below
@@ -739,6 +756,8 @@ services:
     autoscaling: {}
     # -- Affinity settings for the graph service. See the documentation of this setting in approvider for examples.
     affinity: {}
+    # -- Per-service custom labels
+    extraLabels: {}
 
   # -- GROUPS service.
   # @default -- see detailed service configuration options below
@@ -751,6 +770,8 @@ services:
     autoscaling: {}
     # -- Affinity settings for the groups service. See the documentation of this setting in approvider for examples.
     affinity: {}
+    # -- Per-service custom labels
+    extraLabels: {}
 
   # -- IDM service. Not used if `features.externalUserManagement.enabled` equals `true`.
   # @default -- see detailed service configuration options below
@@ -788,6 +809,8 @@ services:
     resources: {}
     # -- Affinity settings for the idm service. See the documentation of this setting in approvider for examples.
     affinity: {}
+    # -- Per-service custom labels
+    extraLabels: {}
 
   # -- IDP service. Not used if `features.externalUserManagement.enabled` equals `true`.
   # @default -- see detailed service configuration options below
@@ -796,6 +819,8 @@ services:
     resources: {}
     # -- Affinity settings for the idp service. See the documentation of this setting in approvider for examples.
     affinity: {}
+    # -- Per-service custom labels
+    extraLabels: {}
 
   # -- NATS service. Not used if `messagingSystem.external.enabled` equals `true`.
   # @default -- see detailed service configuration options below
@@ -833,6 +858,8 @@ services:
     resources: {}
     # -- Affinity settings for the nats service. See the documentation of this setting in approvider for examples.
     affinity: {}
+    # -- Per-service custom labels
+    extraLabels: {}
 
   # -- NOTIFICATIONS service. Not used if `features.emailNotifications.enabled` equals `true`.
   # @default -- see detailed service configuration options below
@@ -845,6 +872,8 @@ services:
     autoscaling: {}
     # -- Affinity settings for the notifications service. See the documentation of this setting in approvider for examples.
     affinity: {}
+    # -- Per-service custom labels
+    extraLabels: {}
 
   # -- OCDAV service.
   # @default -- see detailed service configuration options below
@@ -857,6 +886,8 @@ services:
     autoscaling: {}
     # -- Affinity settings for the ocdav service. See the documentation of this setting in approvider for examples.
     affinity: {}
+    # -- Per-service custom labels
+    extraLabels: {}
 
   # -- OCS service.
   # @default -- see detailed service configuration options below
@@ -869,6 +900,8 @@ services:
     autoscaling: {}
     # -- Affinity settings for the ocs service. See the documentation of this setting in approvider for examples.
     affinity: {}
+    # -- Per-service custom labels
+    extraLabels: {}
 
   # -- POLICIES service.
   # @default -- see detailed service configuration options below
@@ -877,6 +910,8 @@ services:
     autoscaling: {}
     # -- Affinity settings for the policies service. See the documentation of this setting in approvider for examples.
     affinity: {}
+    # -- Per-service custom labels
+    extraLabels: {}
 
   # -- POSTPROCESSING service.
   # @default -- see detailed service configuration options below
@@ -885,6 +920,8 @@ services:
     resources: {}
     # -- Affinity settings for the postprocessing service. See the documentation of this setting in approvider for examples.
     affinity: {}
+    # -- Per-service custom labels
+    extraLabels: {}
 
   # -- PROXY service.
   # @default -- see detailed service configuration options below
@@ -897,6 +934,8 @@ services:
     autoscaling: {}
     # -- Affinity settings for the proxy service. See the documentation of this setting in approvider for examples.
     affinity: {}
+    # -- Per-service custom labels
+    extraLabels: {}
 
   # -- SEARCH service.
   # @default -- see detailed service configuration options below
@@ -946,6 +985,8 @@ services:
     podDisruptionBudget: {}
     # -- Affinity settings for the search service. See the documentation of this setting in approvider for examples.
     affinity: {}
+    # -- Per-service custom labels
+    extraLabels: {}
 
   # -- SETTINGS service.
   # @default -- see detailed service configuration options below
@@ -958,6 +999,8 @@ services:
     autoscaling: {}
     # -- Affinity settings for the settings service. See the documentation of this setting in approvider for examples.
     affinity: {}
+    # -- Per-service custom labels
+    extraLabels: {}
 
   # -- SHARING service.
   # @default -- see detailed service configuration options below
@@ -968,6 +1011,8 @@ services:
     podDisruptionBudget: {}
     # -- Affinity settings for the sharing service. See the documentation of this setting in approvider for examples.
     affinity: {}
+    # -- Per-service custom labels
+    extraLabels: {}
 
   # -- STORAGE-PUBLICLINK service.
   # @default -- see detailed service configuration options below
@@ -980,6 +1025,8 @@ services:
     autoscaling: {}
     # -- Affinity settings for the storagepubliclink service. See the documentation of this setting in approvider for examples.
     affinity: {}
+    # -- Per-service custom labels
+    extraLabels: {}
 
   # -- STORAGE-SHARES service.
   # @default -- see detailed service configuration options below
@@ -992,6 +1039,8 @@ services:
     autoscaling: {}
     # -- Affinity settings for the storageshares service. See the documentation of this setting in approvider for examples.
     affinity: {}
+    # -- Per-service custom labels
+    extraLabels: {}
 
   # -- STORAGE-SYSTEM service.
   # @default -- see detailed service configuration options below
@@ -1033,6 +1082,8 @@ services:
     autoscaling: {}
     # -- Affinity settings for the storagesystem service. See the documentation of this setting in approvider for examples.
     affinity: {}
+    # -- Per-service custom labels
+    extraLabels: {}
 
   # -- STORAGE-USERS service.
   # @default -- see detailed service configuration options below
@@ -1138,6 +1189,8 @@ services:
     autoscaling: {}
     # -- Affinity settings for the storageusers service. See the documentation of this setting in approvider for examples.
     affinity: {}
+    # -- Per-service custom labels
+    extraLabels: {}
 
   # -- STORE service.
   # @default -- see detailed service configuration options below
@@ -1175,6 +1228,8 @@ services:
     resources: {}
     # -- Affinity settings for the store service. See the documentation of this setting in approvider for examples.
     affinity: {}
+    # -- Per-service custom labels
+    extraLabels: {}
 
   # -- THUMBNAILS service.
   # @default -- see detailed service configuration options below
@@ -1226,6 +1281,8 @@ services:
     autoscaling: {}
     # -- Affinity settings for the thumbnails service. See the documentation of this setting in approvider for examples.
     affinity: {}
+    # -- Per-service custom labels
+    extraLabels: {}
 
   # -- USERLOG service.
   # @default -- see detailed service configuration options below
@@ -1248,6 +1305,8 @@ services:
     autoscaling: {}
     # -- Affinity settings for the userlog service. See the documentation of this setting in approvider for examples.
     affinity: {}
+    # -- Per-service custom labels
+    extraLabels: {}
 
   # -- USERS service.
   # @default -- see detailed service configuration options below
@@ -1260,6 +1319,8 @@ services:
     autoscaling: {}
     # -- Affinity settings for the users service. See the documentation of this setting in approvider for examples.
     affinity: {}
+    # -- Per-service custom labels
+    extraLabels: {}
 
   # -- ownCloud WEB service.
   # @default -- see detailed service configuration options below
@@ -1377,6 +1438,8 @@ services:
     autoscaling: {}
     # -- Affinity settings for the web service. See the documentation of this setting in approvider for examples.
     affinity: {}
+    # -- Per-service custom labels
+    extraLabels: {}
 
   # -- WEBDAV service.
   # @default -- see detailed service configuration options below
@@ -1389,6 +1452,8 @@ services:
     autoscaling: {}
     # -- Affinity settings for the webdav service. See the documentation of this setting in approvider for examples.
     affinity: {}
+    # -- Per-service custom labels
+    extraLabels: {}
 
 # -- Service monitoring configuration. Requires the monitoring.coreos.com/v1 CRDs to be installed.
 monitoring:
@@ -1398,4 +1463,3 @@ monitoring:
   interval: 60s
   # -- Scrape timeout.
   scrapeTimeout: 60s
-

--- a/charts/ocis/templates/_common/_tplvalues.tpl
+++ b/charts/ocis/templates/_common/_tplvalues.tpl
@@ -94,6 +94,12 @@ Adds the app names to the scope and set the name of the app based on the input p
   {{- else -}}
   {{- $_ := set .scope "appName" (index .scope .appName) -}}
   {{- end -}}
+
+  {{- if (index .scope.Values.services (index .scope .appName)) -}}
+  {{- $_ := set .scope "appSpecificConfig" (index .scope.Values.services (index .scope .appName)) -}}
+  {{- else -}}
+  {{- $_ := set .scope "appSpecificConfig" (dict) -}}
+  {{- end -}}
 {{- end -}}
 
 {{/*

--- a/charts/ocis/templates/_common/_tplvalues.tpl
+++ b/charts/ocis/templates/_common/_tplvalues.tpl
@@ -97,8 +97,6 @@ Adds the app names to the scope and set the name of the app based on the input p
 
   {{- if (index .scope.Values.services (index .scope .appName)) -}}
   {{- $_ := set .scope "appSpecificConfig" (index .scope.Values.services (index .scope .appName)) -}}
-  {{- else -}}
-  {{- $_ := set .scope "appSpecificConfig" (dict) -}}
   {{- end -}}
 {{- end -}}
 

--- a/charts/ocis/templates/_common/labels/labels.tpl
+++ b/charts/ocis/templates/_common/labels/labels.tpl
@@ -25,6 +25,13 @@ app.kubernetes.io/managed-by: {{ .Release.Service }}
 {{- if .Values.extraLabels }}
 {{ toYaml .Values.extraLabels }}
 {{- end }}
+
+{{- if .appSpecificConfig }}
+{{- if (index .appSpecificConfig "extraLabels") }}
+{{ toYaml .appSpecificConfig.extraLabels }}
+{{- end }}
+{{- end }}
+
 {{- end -}}
 
 {{/*

--- a/charts/ocis/templates/_common/labels/labels.tpl
+++ b/charts/ocis/templates/_common/labels/labels.tpl
@@ -26,10 +26,8 @@ app.kubernetes.io/managed-by: {{ .Release.Service }}
 {{ toYaml .Values.extraLabels }}
 {{- end }}
 
-{{- if .appSpecificConfig }}
-{{- if (index .appSpecificConfig "extraLabels") }}
-{{ toYaml .appSpecificConfig.extraLabels }}
-{{- end }}
+{{- with and .appSpecificConfig .appSpecificConfig.extraLabels }}
+{{ toYaml . }}
 {{- end }}
 
 {{- end -}}

--- a/charts/ocis/values.yaml
+++ b/charts/ocis/values.yaml
@@ -624,6 +624,8 @@ services:
     #       topologyKey: "kubernetes.io/hostname"
     #
     # Do note that the value will be different for each service.
+    # -- Per-service custom labels
+    extraLabels: {}
 
   # -- APP REGISTRY service. Not used if `features.appsIntegration.enabled` equals `false`.
   # @default -- see detailed service configuration options below
@@ -632,6 +634,8 @@ services:
     resources: {}
     # -- Affinity settings for the appregistry service. See the documentation of this setting in approvider for examples.
     affinity: {}
+    # -- Per-service custom labels
+    extraLabels: {}
 
   # -- AUDIT service.
   # @default -- see detailed service configuration options below
@@ -644,6 +648,8 @@ services:
     autoscaling: {}
     # -- Affinity settings for the audit service. See the documentation of this setting in approvider for examples.
     affinity: {}
+    # -- Per-service custom labels
+    extraLabels: {}
 
   # -- AUTH BASIC service. Not used if `features.externalUserManagement.enabled` equals `true`.
   # @default -- see detailed service configuration options below
@@ -656,6 +662,8 @@ services:
     autoscaling: {}
     # -- Affinity settings for the authbasic service. See the documentation of this setting in approvider for examples.
     affinity: {}
+    # -- Per-service custom labels
+    extraLabels: {}
 
   # -- AUTH MACHINE service.
   # @default -- see detailed service configuration options below
@@ -668,6 +676,8 @@ services:
     autoscaling: {}
     # -- Affinity settings for the authmachine service. See the documentation of this setting in approvider for examples.
     affinity: {}
+    # -- Per-service custom labels
+    extraLabels: {}
 
   # -- ANTIVIRUS service. Not used if `features.virusscan.enabled` equals `false`.
   # @default -- see detailed service configuration options below
@@ -680,6 +690,8 @@ services:
     autoscaling: {}
     # -- Affinity settings for the antivirus service. See the documentation of this setting in approvider for examples.
     affinity: {}
+    # -- Per-service custom labels
+    extraLabels: {}
 
   # -- EVENT HISTORY service.
   # @default -- see detailed service configuration options below
@@ -702,6 +714,8 @@ services:
     autoscaling: {}
     # -- Affinity settings for the eventhistory service. See the documentation of this setting in approvider for examples.
     affinity: {}
+    # -- Per-service custom labels
+    extraLabels: {}
 
   # -- FRONTEND service.
   # @default -- see detailed service configuration options below
@@ -714,6 +728,8 @@ services:
     autoscaling: {}
     # -- Affinity settings for the frontend service. See the documentation of this setting in approvider for examples.
     affinity: {}
+    # -- Per-service custom labels
+    extraLabels: {}
 
   # -- GATEWAY service.
   # @default -- see detailed service configuration options below
@@ -726,6 +742,8 @@ services:
     autoscaling: {}
     # -- Affinity settings for the gateway service. See the documentation of this setting in approvider for examples.
     affinity: {}
+    # -- Per-service custom labels
+    extraLabels: {}
 
   # -- GRAPH service.
   # @default -- see detailed service configuration options below
@@ -738,6 +756,8 @@ services:
     autoscaling: {}
     # -- Affinity settings for the graph service. See the documentation of this setting in approvider for examples.
     affinity: {}
+    # -- Per-service custom labels
+    extraLabels: {}
 
   # -- GROUPS service.
   # @default -- see detailed service configuration options below
@@ -750,6 +770,8 @@ services:
     autoscaling: {}
     # -- Affinity settings for the groups service. See the documentation of this setting in approvider for examples.
     affinity: {}
+    # -- Per-service custom labels
+    extraLabels: {}
 
   # -- IDM service. Not used if `features.externalUserManagement.enabled` equals `true`.
   # @default -- see detailed service configuration options below
@@ -787,6 +809,8 @@ services:
     resources: {}
     # -- Affinity settings for the idm service. See the documentation of this setting in approvider for examples.
     affinity: {}
+    # -- Per-service custom labels
+    extraLabels: {}
 
   # -- IDP service. Not used if `features.externalUserManagement.enabled` equals `true`.
   # @default -- see detailed service configuration options below
@@ -795,6 +819,8 @@ services:
     resources: {}
     # -- Affinity settings for the idp service. See the documentation of this setting in approvider for examples.
     affinity: {}
+    # -- Per-service custom labels
+    extraLabels: {}
 
   # -- NATS service. Not used if `messagingSystem.external.enabled` equals `true`.
   # @default -- see detailed service configuration options below
@@ -832,6 +858,8 @@ services:
     resources: {}
     # -- Affinity settings for the nats service. See the documentation of this setting in approvider for examples.
     affinity: {}
+    # -- Per-service custom labels
+    extraLabels: {}
 
   # -- NOTIFICATIONS service. Not used if `features.emailNotifications.enabled` equals `true`.
   # @default -- see detailed service configuration options below
@@ -844,6 +872,8 @@ services:
     autoscaling: {}
     # -- Affinity settings for the notifications service. See the documentation of this setting in approvider for examples.
     affinity: {}
+    # -- Per-service custom labels
+    extraLabels: {}
 
   # -- OCDAV service.
   # @default -- see detailed service configuration options below
@@ -856,6 +886,8 @@ services:
     autoscaling: {}
     # -- Affinity settings for the ocdav service. See the documentation of this setting in approvider for examples.
     affinity: {}
+    # -- Per-service custom labels
+    extraLabels: {}
 
   # -- OCS service.
   # @default -- see detailed service configuration options below
@@ -868,6 +900,8 @@ services:
     autoscaling: {}
     # -- Affinity settings for the ocs service. See the documentation of this setting in approvider for examples.
     affinity: {}
+    # -- Per-service custom labels
+    extraLabels: {}
 
   # -- POLICIES service.
   # @default -- see detailed service configuration options below
@@ -876,6 +910,8 @@ services:
     autoscaling: {}
     # -- Affinity settings for the policies service. See the documentation of this setting in approvider for examples.
     affinity: {}
+    # -- Per-service custom labels
+    extraLabels: {}
 
   # -- POSTPROCESSING service.
   # @default -- see detailed service configuration options below
@@ -884,6 +920,8 @@ services:
     resources: {}
     # -- Affinity settings for the postprocessing service. See the documentation of this setting in approvider for examples.
     affinity: {}
+    # -- Per-service custom labels
+    extraLabels: {}
 
   # -- PROXY service.
   # @default -- see detailed service configuration options below
@@ -896,6 +934,8 @@ services:
     autoscaling: {}
     # -- Affinity settings for the proxy service. See the documentation of this setting in approvider for examples.
     affinity: {}
+    # -- Per-service custom labels
+    extraLabels: {}
 
   # -- SEARCH service.
   # @default -- see detailed service configuration options below
@@ -945,6 +985,8 @@ services:
     podDisruptionBudget: {}
     # -- Affinity settings for the search service. See the documentation of this setting in approvider for examples.
     affinity: {}
+    # -- Per-service custom labels
+    extraLabels: {}
 
   # -- SETTINGS service.
   # @default -- see detailed service configuration options below
@@ -957,6 +999,8 @@ services:
     autoscaling: {}
     # -- Affinity settings for the settings service. See the documentation of this setting in approvider for examples.
     affinity: {}
+    # -- Per-service custom labels
+    extraLabels: {}
 
   # -- SHARING service.
   # @default -- see detailed service configuration options below
@@ -967,6 +1011,8 @@ services:
     podDisruptionBudget: {}
     # -- Affinity settings for the sharing service. See the documentation of this setting in approvider for examples.
     affinity: {}
+    # -- Per-service custom labels
+    extraLabels: {}
 
   # -- STORAGE-PUBLICLINK service.
   # @default -- see detailed service configuration options below
@@ -979,6 +1025,8 @@ services:
     autoscaling: {}
     # -- Affinity settings for the storagepubliclink service. See the documentation of this setting in approvider for examples.
     affinity: {}
+    # -- Per-service custom labels
+    extraLabels: {}
 
   # -- STORAGE-SHARES service.
   # @default -- see detailed service configuration options below
@@ -991,6 +1039,8 @@ services:
     autoscaling: {}
     # -- Affinity settings for the storageshares service. See the documentation of this setting in approvider for examples.
     affinity: {}
+    # -- Per-service custom labels
+    extraLabels: {}
 
   # -- STORAGE-SYSTEM service.
   # @default -- see detailed service configuration options below
@@ -1032,6 +1082,8 @@ services:
     autoscaling: {}
     # -- Affinity settings for the storagesystem service. See the documentation of this setting in approvider for examples.
     affinity: {}
+    # -- Per-service custom labels
+    extraLabels: {}
 
   # -- STORAGE-USERS service.
   # @default -- see detailed service configuration options below
@@ -1137,6 +1189,8 @@ services:
     autoscaling: {}
     # -- Affinity settings for the storageusers service. See the documentation of this setting in approvider for examples.
     affinity: {}
+    # -- Per-service custom labels
+    extraLabels: {}
 
   # -- STORE service.
   # @default -- see detailed service configuration options below
@@ -1174,6 +1228,8 @@ services:
     resources: {}
     # -- Affinity settings for the store service. See the documentation of this setting in approvider for examples.
     affinity: {}
+    # -- Per-service custom labels
+    extraLabels: {}
 
   # -- THUMBNAILS service.
   # @default -- see detailed service configuration options below
@@ -1225,6 +1281,8 @@ services:
     autoscaling: {}
     # -- Affinity settings for the thumbnails service. See the documentation of this setting in approvider for examples.
     affinity: {}
+    # -- Per-service custom labels
+    extraLabels: {}
 
   # -- USERLOG service.
   # @default -- see detailed service configuration options below
@@ -1247,6 +1305,8 @@ services:
     autoscaling: {}
     # -- Affinity settings for the userlog service. See the documentation of this setting in approvider for examples.
     affinity: {}
+    # -- Per-service custom labels
+    extraLabels: {}
 
   # -- USERS service.
   # @default -- see detailed service configuration options below
@@ -1259,6 +1319,8 @@ services:
     autoscaling: {}
     # -- Affinity settings for the users service. See the documentation of this setting in approvider for examples.
     affinity: {}
+    # -- Per-service custom labels
+    extraLabels: {}
 
   # -- ownCloud WEB service.
   # @default -- see detailed service configuration options below
@@ -1376,6 +1438,8 @@ services:
     autoscaling: {}
     # -- Affinity settings for the web service. See the documentation of this setting in approvider for examples.
     affinity: {}
+    # -- Per-service custom labels
+    extraLabels: {}
 
   # -- WEBDAV service.
   # @default -- see detailed service configuration options below
@@ -1388,6 +1452,8 @@ services:
     autoscaling: {}
     # -- Affinity settings for the webdav service. See the documentation of this setting in approvider for examples.
     affinity: {}
+    # -- Per-service custom labels
+    extraLabels: {}
 
 # -- Service monitoring configuration. Requires the monitoring.coreos.com/v1 CRDs to be installed.
 monitoring:


### PR DESCRIPTION
This PR adds the possibility to add labels per service. This is useful
for affinity rules and selecting pods and deployments in a more flexible way.

To do this, I've added a new key `appSpecificConfig` to the scope via
`ocis.appNames`. This can in the future also be used to simplify other
service specific templates.

Fixes #251