### PR TITLE
fix store update strategy

### DIFF
--- a/charts/ocis/templates/store/deployment.yaml
+++ b/charts/ocis/templates/store/deployment.yaml
@@ -5,7 +5,8 @@ kind: Deployment
 spec:
   {{- include "ocis.selector" . | nindent 2 }}
   replicas: 1 #TODO: https://github.com/owncloud/ocis-charts/issues/113
-  {{- include "ocis.deploymentStrategy" . | nindent 2 }}
+  strategy:
+    type: Recreate
   template:
     {{- include "ocis.templateMetadata" (dict "scope" $ "configCheck" false) | nindent 4 }}
     spec:


### PR DESCRIPTION
## Description
The store needs a static update strategy recreate because it is not scalable and thus will probably use RWO storage.
In this case the new pod will be probably pending forever because the RWO volume might be mounted on a differnt node.

## Related Issue

## Motivation and Context
have no pending pods when using RWO volumes

## How Has This Been Tested?
- none

## Screenshots (if appropriate):

## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Technical debt
- [ ] Tests only (no source changes)

## Checklist:
- [x] Code changes
- [ ] Unit tests added
- [ ] Acceptance tests added
- [ ] Documentation generated (`make docs`) and committed
- [ ] Documentation ticket raised: <link>
- [ ] Documentation PR created: <link>
