### PR TITLE
Fix service addition for names with non-DNS names.

### DIFF
--- a/charts/ocis/templates/appprovider/deployment.yaml
+++ b/charts/ocis/templates/appprovider/deployment.yaml
@@ -1,7 +1,7 @@
 {{ if .Values.features.appsIntegration.enabled }}
 {{- range $officeSuite := .Values.features.appsIntegration.wopiIntegration.officeSuites }}
 {{ if $officeSuite.enabled }}
-{{- include "ocis.appNames" (dict "scope" $ "appName" "appNameAppProvider" "appNameSuffix" (regexReplaceAll "\\W+" (lower $officeSuite.name) "_")) -}}
+{{- include "ocis.appNames" (dict "scope" $ "appName" "appNameAppProvider" "appNameSuffix" (regexReplaceAll "\\W+" (lower $officeSuite.name) "-")) -}}
 {{- $_ := set $ "resources" (default (default (dict) $.Values.resources) $.Values.services.appprovider.resources) -}}
 ---
 apiVersion: apps/v1

--- a/charts/ocis/templates/appprovider/service.yaml
+++ b/charts/ocis/templates/appprovider/service.yaml
@@ -1,7 +1,7 @@
 {{ if .Values.features.appsIntegration.enabled }}
 {{- range $officeSuite := .Values.features.appsIntegration.wopiIntegration.officeSuites }}
 {{ if $officeSuite.enabled }}
-{{- include "ocis.appNames" (dict "scope" $ "appName" "appNameAppProvider" "appNameSuffix" (regexReplaceAll "\\W+" (lower $officeSuite.name) "_")) -}}
+{{- include "ocis.appNames" (dict "scope" $ "appName" "appNameAppProvider" "appNameSuffix" (regexReplaceAll "\\W+" (lower $officeSuite.name) "-")) -}}
 ---
 apiVersion: v1
 kind: Service


### PR DESCRIPTION
This switches the replacement of non-word characters from `_` to `-`.
This is necessary because the service name is used as a DNS name and
_ is not a valid character in DNS names.

Fixes #270