### PR TITLE
add echo for newline after printed password

### DIFF
--- a/charts/ocis/templates/NOTES.txt
+++ b/charts/ocis/templates/NOTES.txt
@@ -16,7 +16,7 @@ You're now running
 
 You can get the initial "admin" administrator user password by running:
 
-kubectl -n {{ .Release.Namespace }} get secrets/admin-user --template='{{"{{"}}.data.password | base64decode{{"}}"}}' ; echo
+kubectl -n {{ .Release.Namespace }} get secrets/admin-user --template='{{"{{"}}.data.password | base64decode | printf "%s\n" {{"}}"}}'
 
 {{ $noExternalUserManagement := not .Values.features.externalUserManagement.enabled -}}
 {{- $noopCache := eq .Values.cache.type "noop" -}}

--- a/deployments/development-install/README.md
+++ b/deployments/development-install/README.md
@@ -42,7 +42,7 @@ This will deploy all the needed steps.
 You can get the admin password with the following command:
 
 ```bash
-$ kubectl -n ocis get secret admin-user -o go-template --template="{{.data.password | base64decode }} ; echo"
+$ kubectl -n ocis get secrets/admin-user --template='{{.data.password | base64decode | printf "%s\n" }}'
 ```
 
 You can use this password to login with the user `admin`.

--- a/deployments/ocis-etcd/README.md
+++ b/deployments/ocis-etcd/README.md
@@ -42,7 +42,7 @@ This will deploy oCIS and etcd.
 You can get the admin password with the following command:
 
 ```bash
-$ kubectl -n ocis get secret admin-user -o go-template --template="{{.data.password | base64decode }} ; echo"
+$ kubectl -n ocis get secrets/admin-user --template='{{.data.password | base64decode | printf "%s\n" }}'
 ```
 
 You can use this password to login with the user `admin`.

--- a/deployments/ocis-redis/README.md
+++ b/deployments/ocis-redis/README.md
@@ -42,7 +42,7 @@ This will deploy oCIS and Redis.
 You can get the admin password with the following command:
 
 ```bash
-$ kubectl -n ocis get secret admin-user -o go-template --template="{{.data.password | base64decode }} ; echo"
+$ kubectl -n ocis get secrets/admin-user --template='{{.data.password | base64decode | printf "%s\n" }}'
 ```
 
 You can use this password to login with the user `admin`.


### PR DESCRIPTION
## Description
add a new line after the command that gets the initial admin password.

this changes the output from:

```
kubectl -n ocis get secrets/admin-user --template='{{.data.password | base64decode}}'       
CkBMbNuSJI%  
```

to 

```
$kubectl -n ocis get secrets/admin-user --template='{{.data.password | base64decode}}'       
CkBMbNuSJI
```

## Related Issue
- Fixes possible confusion when copying the proposed command to get the initial password

## Motivation and Context

## How Has This Been Tested?
- `helmfile sync` of any deployment example

## Screenshots (if appropriate):

## Types of changes
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Technical debt
- [ ] Tests only (no source changes)

## Checklist:
- [x] Code changes
- [ ] Unit tests added
- [ ] Acceptance tests added
- [ ] Documentation generated (`make docs`) and committed
- [ ] Documentation ticket raised: <link>
- [ ] Documentation PR created: <link>
