### PR TITLE
Fix missing feature flag check for email template and uncomment tracing config

### DIFF
--- a/charts/ocis/templates/notifications/deployment.yaml
+++ b/charts/ocis/templates/notifications/deployment.yaml
@@ -32,14 +32,14 @@ spec:
               value: {{ .Values.logging.pretty | quote }}
 
             # Tracing not yet implemented: https://github.com/owncloud/ocis/issues/6175
-            # - name: NOTIFICATIONS_TRACING_ENABLED
-            #   value: "{{ .Values.tracing.enabled }}"
-            # - name: NOTIFICATIONS_TRACING_TYPE
-            #   value: {{ .Values.tracing.type | quote }}
-            # - name: NOTIFICATIONS_TRACING_ENDPOINT
-            #   value: {{ .Values.tracing.endpoint | quote }}
-            # - name: NOTIFICATIONS_TRACING_COLLECTOR
-            #   value: {{ .Values.tracing.collector | quote }}
+            - name: NOTIFICATIONS_TRACING_ENABLED
+              value: "{{ .Values.tracing.enabled }}"
+            - name: NOTIFICATIONS_TRACING_TYPE
+              value: {{ .Values.tracing.type | quote }}
+            - name: NOTIFICATIONS_TRACING_ENDPOINT
+              value: {{ .Values.tracing.endpoint | quote }}
+            - name: NOTIFICATIONS_TRACING_COLLECTOR
+              value: {{ .Values.tracing.collector | quote }}
 
             - name: NOTIFICATIONS_DEBUG_PPROF
               value: {{ .Values.debug.profiling | quote }}
@@ -100,9 +100,11 @@ spec:
                   name: {{ include "secrets.machineAuthAPIKeySecret" . }}
                   key: machine-auth-api-key
 
+            {{- if .Values.features.emailNotifications.branding.enabled }}
             # Mail theming
             - name: NOTIFICATIONS_EMAIL_TEMPLATE_PATH
               value: /etc/ocis/notifications
+            {{- end }}
 
           {{- include "ocis.livenessProbe" . | nindent 10 }}
 


### PR DESCRIPTION
<!--
Thanks for submitting a change to ownCloud!

This is the bug tracker for the oCIS Helm Chart.

For fixing potential security issues please see https://owncloud.org/security/

To make it possible for us to get your change reviewed and merged please carefully fill out the requested information below.

Please note that any kind of change needs to first be submitted to the master branch which holds the next version of the oCIS Helm Chart.

Please set the following labels:

- Set label "Status:Needs-Review" for review or "Status:In-Progress" if the PR still has open tasks.
- Assignment: assign to self
- Reviewers: pick at least one
-->

## Description
This adds missing check for branding with email templates and uncomments tracing the config.

## Motivation and Context
Notifications was broken because of missing flag. And we want to run tracing.

## How Has This Been Tested?
Tested on my local k3s cluster.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Technical debt
- [ ] Tests only (no source changes)

## Checklist:
<!-- Tick the checkboxes when done. -->
<!-- Raise documentation ticket in https://github.com/owncloud/docs-ocis/issues -->
<!-- or create documentation PR in https://github.com/owncloud/docs-ocis/tree/master/modules/ROOT/pages/deployment/container>
- [x] Code changes
- [ ] Unit tests added
- [ ] Acceptance tests added
- [ ] Documentation generated (`make docs`) and committed
- [ ] Documentation ticket raised: <link>
- [ ] Documentation PR created: <link>
