### PR TITLE
disable stat cache for frontend

### DIFF
--- a/charts/ocis/templates/frontend/deployment.yaml
+++ b/charts/ocis/templates/frontend/deployment.yaml
@@ -83,12 +83,9 @@ spec:
               value: {{ .Values.features.sharing.users.resharing | quote }}
 
             # cache
+            # the stat cache is disabled for now for performance reasons, see https://github.com/owncloud/ocis-charts/issues/214
             - name: FRONTEND_OCS_STAT_CACHE_STORE
-              value: {{ .Values.cache.type | quote }}
-            {{- if ne .Values.cache.type "noop" }}
-            - name: FRONTEND_OCS_STAT_CACHE_STORE_NODES
-              value: {{ join "," .Values.cache.nodes | quote }}
-            {{- end }}
+              value: noop
 
             - name: OCIS_EDITION
               value: {{ .Values.features.edition | quote }}


### PR DESCRIPTION
using a stat cache causes https://github.com/owncloud/ocis/issues/6299

the cache is empty, but invalidating the cache over a network hop is still slow.