### PR TITLE
graph ldap settings

### DIFF
--- a/charts/ocis/templates/graph/deployment.yaml
+++ b/charts/ocis/templates/graph/deployment.yaml
@@ -64,24 +64,24 @@ spec:
                   name: {{ .Values.secretRefs.ldapSecretRef }}
                   key: graph-ldap-bind-password
             {{ else }}
-            - name: OCIS_LDAP_URI
+            - name: GRAPH_LDAP_URI
               value: {{ .Values.features.externalUserManagement.ldap.uri | quote }}
             - name: GRAPH_LDAP_BIND_DN
               value: {{ .Values.features.externalUserManagement.ldap.bindDN | quote }}
-            - name: OCIS_LDAP_BIND_PASSWORD
+            - name: GRAPH_LDAP_BIND_PASSWORD
               valueFrom:
                 secretKeyRef:
                   name: {{ .Values.secretRefs.ldapSecretRef }}
                   key: reva-ldap-bind-password
             - name: GRAPH_LDAP_SERVER_WRITE_ENABLED
               value: {{ .Values.features.externalUserManagement.ldap.writeable | quote }}
-            - name: OCIS_LDAP_CACERT
+            - name: GRAPH_LDAP_CACERT
               {{ if or (not .Values.features.externalUserManagement.enabled) (not .Values.features.externalUserManagement.ldap.certTrusted) }}
               value: /etc/ocis/ldap-ca/ldap-ca.crt
               {{ else }}
               value: "" # no cert needed
               {{ end }}
-            - name: OCIS_LDAP_INSECURE
+            - name: GRAPH_LDAP_INSECURE
               value: {{ .Values.features.externalUserManagement.ldap.insecure | quote }}
             - name: GRAPH_LDAP_SERVER_UUID
               value: {{ .Values.features.externalUserManagement.ldap.useServerUUID | quote }}
@@ -91,9 +91,9 @@ spec:
             - name: GRAPH_LDAP_REFINT_ENABLED
               value: {{ .Values.features.externalUserManagement.ldap.refintEnabled | quote }}
 
-            - name: OCIS_LDAP_USER_BASE_DN
+            - name: GRAPH_LDAP_USER_BASE_DN
               value: {{ .Values.features.externalUserManagement.ldap.user.baseDN | quote }}
-            - name: OCIS_LDAP_GROUP_BASE_DN
+            - name: GRAPH_LDAP_GROUP_BASE_DN
               value: {{ .Values.features.externalUserManagement.ldap.group.baseDN | quote }}
             - name: GRAPH_LDAP_GROUP_CREATE_BASE_DN
             {{- if .Values.features.externalUserManagement.ldap.group.createBaseDN }}
@@ -102,50 +102,48 @@ spec:
               value: {{ .Values.features.externalUserManagement.ldap.group.baseDN | quote }}
             {{- end }}
 
-            - name: GRAPH_LDAP_USER_DISPLAYNAME_ATTRIBUTE
-              value: {{ .Values.features.externalUserManagement.ldap.user.displayName | quote }}
-            - name: OCIS_LDAP_USER_SCOPE
+            - name: GRAPH_LDAP_USER_SCOPE
               value: {{ .Values.features.externalUserManagement.ldap.user.scope | quote }}
-            - name: OCIS_LDAP_GROUP_SCOPE
+            - name: GRAPH_LDAP_GROUP_SEARCH_SCOPE
               value: {{ .Values.features.externalUserManagement.ldap.group.scope | quote }}
 
-            - name: OCIS_LDAP_USER_FILTER
+            - name: GRAPH_LDAP_USER_FILTER
               value: {{ .Values.features.externalUserManagement.ldap.user.filter | quote }}
-            - name: OCIS_LDAP_GROUP_FILTER
+            - name: GRAPH_LDAP_GROUP_FILTER
               value: {{ .Values.features.externalUserManagement.ldap.group.filter | quote }}
 
-            - name: OCIS_LDAP_USER_OBJECTCLASS
+            - name: GRAPH_LDAP_USER_OBJECTCLASS
               value: {{ .Values.features.externalUserManagement.ldap.user.objectClass | quote }}
-            - name: OCIS_LDAP_GROUP_OBJECTCLASS
+            - name: GRAPH_LDAP_GROUP_OBJECTCLASS
               value: {{ .Values.features.externalUserManagement.ldap.group.objectClass | quote }}
 
-            - name: OCIS_LDAP_USER_SCHEMA_ID
+            - name: GRAPH_LDAP_USER_UID_ATTRIBUTE
               value: {{ .Values.features.externalUserManagement.ldap.user.schema.id | quote }}
-            - name: OCIS_LDAP_GROUP_SCHEMA_ID
+            - name: GRAPH_LDAP_GROUP_ID_ATTRIBUTE
               value: {{ .Values.features.externalUserManagement.ldap.group.schema.id | quote }}
 
-            - name: OCIS_LDAP_USER_SCHEMA_MAIL
+            - name: GRAPH_LDAP_USER_EMAIL_ATTRIBUTE
               value: {{ .Values.features.externalUserManagement.ldap.user.schema.mail | quote }}
 
-            - name: OCIS_LDAP_USER_SCHEMA_DISPLAYNAME
+            - name: GRAPH_LDAP_USER_DISPLAYNAME_ATTRIBUTE
               value: {{ .Values.features.externalUserManagement.ldap.user.schema.displayName | quote }}
-            - name: OCIS_LDAP_USER_SCHEMA_USERNAME
+            - name: GRAPH_LDAP_USER_NAME_ATTRIBUTE
               value: {{ .Values.features.externalUserManagement.ldap.user.schema.userName | quote }}
-            - name: OCIS_LDAP_USER_SCHEMA_USER_TYPE
+            - name: GRAPH_LDAP_USER_TYPE_ATTRIBUTE
               value: {{ .Values.features.externalUserManagement.ldap.user.schema.userType | quote }}
-            - name: OCIS_LDAP_GROUP_SCHEMA_GROUPNAME
+            - name: GRAPH_LDAP_GROUP_NAME_ATTRIBUTE
               value: {{ .Values.features.externalUserManagement.ldap.group.schema.groupName | quote }}
 
-            - name: OCIS_LDAP_USER_SCHEMA_ID_IS_OCTETSTRING
+            - name: GRAPH_LDAP_USER_SCHEMA_ID_IS_OCTETSTRING
               value: {{ .Values.features.externalUserManagement.ldap.user.schema.idIsOctetString | quote }}
-            - name: OCIS_LDAP_GROUP_SCHEMA_ID_IS_OCTETSTRING
+            - name: GRAPH_LDAP_GROUP_SCHEMA_ID_IS_OCTETSTRING
               value: {{ .Values.features.externalUserManagement.ldap.group.schema.idIsOctetString | quote }}
 
-            - name: OCIS_LDAP_USER_ENABLED_ATTRIBUTE
+            - name: GRAPH_USER_ENABLED_ATTRIBUTE
               value: {{ .Values.features.externalUserManagement.ldap.disableUsers.userEnabledAttribute | quote }}
-            - name: OCIS_LDAP_DISABLE_USER_MECHANISM
+            - name: GRAPH_DISABLE_USER_MECHANISM
               value: {{ .Values.features.externalUserManagement.ldap.disableUsers.disableMechanism | quote }}
-            - name: OCIS_LDAP_DISABLED_USERS_GROUP_DN
+            - name: GRAPH_DISABLED_USERS_GROUP_DN
               value: {{ .Values.features.externalUserManagement.ldap.disableUsers.disabledUsersGroupDN | quote }}
 
             {{ end }}

--- a/charts/ocis/templates/graph/deployment.yaml
+++ b/charts/ocis/templates/graph/deployment.yaml
@@ -66,7 +66,7 @@ spec:
             {{ else }}
             - name: OCIS_LDAP_URI
               value: {{ .Values.features.externalUserManagement.ldap.uri | quote }}
-            - name: OCIS_LDAP_BIND_DN
+            - name: GRAPH_LDAP_BIND_DN
               value: {{ .Values.features.externalUserManagement.ldap.bindDN | quote }}
             - name: OCIS_LDAP_BIND_PASSWORD
               valueFrom:


### PR DESCRIPTION
## Description
- replace non-existing OCIS_LDAP_BIND_PASSWORD
- switch to GRAPH_* variables for graph ldap settings

## Related Issue
- Fixes graph startup (because no bind credentials are passed, because the are passed to a non existing variable)

## Motivation and Context
fix a bug and consistency (all other services using ldap settings are also using <service name>_LDAP_* variables)

## How Has This Been Tested?
- reading https://doc.owncloud.com/ocis/next/deployment/services/s-list/graph.html
- https://github.com/owncloud/ocis-charts/tree/master/deployments/external-user-management

## Screenshots (if appropriate):

## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [x] Technical debt
- [ ] Tests only (no source changes)

## Checklist:
- [x] Code changes
- [ ] Unit tests added
- [ ] Acceptance tests added
- [ ] Documentation generated (`make docs`) and committed
- [ ] Documentation ticket raised: <link>
- [ ] Documentation PR created: <link>
