### PR TITLE
use external ldap bind password secret for keycloak example

### DIFF
--- a/deployments/external-user-management/helmfile.yaml
+++ b/deployments/external-user-management/helmfile.yaml
@@ -340,6 +340,8 @@ releases:
       - insecure:
           oidcIdpInsecure: true
           ocisHttpApiInsecure: true
+      - secretRefs:
+          ldapSecretRef: ldap-bind-secrets # we provide the ldap bind password of the ldap server in the extraResources section as secret
       - features:
           externalUserManagement:
             # -- Enables external user management (and disables internal user management).


### PR DESCRIPTION
## Description
fixes the Keycloak example by explicitely using the secret from extraResources.
Prior this change I always got a "secret already exists" error

## Related Issue
- fixes the keycloak deployment example

## Motivation and Context
keep the examples working

## How Has This Been Tested?
- `helmfile sync` on an empty cluster

## Screenshots (if appropriate):

## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Technical debt
- [ ] Tests only (no source changes)

## Checklist:
- [x] Code changes
- [ ] Unit tests added
- [ ] Acceptance tests added
- [ ] Documentation generated (`make docs`) and committed
- [ ] Documentation ticket raised: <link>
- [ ] Documentation PR created: <link>
