### PR TITLE
fix archive max size integer interpretation

### DIFF
--- a/charts/ocis/templates/frontend/deployment.yaml
+++ b/charts/ocis/templates/frontend/deployment.yaml
@@ -80,10 +80,10 @@ spec:
               value: {{ .Values.features.sharing.users.resharing | quote }}
 
             - name: FRONTEND_ARCHIVER_MAX_SIZE
-              value: {{ .Values.features.archiver.maxSize | quote }}
+              value: {{ int64 .Values.features.archiver.maxSize | quote }}
 
             - name: FRONTEND_ARCHIVER_MAX_NUM_FILES
-              value: {{ .Values.features.archiver.maxNumFiles | quote }}
+              value: {{ int64 .Values.features.archiver.maxNumFiles | quote }}
 
             # cache
             # the stat cache is disabled for now for performance reasons, see https://github.com/owncloud/ocis-charts/issues/214


### PR DESCRIPTION
## Description
prior this PR, a value of 10000000000 would be transformed to 1e+10, which is not an acceptable number format for FRONTEND_ARCHIVER_MAX_SIZE or FRONTEND_ARCHIVER_MAX_NUM_FILES

## Related Issue
- fixes archiver settings

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->

## How Has This Been Tested?
in minikube

## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Technical debt
- [ ] Tests only (no source changes)

## Checklist:
- [x] Code changes
- [ ] Unit tests added
- [ ] Acceptance tests added
- [ ] Documentation generated (`make docs`) and committed
- [ ] Documentation ticket raised: <link>
- [ ] Documentation PR created: <link>
