### PR TITLE
search recreate strategy

### DIFF
--- a/charts/ocis/templates/search/deployment.yaml
+++ b/charts/ocis/templates/search/deployment.yaml
@@ -6,9 +6,8 @@ kind: Deployment
 spec:
   {{- include "ocis.selector" . | nindent 2 }}
   replicas: 1 #TODO: https://github.com/owncloud/ocis-charts/issues/15
-  {{- if .Values.deploymentStrategy }}
-  strategy: {{ toYaml .Values.deploymentStrategy | nindent 4 }}
-  {{ end }}
+  strategy:
+    type: Recreate
   template:
     {{- include "ocis.templateMetadata" (dict "scope" $ "configCheck" false) | nindent 4 }}
     spec:


### PR DESCRIPTION
## Description
since search is not scalable and has a persistent volume, we enforce the recreate strategy.

Type RollingUpdate might lead to a stuck pod when the persistent volume is RWO and the new search pod is scheduled on a different node.

## Related Issue
- Fixes stuck search pods on update

## Motivation and Context

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
- have a RWO volume for search on a multinode cluster and you'll probably run into this when ugprading (eg. change labels / image version / log levels)

## Screenshots (if appropriate):

## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Technical debt
- [ ] Tests only (no source changes)

## Checklist:
- [x] Code changes
- [ ] Unit tests added
- [ ] Acceptance tests added
- [ ] Documentation generated (`make docs`) and committed
- [ ] Documentation ticket raised: <link>
- [ ] Documentation PR created: <link>
