### PR TITLE
Improved resource templating

### DIFF
--- a/charts/ocis/docs/values.adoc.yaml
+++ b/charts/ocis/docs/values.adoc.yaml
@@ -614,7 +614,7 @@ autoscaling:
 resources:
   {}
   # limits:
-  # cpu: 100m
+  #   cpu: 100m
   #   memory: 128Mi
   # requests:
   #   cpu: 100m

--- a/charts/ocis/templates/_common/_tplvalues.tpl
+++ b/charts/ocis/templates/_common/_tplvalues.tpl
@@ -108,6 +108,8 @@ Adds the app names to the scope and set the name of the app based on the input p
   {{- if (index .scope.Values.services (index .scope .appName)) -}}
   {{- $_ := set .scope "appSpecificConfig" (index .scope.Values.services (index .scope .appName)) -}}
   {{- end -}}
+
+  {{- $_ := set .scope "resources" (default (default (dict) .scope.Values.resources) .scope.appSpecificConfig.resources) -}}
 {{- end -}}
 
 {{/*

--- a/charts/ocis/templates/antivirus/deployment.yaml
+++ b/charts/ocis/templates/antivirus/deployment.yaml
@@ -1,6 +1,5 @@
 {{ if .Values.features.virusscan.enabled }}
 {{- include "ocis.appNames" (dict "scope" . "appName" "appNameAntivirus" "appNameSuffix" "") -}}
-{{- $_ := set . "resources" (default (default (dict) .Values.resources) .Values.services.antivirus.resources) -}}
 apiVersion: apps/v1
 kind: Deployment
 {{ include "ocis.metadata" . }}

--- a/charts/ocis/templates/appprovider/deployment.yaml
+++ b/charts/ocis/templates/appprovider/deployment.yaml
@@ -2,7 +2,6 @@
 {{- range $officeSuite := .Values.features.appsIntegration.wopiIntegration.officeSuites }}
 {{ if $officeSuite.enabled }}
 {{- include "ocis.appNames" (dict "scope" $ "appName" "appNameAppProvider" "appNameSuffix" (regexReplaceAll "\\W+" (lower $officeSuite.name) "-")) -}}
-{{- $_ := set $ "resources" (default (default (dict) $.Values.resources) $.Values.services.appprovider.resources) -}}
 ---
 apiVersion: apps/v1
 kind: Deployment

--- a/charts/ocis/templates/appregistry/deployment.yaml
+++ b/charts/ocis/templates/appregistry/deployment.yaml
@@ -1,5 +1,4 @@
 {{- include "ocis.appNames" (dict "scope" . "appName" "appNameAppRegistry" "appNameSuffix" "") -}}
-{{- $_ := set . "resources" (default (default (dict) .Values.resources) .Values.services.appregistry.resources) -}}
 apiVersion: apps/v1
 kind: Deployment
 {{ include "ocis.metadata" . }}

--- a/charts/ocis/templates/audit/deployment.yaml
+++ b/charts/ocis/templates/audit/deployment.yaml
@@ -1,5 +1,4 @@
 {{- include "ocis.appNames" (dict "scope" . "appName" "appNameAudit" "appNameSuffix" "") -}}
-{{- $_ := set . "resources" (default (default (dict) .Values.resources) .Values.services.audit.resources) -}}
 apiVersion: apps/v1
 kind: Deployment
 {{ include "ocis.metadata" . }}

--- a/charts/ocis/templates/authbasic/deployment.yaml
+++ b/charts/ocis/templates/authbasic/deployment.yaml
@@ -1,6 +1,5 @@
 {{ if .Values.features.basicAuthentication }}
 {{- include "ocis.appNames" (dict "scope" . "appName" "appNameAuthBasic" "appNameSuffix" "") -}}
-{{- $_ := set . "resources" (default (default (dict) .Values.resources) .Values.services.authbasic.resources) -}}
 apiVersion: apps/v1
 kind: Deployment
 {{ include "ocis.metadata" . }}

--- a/charts/ocis/templates/authmachine/deployment.yaml
+++ b/charts/ocis/templates/authmachine/deployment.yaml
@@ -1,5 +1,4 @@
 {{- include "ocis.appNames" (dict "scope" . "appName" "appNameAuthMachine" "appNameSuffix" "") -}}
-{{- $_ := set . "resources" (default (default (dict) .Values.resources) .Values.services.authmachine.resources) -}}
 apiVersion: apps/v1
 kind: Deployment
 {{ include "ocis.metadata" . }}

--- a/charts/ocis/templates/eventhistory/deployment.yaml
+++ b/charts/ocis/templates/eventhistory/deployment.yaml
@@ -1,5 +1,4 @@
 {{- include "ocis.appNames" (dict "scope" . "appName" "appNameEventhistory" "appNameSuffix" "") -}}
-{{- $_ := set . "resources" (default (default (dict) .Values.resources) .Values.services.eventhistory.resources) -}}
 {{- $_ := set . "store" (default (default (dict) .Values.store) .Values.services.eventhistory.store) -}}
 apiVersion: apps/v1
 kind: Deployment

--- a/charts/ocis/templates/frontend/deployment.yaml
+++ b/charts/ocis/templates/frontend/deployment.yaml
@@ -1,5 +1,4 @@
 {{- include "ocis.appNames" (dict "scope" . "appName" "appNameFrontend" "appNameSuffix" "") -}}
-{{- $_ := set . "resources" (default (default (dict) .Values.resources) .Values.services.frontend.resources) -}}
 apiVersion: apps/v1
 kind: Deployment
 {{ include "ocis.metadata" . }}

--- a/charts/ocis/templates/gateway/deployment.yaml
+++ b/charts/ocis/templates/gateway/deployment.yaml
@@ -1,5 +1,4 @@
 {{- include "ocis.appNames" (dict "scope" . "appName" "appNameGateway" "appNameSuffix" "") -}}
-{{- $_ := set . "resources" (default (default (dict) .Values.resources) .Values.services.gateway.resources) -}}
 apiVersion: apps/v1
 kind: Deployment
 {{ include "ocis.metadata" . }}

--- a/charts/ocis/templates/graph/deployment.yaml
+++ b/charts/ocis/templates/graph/deployment.yaml
@@ -1,5 +1,4 @@
 {{- include "ocis.appNames" (dict "scope" . "appName" "appNameGraph" "appNameSuffix" "") -}}
-{{- $_ := set . "resources" (default (default (dict) .Values.resources) .Values.services.graph.resources) -}}
 apiVersion: apps/v1
 kind: Deployment
 {{ include "ocis.metadata" . }}

--- a/charts/ocis/templates/groups/deployment.yaml
+++ b/charts/ocis/templates/groups/deployment.yaml
@@ -1,5 +1,4 @@
 {{- include "ocis.appNames" (dict "scope" . "appName" "appNameGroups" "appNameSuffix" "") -}}
-{{- $_ := set . "resources" (default (default (dict) .Values.resources) .Values.services.groups.resources) -}}
 apiVersion: apps/v1
 kind: Deployment
 {{ include "ocis.metadata" . }}

--- a/charts/ocis/templates/idm/deployment.yaml
+++ b/charts/ocis/templates/idm/deployment.yaml
@@ -1,6 +1,5 @@
 {{- if not .Values.features.externalUserManagement.enabled }}
 {{- include "ocis.appNames" (dict "scope" . "appName" "appNameIdm" "appNameSuffix" "") -}}
-{{- $_ := set . "resources" (default (default (dict) .Values.resources) .Values.services.idm.resources) -}}
 apiVersion: apps/v1
 kind: Deployment
 {{ include "ocis.metadata" . }}

--- a/charts/ocis/templates/idp/deployment.yaml
+++ b/charts/ocis/templates/idp/deployment.yaml
@@ -1,6 +1,5 @@
 {{- if not .Values.features.externalUserManagement.enabled }}
 {{- include "ocis.appNames" (dict "scope" . "appName" "appNameIdp" "appNameSuffix" "") -}}
-{{- $_ := set . "resources" (default (default (dict) .Values.resources) .Values.services.idp.resources) -}}
 apiVersion: apps/v1
 kind: Deployment
 {{ include "ocis.metadata" . }}

--- a/charts/ocis/templates/nats/deployment.yaml
+++ b/charts/ocis/templates/nats/deployment.yaml
@@ -1,6 +1,5 @@
 {{- if not .Values.messagingSystem.external.enabled }}
 {{- include "ocis.appNames" (dict "scope" . "appName" "appNameNats" "appNameSuffix" "") -}}
-{{- $_ := set . "resources" (default (default (dict) .Values.resources) .Values.services.nats.resources) -}}
 apiVersion: apps/v1
 kind: Deployment
 {{ include "ocis.metadata" . }}

--- a/charts/ocis/templates/notifications/deployment.yaml
+++ b/charts/ocis/templates/notifications/deployment.yaml
@@ -1,6 +1,5 @@
 {{- if .Values.features.emailNotifications.enabled }}
 {{- include "ocis.appNames" (dict "scope" . "appName" "appNameNotifications" "appNameSuffix" "") -}}
-{{- $_ := set . "resources" (default (default (dict) .Values.resources) .Values.services.notifications.resources) -}}
 apiVersion: apps/v1
 kind: Deployment
 {{ include "ocis.metadata" . }}

--- a/charts/ocis/templates/ocdav/deployment.yaml
+++ b/charts/ocis/templates/ocdav/deployment.yaml
@@ -1,5 +1,4 @@
 {{- include "ocis.appNames" (dict "scope" . "appName" "appNameOcdav" "appNameSuffix" "") -}}
-{{- $_ := set . "resources" (default (default (dict) .Values.resources) .Values.services.ocdav.resources) -}}
 apiVersion: apps/v1
 kind: Deployment
 {{ include "ocis.metadata" . }}

--- a/charts/ocis/templates/ocs/deployment.yaml
+++ b/charts/ocis/templates/ocs/deployment.yaml
@@ -1,5 +1,4 @@
 {{- include "ocis.appNames" (dict "scope" . "appName" "appNameOcs" "appNameSuffix" "") -}}
-{{- $_ := set . "resources" (default (default (dict) .Values.resources) .Values.services.ocs.resources) -}}
 apiVersion: apps/v1
 kind: Deployment
 {{ include "ocis.metadata" . }}

--- a/charts/ocis/templates/policies/deployment.yaml
+++ b/charts/ocis/templates/policies/deployment.yaml
@@ -1,6 +1,5 @@
 {{ if .Values.features.policies.enabled }}
 {{- include "ocis.appNames" (dict "scope" . "appName" "appNamePolicies" "appNameSuffix" "") -}}
-{{- $_ := set . "resources" (default (default (dict) .Values.resources) .Values.services.policies.resources) -}}
 apiVersion: apps/v1
 kind: Deployment
 metadata:

--- a/charts/ocis/templates/postprocessing/deployment.yaml
+++ b/charts/ocis/templates/postprocessing/deployment.yaml
@@ -1,5 +1,4 @@
 {{- include "ocis.appNames" (dict "scope" . "appName" "appNamePostprocessing" "appNameSuffix" "") -}}
-{{- $_ := set . "resources" (default (default (dict) .Values.resources) .Values.services.postprocessing.resources) -}}
 {{- $_ := set . "store" (default (default (dict) .Values.store) .Values.services.postprocessing.store) -}}
 apiVersion: apps/v1
 kind: Deployment

--- a/charts/ocis/templates/proxy/deployment.yaml
+++ b/charts/ocis/templates/proxy/deployment.yaml
@@ -1,5 +1,4 @@
 {{- include "ocis.appNames" (dict "scope" . "appName" "appNameProxy" "appNameSuffix" "") -}}
-{{- $_ := set . "resources" (default (default (dict) .Values.resources) .Values.services.proxy.resources) -}}
 apiVersion: apps/v1
 kind: Deployment
 {{ include "ocis.metadata" . }}

--- a/charts/ocis/templates/search/deployment.yaml
+++ b/charts/ocis/templates/search/deployment.yaml
@@ -1,5 +1,4 @@
 {{- include "ocis.appNames" (dict "scope" . "appName" "appNameSearch" "appNameSuffix" "") -}}
-{{- $_ := set . "resources" (default (default (dict) .Values.resources) .Values.services.search.resources) -}}
 apiVersion: apps/v1
 kind: Deployment
 {{ include "ocis.metadata" . }}

--- a/charts/ocis/templates/settings/deployment.yaml
+++ b/charts/ocis/templates/settings/deployment.yaml
@@ -1,5 +1,4 @@
 {{- include "ocis.appNames" (dict "scope" . "appName" "appNameSettings" "appNameSuffix" "") -}}
-{{- $_ := set . "resources" (default (default (dict) .Values.resources) .Values.services.settings.resources) -}}
 apiVersion: apps/v1
 kind: Deployment
 {{ include "ocis.metadata" . }}

--- a/charts/ocis/templates/sharing/deployment.yaml
+++ b/charts/ocis/templates/sharing/deployment.yaml
@@ -1,5 +1,4 @@
 {{- include "ocis.appNames" (dict "scope" . "appName" "appNameSharing" "appNameSuffix" "") -}}
-{{- $_ := set . "resources" (default (default (dict) .Values.resources) .Values.services.sharing.resources) -}}
 apiVersion: apps/v1
 kind: Deployment
 {{ include "ocis.metadata" . }}

--- a/charts/ocis/templates/storagepubliclink/deployment.yaml
+++ b/charts/ocis/templates/storagepubliclink/deployment.yaml
@@ -1,5 +1,4 @@
 {{- include "ocis.appNames" (dict "scope" . "appName" "appNameStoragePubliclink" "appNameSuffix" "") -}}
-{{- $_ := set . "resources" (default (default (dict) .Values.resources) .Values.services.storagepubliclink.resources) -}}
 apiVersion: apps/v1
 kind: Deployment
 {{ include "ocis.metadata" . }}

--- a/charts/ocis/templates/storageshares/deployment.yaml
+++ b/charts/ocis/templates/storageshares/deployment.yaml
@@ -1,5 +1,4 @@
 {{- include "ocis.appNames" (dict "scope" . "appName" "appNameStorageShares" "appNameSuffix" "") -}}
-{{- $_ := set . "resources" (default (default (dict) .Values.resources) .Values.services.storageshares.resources) -}}
 apiVersion: apps/v1
 kind: Deployment
 {{ include "ocis.metadata" . }}

--- a/charts/ocis/templates/storagesystem/deployment.yaml
+++ b/charts/ocis/templates/storagesystem/deployment.yaml
@@ -1,5 +1,4 @@
 {{- include "ocis.appNames" (dict "scope" . "appName" "appNameStorageSystem" "appNameSuffix" "") -}}
-{{- $_ := set . "resources" (default (default (dict) .Values.resources) .Values.services.storagesystem.resources) -}}
 apiVersion: apps/v1
 kind: Deployment
 {{ include "ocis.metadata" . }}

--- a/charts/ocis/templates/storageusers/deployment.yaml
+++ b/charts/ocis/templates/storageusers/deployment.yaml
@@ -1,5 +1,4 @@
 {{- include "ocis.appNames" (dict "scope" . "appName" "appNameStorageUsers" "appNameSuffix" "") -}}
-{{- $_ := set . "resources" (default (default (dict) .Values.resources) .Values.services.storageusers.resources) -}}
 apiVersion: apps/v1
 kind: Deployment
 {{ include "ocis.metadata" . }}

--- a/charts/ocis/templates/store/deployment.yaml
+++ b/charts/ocis/templates/store/deployment.yaml
@@ -1,5 +1,4 @@
 {{- include "ocis.appNames" (dict "scope" . "appName" "appNameStore" "appNameSuffix" "") -}}
-{{- $_ := set . "resources" (default (default (dict) .Values.resources) .Values.services.store.resources) -}}
 apiVersion: apps/v1
 kind: Deployment
 {{ include "ocis.metadata" . }}

--- a/charts/ocis/templates/thumbnails/deployment.yaml
+++ b/charts/ocis/templates/thumbnails/deployment.yaml
@@ -1,5 +1,4 @@
 {{- include "ocis.appNames" (dict "scope" . "appName" "appNameThumbnails" "appNameSuffix" "") -}}
-{{- $_ := set . "resources" (default (default (dict) .Values.resources) .Values.services.thumbnails.resources) -}}
 apiVersion: apps/v1
 kind: Deployment
 {{ include "ocis.metadata" . }}

--- a/charts/ocis/templates/userlog/deployment.yaml
+++ b/charts/ocis/templates/userlog/deployment.yaml
@@ -1,5 +1,4 @@
 {{- include "ocis.appNames" (dict "scope" . "appName" "appNameUserlog" "appNameSuffix" "") -}}
-{{- $_ := set . "resources" (default (default (dict) .Values.resources) .Values.services.userlog.resources) -}}
 {{- $_ := set . "store" (default (default (dict) .Values.store) .Values.services.userlog.store) -}}
 apiVersion: apps/v1
 kind: Deployment

--- a/charts/ocis/templates/users/deployment.yaml
+++ b/charts/ocis/templates/users/deployment.yaml
@@ -1,5 +1,4 @@
 {{- include "ocis.appNames" (dict "scope" . "appName" "appNameUsers" "appNameSuffix" "") -}}
-{{- $_ := set . "resources" (default (default (dict) .Values.resources) .Values.services.users.resources) -}}
 apiVersion: apps/v1
 kind: Deployment
 {{ include "ocis.metadata" . }}

--- a/charts/ocis/templates/web/deployment.yaml
+++ b/charts/ocis/templates/web/deployment.yaml
@@ -1,5 +1,4 @@
 {{- include "ocis.appNames" (dict "scope" . "appName" "appNameWeb" "appNameSuffix" "") -}}
-{{- $_ := set . "resources" (default (default (dict) .Values.resources) .Values.services.web.resources) -}}
 apiVersion: apps/v1
 kind: Deployment
 {{ include "ocis.metadata" . }}

--- a/charts/ocis/templates/webdav/deployment.yaml
+++ b/charts/ocis/templates/webdav/deployment.yaml
@@ -1,5 +1,4 @@
 {{- include "ocis.appNames" (dict "scope" . "appName" "appNameWebdav" "appNameSuffix" "") -}}
-{{- $_ := set . "resources" (default (default (dict) .Values.resources) .Values.services.webdav.resources) -}}
 apiVersion: apps/v1
 kind: Deployment
 {{ include "ocis.metadata" . }}

--- a/charts/ocis/values.yaml
+++ b/charts/ocis/values.yaml
@@ -613,7 +613,7 @@ autoscaling:
 resources:
   {}
   # limits:
-  # cpu: 100m
+  #   cpu: 100m
   #   memory: 128Mi
   # requests:
   #   cpu: 100m


### PR DESCRIPTION
## Description
This PR improves the resource templating. So resources are no more set in every `deployment.yaml` but rather in the `ocis.appNames` template included in every `deployment.yaml

## Related Issue
- Fixes #328

## Motivation and Context
Feature Request

## How Has This Been Tested?
Tested with `helm template` and the following values yaml

```YAML
services:
  antivirus:
    resources:
      limits:
        cpu: 100m
        memory: 128Mi
      requests:
          cpu: 100m
          memory: 128Mi

resources:
  limits:
    cpu: 200m
    memory: 128Mi
  requests:
      cpu: 100m
      memory: 128Mi
```

## Types of changes
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [x] Technical debt
- [ ] Tests only (no source changes)

## Checklist:
- [x] Code changes
- [ ] Unit tests added
- [ ] Acceptance tests added
- [x] Documentation generated (`make docs`) and committed
- [ ] Documentation ticket raised: <link>
- [ ] Documentation PR created: <link>
