### PR TITLE
Fix typo of 'environment'

### DIFF
--- a/.drone.star
+++ b/.drone.star
@@ -131,7 +131,7 @@ def documentation(ctx):
             {
                 "name": "gomplate-values-adoc",
                 "image": "hairyhenderson/gomplate:v3.10.0-alpine",
-                "enviornment": {
+                "environment": {
                     "ASSUME_NO_MOVING_GC_UNSAFE_RISK_IT_WITH": "go1.18",
                 },
                 "entrypoint": [


### PR DESCRIPTION
## Description
`environment` was spelt wrong in `.drone.star` so it would not have been effective.

I wonder what will be the real difference now in CI.

## How Has This Been Tested?
CI

## Types of changes
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Technical debt
- [ ] Tests only (no source changes)

## Checklist:
- [ ] Code changes
- [ ] Unit tests added
- [ ] Acceptance tests added
- [ ] Documentation generated (`make docs`) and committed
- [ ] Documentation ticket raised: <link>
- [ ] Documentation PR created: <link>
