### PR TITLE
add shared cache for settings service according to latest loadtests

### DIFF
--- a/charts/ocis/docs/values-desc-table.adoc
+++ b/charts/ocis/docs/values-desc-table.adoc
@@ -40,8 +40,8 @@ a| [subs=-attributes]
 a| [subs=-attributes]
 +string+
 a| [subs=-attributes]
-`"noop"`
-| Type of the cache to use. To disable the cache, set to "noop". Can be set to "redis", "redis-sentinel" or "etcd", then the address of Redis (Sentinel) / etcd node(s) needs to be set to `cache.nodes`.
+`""`
+| Type of the cache to use. It defaults to no cache or a in memory cache depending on the service. To disable the cache, set to "noop". Can be set to "redis", "redis-sentinel" or "etcd", then the address of Redis (Sentinel) / etcd node(s) needs to be set to `cache.nodes`.
 | configRefs.graphConfigRef
 a| [subs=-attributes]
 +string+

--- a/charts/ocis/docs/values.adoc.yaml
+++ b/charts/ocis/docs/values.adoc.yaml
@@ -88,9 +88,10 @@ insecure:
   ocisHttpApiInsecure: false
 
 cache:
-  # -- Type of the cache to use. To disable the cache, set to "noop".
+  # -- Type of the cache to use. It defaults to no cache or a in memory cache depending on the service.
+  # To disable the cache, set to "noop".
   # Can be set to "redis", "redis-sentinel" or "etcd", then the address of Redis (Sentinel) / etcd node(s) needs to be set to `cache.nodes`.
-  type: noop
+  type: ""
   # -- Nodes of the cache to use.
   nodes: []
   # nodes:

--- a/charts/ocis/templates/graph/deployment.yaml
+++ b/charts/ocis/templates/graph/deployment.yaml
@@ -147,8 +147,8 @@ spec:
 
             # cache
             - name: GRAPH_CACHE_STORE
-              value: {{ .Values.cache.type | quote }}
-            {{- if ne .Values.cache.type "noop" }}
+              value: {{ default "noop" .Values.cache.type | quote }}
+            {{- if ne (default "noop" .Values.cache.type) "noop" }}
             - name: GRAPH_CACHE_STORE_NODES
               value: {{ join "," .Values.cache.nodes | quote }}
             {{- end }}

--- a/charts/ocis/templates/settings/deployment.yaml
+++ b/charts/ocis/templates/settings/deployment.yaml
@@ -44,8 +44,8 @@ spec:
 
             # cache
             - name: SETTINGS_CACHE_STORE
-              value: {{ .Values.cache.type | quote }}
-            {{- if ne .Values.cache.type "noop" }}
+              value: {{ default "memory" .Values.cache.type | quote }}
+            {{- if ne (default "memory" .Values.cache.type) "noop" }}
             - name: SETTINGS_CACHE_STORE_NODES
               value: {{ join "," .Values.cache.nodes | quote }}
             {{- end }}

--- a/charts/ocis/templates/settings/deployment.yaml
+++ b/charts/ocis/templates/settings/deployment.yaml
@@ -42,6 +42,14 @@ spec:
             - name: SETTINGS_DEBUG_PPROF
               value: {{ .Values.debug.profiling | quote }}
 
+            # cache
+            - name: SETTINGS_CACHE_STORE
+              value: {{ .Values.cache.type | quote }}
+            {{- if ne .Values.cache.type "noop" }}
+            - name: SETTINGS_CACHE_STORE_NODES
+              value: {{ join "," .Values.cache.nodes | quote }}
+            {{- end }}
+
             - name: SETTINGS_HTTP_ADDR
               value: 0.0.0.0:9190
             - name: SETTINGS_GRPC_ADDR

--- a/charts/ocis/templates/settings/deployment.yaml
+++ b/charts/ocis/templates/settings/deployment.yaml
@@ -45,7 +45,7 @@ spec:
             # cache
             - name: SETTINGS_CACHE_STORE
               value: {{ default "memory" .Values.cache.type | quote }}
-            {{- if ne (default "memory" .Values.cache.type) "noop" }}
+            {{- if not (has (default "memory" .Values.cache.type) (list "noop" "memory")) }}
             - name: SETTINGS_CACHE_STORE_NODES
               value: {{ join "," .Values.cache.nodes | quote }}
             {{- end }}

--- a/charts/ocis/templates/storagesystem/deployment.yaml
+++ b/charts/ocis/templates/storagesystem/deployment.yaml
@@ -74,8 +74,8 @@ spec:
 
             # cache
             - name: STORAGE_SYSTEM_CACHE_STORE
-              value: {{ .Values.cache.type | quote }}
-            {{- if ne .Values.cache.type "noop" }}
+              value: {{ default "noop" .Values.cache.type | quote }}
+            {{- if ne (default "noop" .Values.cache.type) "noop" }}
             - name: STORAGE_SYSTEM_CACHE_STORE_NODES
               value: {{ join "," .Values.cache.nodes | quote }}
             {{- end }}

--- a/charts/ocis/templates/storageusers/deployment.yaml
+++ b/charts/ocis/templates/storageusers/deployment.yaml
@@ -141,15 +141,15 @@ spec:
 
             # cache
             - name: STORAGE_USERS_FILEMETADATA_CACHE_STORE
-              value: {{ .Values.cache.type | quote }}
-            {{- if ne .Values.cache.type "noop" }}
+              value: {{ default "noop" .Values.cache.type | quote }}
+            {{- if ne (default "noop" .Values.cache.type) "noop" }}
             - name: STORAGE_USERS_FILEMETADATA_CACHE_STORE_NODES
               value: {{ join "," .Values.cache.nodes | quote }}
             {{- end }}
 
             - name: STORAGE_USERS_ID_CACHE_STORE
-              value: {{ .Values.cache.type | quote }}
-            {{- if ne .Values.cache.type "noop" }}
+              value: {{ default "noop" .Values.cache.type | quote }}
+            {{- if ne (default "noop" .Values.cache.type) "noop" }}
             - name: STORAGE_USERS_ID_CACHE_STORE_NODES
               value: {{ join "," .Values.cache.nodes | quote }}
             {{- end }}

--- a/charts/ocis/values.yaml
+++ b/charts/ocis/values.yaml
@@ -87,9 +87,10 @@ insecure:
   ocisHttpApiInsecure: false
 
 cache:
-  # -- Type of the cache to use. To disable the cache, set to "noop".
+  # -- Type of the cache to use. It defaults to no cache or a in memory cache depending on the service.
+  # To disable the cache, set to "noop".
   # Can be set to "redis", "redis-sentinel" or "etcd", then the address of Redis (Sentinel) / etcd node(s) needs to be set to `cache.nodes`.
-  type: noop
+  type: ""
   # -- Nodes of the cache to use.
   nodes: []
   # nodes:


### PR DESCRIPTION
## Description
Use whatever configured shared cache for the settings service, too. This makes it benefit from hot caches when scaling the settings service.

## Related Issue

## Motivation and Context
Better scaling of the settings service

## How Has This Been Tested?
- ocis-redis deployment example
- development-install deployment example
- 
## Screenshots (if appropriate):

## Types of changes
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Technical debt
- [ ] Tests only (no source changes)

## Checklist:
- [x] Code changes
- [ ] Unit tests added
- [ ] Acceptance tests added
- [x] Documentation generated (`make docs`) and committed
- [ ] Documentation ticket raised: <link>
- [ ] Documentation PR created: <link>
