### PR TITLE
[docs-only] Fix typo in NOTIFICATIONS environment variable names

### DIFF
--- a/charts/ocis/templates/notifications/deployment.yaml
+++ b/charts/ocis/templates/notifications/deployment.yaml
@@ -84,13 +84,13 @@ spec:
               value: {{ .appNameNats }}:9233
             {{- else }}
               value: {{ .Values.messagingSystem.external.endpoint | quote }}
-            - name: NOTIFICIATIONS_EVENTS_CLUSTER
+            - name: NOTIFICATIONS_EVENTS_CLUSTER
               value: {{ .Values.messagingSystem.external.cluster | quote }}
-            - name: NOTIFICIATIONS_EVENTS_ENABLE_TLS
+            - name: NOTIFICATIONS_EVENTS_ENABLE_TLS
               value: {{ .Values.messagingSystem.external.tls.enabled | quote }}
-            - name: NOTIFICIATIONS_EVENTS_TLS_INSECURE
+            - name: NOTIFICATIONS_EVENTS_TLS_INSECURE
               value: {{ .Values.messagingSystem.external.tls.insecure | quote }}
-            - name: NOTIFICIATIONS_EVENTS_TLS_ROOT_CA_CERTIFICATE
+            - name: NOTIFICATIONS_EVENTS_TLS_ROOT_CA_CERTIFICATE
               {{- if not .Values.messagingSystem.external.tls.certTrusted }}
               value: /etc/ocis/messaging-system-ca/messaging-system-ca.crt
               {{- else }}


### PR DESCRIPTION
## Description
Fix the spelling of the `NOTIFICATIONS` environment variables.
They are spelt correctly in the `ocis` repo.

## Related Issue
- Fixes #282 

## How Has This Been Tested?
CI

## Types of changes
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Technical debt
- [ ] Tests only (no source changes)

## Checklist:
- [ ] Code changes
- [ ] Unit tests added
- [ ] Acceptance tests added
- [ ] Documentation generated (`make docs`) and committed
- [ ] Documentation ticket raised: <link>
- [ ] Documentation PR created: <link>
