### PR TITLE
disable policies postprocessing

### DIFF
--- a/charts/ocis/templates/postprocessing/deployment.yaml
+++ b/charts/ocis/templates/postprocessing/deployment.yaml
@@ -49,10 +49,12 @@ spec:
             - name: POSTPROCESSING_DEBUG_ADDR
               value: 0.0.0.0:9255
 
-            {{- $_ := set . "postprocessingSteps" list -}}
-            {{- if .Values.features.policies.enabled }}
-            {{- $_ := set . "postprocessingSteps" (append .postprocessingSteps "policies") -}}
-            {{- end }}
+            # We currently don't support enforcing policies as a postprocessing step.
+            # See https://github.com/owncloud/enterprise/issues/5919
+            # {{- $_ := set . "postprocessingSteps" list -}}
+            # {{- if .Values.features.policies.enabled }}
+            # {{- $_ := set . "postprocessingSteps" (append .postprocessingSteps "policies") -}}
+            # {{- end }}
             {{- if .Values.features.virusscan.enabled }}
             {{- $_ := set . "postprocessingSteps" (append .postprocessingSteps "virusscan") -}}
             {{- end }}


### PR DESCRIPTION
## Description
We're disabling policies in the postprocessing because it is currently not supported.

## Related Issue
- https://github.com/owncloud/enterprise/issues/5919

## Motivation and Context
Don't run unnecessary postprocessing steps

## How Has This Been Tested?

## Screenshots (if appropriate):

## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Technical debt
- [ ] Tests only (no source changes)

## Checklist:
- [x] Code changes
- [ ] Unit tests added
- [ ] Acceptance tests added
- [ ] Documentation generated (`make docs`) and committed
- [ ] Documentation ticket raised: <link>
- [ ] Documentation PR created: <link>
