### PR TITLE
Use `OCIS_LDAP_SERVER_WRITE_ENABLED` envvar

### DIFF
--- a/charts/ocis/templates/frontend/deployment.yaml
+++ b/charts/ocis/templates/frontend/deployment.yaml
@@ -55,6 +55,9 @@ spec:
             - name: OCIS_REVA_GATEWAY
               value: {{ .appNameGateway }}:9142
 
+            - name: OCIS_LDAP_SERVER_WRITE_ENABLED
+              value: {{ .Values.features.externalUserManagement.ldap.writeable | quote }}
+
             {{- if .Values.features.externalUserManagement.enabled }}
             - name: FRONTEND_READONLY_USER_ATTRIBUTES
               value: {{ tpl (join "," .Values.features.externalUserManagement.ldap.readOnlyAttributes) . | quote }}


### PR DESCRIPTION
Starting from this PR https://github.com/owncloud/ocis/pull/6339 frontend service needs a new envvar to tell web to lock `Create User` actions. 

Has no effect on other versions so this could be merged proactively