### PR TITLE
use cache as postprocessing store

### DIFF
--- a/charts/ocis/templates/postprocessing/deployment.yaml
+++ b/charts/ocis/templates/postprocessing/deployment.yaml
@@ -75,6 +75,14 @@ spec:
               value: "" # no cert needed
               {{- end }}
             {{- end }}
+            
+            # cache
+            - name: POSTPROCESSING_STORE_TYPE
+              value: {{ .Values.cache.type | quote }}
+            {{- if ne .Values.cache.type "noop" }}
+            - name: POSTPROCESSING_STORE_NODES
+              value: {{ join "," .Values.cache.nodes | quote }}
+            {{- end }}
 
           {{- include "ocis.livenessProbe" . | nindent 10 }}
 


### PR DESCRIPTION
This may need a dedicated option if we want to persist postprocessing events in a persistent store ... which I think we do. cc @kobergj 