### PR TITLE
support post logout redirect uri configuration

### DIFF
--- a/charts/ocis/docs/values.adoc.yaml
+++ b/charts/ocis/docs/values.adoc.yaml
@@ -1482,6 +1482,8 @@ services:
         server: ""
         # -- URL path to load themes from. The theme server will be prepended. Defaults to the ownCloud Web default theme.
         path: ""
+      # URI where to redirect the user after a logout was performed. Defaults to the URI of the login page.
+      postLogoutRedirectURI: ""
 
     # -- Persistence settings.
     # @default -- see detailed persistence configuration options below

--- a/charts/ocis/templates/web/deployment.yaml
+++ b/charts/ocis/templates/web/deployment.yaml
@@ -85,6 +85,11 @@ spec:
               value: {{ . | quote }}
             {{- end }}
 
+            {{- with .Values.services.web.config.postLogoutRedirectURI }}
+            - name: WEB_OIDC_POST_LOGOUT_REDIRECT_URI
+              value: {{ . | quote }}
+            {{- end }}
+
             - name: WEB_JWT_SECRET
               valueFrom:
                 secretKeyRef:

--- a/charts/ocis/values.yaml
+++ b/charts/ocis/values.yaml
@@ -1481,6 +1481,8 @@ services:
         server: ""
         # -- URL path to load themes from. The theme server will be prepended. Defaults to the ownCloud Web default theme.
         path: ""
+      # URI where to redirect the user after a logout was performed. Defaults to the URI of the login page.
+      postLogoutRedirectURI: ""
 
     # -- Persistence settings.
     # @default -- see detailed persistence configuration options below


### PR DESCRIPTION
## Description
support the post logout uri configuration for oC Web.
Needs oCIS 3.0.0-next.3 release (or "latest" including https://github.com/owncloud/ocis/pull/6583)

## Related Issue
- fixes https://github.com/owncloud/ocis-charts/issues/337

## Motivation and Context

## How Has This Been Tested?
- set postLogoutRedirectURI in the external-user-management example and allow the redirect uri in the Web OIDC client settings in Keycloak

## Screenshots (if appropriate):

## Types of changes
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Technical debt
- [ ] Tests only (no source changes)

## Checklist:
- [x] Code changes
- [ ] Unit tests added
- [ ] Acceptance tests added
- [x] Documentation generated (`make docs`) and committed
- [ ] Documentation ticket raised: <link>
- [ ] Documentation PR created: <link>
