### PR TITLE
add fulltext search capability and extractor size limit

### DIFF
--- a/charts/ocis/docs/values-desc-table.adoc
+++ b/charts/ocis/docs/values-desc-table.adoc
@@ -1872,6 +1872,12 @@ a| [subs=-attributes]
 a| [subs=-attributes]
 see detailed search extractor configuration options below
 | Search Extractor settings.
+| services.search.extractor.sizeLimit
+a| [subs=-attributes]
++string+
+a| [subs=-attributes]
+`nil`
+| Configures the maximum file size in bytes that is allowed for content extraction. For the default value see https://doc.owncloud.com/ocis/next/deployment/services/s-list/search.html
 | services.search.extractor.tika.url
 a| [subs=-attributes]
 +string+

--- a/charts/ocis/docs/values.adoc.yaml
+++ b/charts/ocis/docs/values.adoc.yaml
@@ -1057,6 +1057,9 @@ services:
       # - `basic`: the default search extractor.
       # - `tika`: the Tika search extractor. If set to this value, additional settings in the `tika` section apply.
       type: basic
+      # -- Configures the maximum file size in bytes that is allowed for content extraction.
+      # For the default value see https://doc.owncloud.com/ocis/next/deployment/services/s-list/search.html
+      sizeLimit:
       tika:
         # -- Set the URL to Tika. Only applicable if `services.search.extractor.type` == `tika`.
         url: http://tika.tika.svc.cluster.local:9998

--- a/charts/ocis/templates/frontend/deployment.yaml
+++ b/charts/ocis/templates/frontend/deployment.yaml
@@ -84,6 +84,9 @@ spec:
             - name: FRONTEND_ARCHIVER_MAX_NUM_FILES
               value: {{ int64 .Values.features.archiver.maxNumFiles | quote }}
 
+            - name: FRONTEND_FULL_TEXT_SEARCH_ENABLED
+              value: {{ not (eq .Values.services.search.extractor.type "basic") | quote }}
+
             # cache
             # the stat cache is disabled for now for performance reasons, see https://github.com/owncloud/ocis-charts/issues/214
             - name: FRONTEND_OCS_STAT_CACHE_STORE

--- a/charts/ocis/templates/search/deployment.yaml
+++ b/charts/ocis/templates/search/deployment.yaml
@@ -68,6 +68,11 @@ spec:
               {{- end }}
             {{- end }}
 
+            {{- with .Values.services.search.extractor.sizeLimit }}
+            - name: SEARCH_CONTENT_EXTRACTION_SIZE_LIMIT
+              value: {{ int64 . | quote}}
+            {{- end }}
+
             {{- if  eq .Values.services.search.extractor.type "tika" }}
             - name: SEARCH_EXTRACTOR_TYPE
               value: tika

--- a/charts/ocis/values.yaml
+++ b/charts/ocis/values.yaml
@@ -1056,6 +1056,9 @@ services:
       # - `basic`: the default search extractor.
       # - `tika`: the Tika search extractor. If set to this value, additional settings in the `tika` section apply.
       type: basic
+      # -- Configures the maximum file size in bytes that is allowed for content extraction.
+      # For the default value see https://doc.owncloud.com/ocis/next/deployment/services/s-list/search.html
+      sizeLimit:
       tika:
         # -- Set the URL to Tika. Only applicable if `services.search.extractor.type` == `tika`.
         url: http://tika.tika.svc.cluster.local:9998

--- a/deployments/ocis-office/README.md
+++ b/deployments/ocis-office/README.md
@@ -2,11 +2,11 @@
 
 ## Introduction
 
-This example shows how to deploy oCIS with Collabora and OnlyOffice as Office.
-It will deploy an oCIS instance, Collabora and OnlyOffice, preconfigured to work together.
+This example shows how to deploy oCIS with Collabora and OnlyOffice as Office. It also brings Tika for fulltext search extraction.
+It will deploy an oCIS instance, Collabora and OnlyOffice and Tika, preconfigured to work together.
 
 ***Note***: This example is not intended for production use. It is intended to get a working oCIS
-with Collabora and OnlyOffice running in Kubernetes as quickly as possible. It is not hardened in any way.
+with Collabora, OnlyOffice and Tika running in Kubernetes as quickly as possible. It is not hardened in any way.
 
 ## Getting started
 
@@ -37,7 +37,7 @@ In this directory, run the following commands:
 $ helmfile sync
 ```
 
-This will deploy oCIS, the WOPI server, Collabora and OnlyOffice.
+This will deploy oCIS, Tika, the WOPI server, Collabora and OnlyOffice.
 
 ### Logging in
 

--- a/deployments/ocis-office/helmfile.yaml
+++ b/deployments/ocis-office/helmfile.yaml
@@ -1,5 +1,6 @@
 repositories:
-
+  - name: tika
+    url: https://apache.jfrog.io/artifactory/tika
   - name: cs3org
     url: https://cs3org.github.io/charts/
   - name: collabora
@@ -10,6 +11,10 @@ repositories:
     url: https://download.onlyoffice.com/charts/stable
 
 releases:
+
+  - name: tika
+    namespace: tika
+    chart: tika/tika
 
   - name: addons-onlyoffice
     chart: addons/onlyoffice
@@ -191,6 +196,10 @@ releases:
           search:
             persistence:
               enabled: true
+            extractor:
+              type: tika
+              tika:
+                url: http://tika.tika.svc.cluster.local:9998
 
           storagesystem:
             persistence:


### PR DESCRIPTION
## Description
Sets the fulltext search capability, which was missing until now.
Adds configuration for the search extractor size limit.

## Related Issue

## Motivation and Context

## How Has This Been Tested?
- tested with the oCIS with Office deployment example

## Screenshots (if appropriate):

## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Technical debt
- [ ] Tests only (no source changes)

## Checklist:
- [x] Code changes
- [ ] Unit tests added
- [ ] Acceptance tests added
- [x] Documentation generated (`make docs`) and committed
- [ ] Documentation ticket raised: <link>
- [ ] Documentation PR created: <link>
