### PR TITLE
fix #370

### DIFF
--- a/charts/ocis/templates/policies/deployment.yaml
+++ b/charts/ocis/templates/policies/deployment.yaml
@@ -48,8 +48,10 @@ spec:
               value: 0.0.0.0:9125
             - name: POLICIES_ENGINE_TIMEOUT
               value: {{ .Values.features.policies.engineTimeout | quote }}
-            - name: POLICIES_POSTPROCESSING_QUERY
-              value: "data.postprocessing.granted"
+            # We currently don't support enforcing policies as a postprocessing step.
+            # See https://github.com/owncloud/enterprise/issues/5919
+            # - name: POLICIES_POSTPROCESSING_QUERY
+            #   value: "data.postprocessing.granted"
             - name: POLICIES_EVENTS_ENDPOINT
             {{- if not .Values.messagingSystem.external.enabled }}
               value: {{ .appNameNats }}:9233

--- a/charts/ocis/templates/postprocessing/deployment.yaml
+++ b/charts/ocis/templates/postprocessing/deployment.yaml
@@ -50,9 +50,9 @@ spec:
               value: 0.0.0.0:9255
 
             {{- $_ := set . "postprocessingSteps" list -}}
+            {{/*
             # We currently don't support enforcing policies as a postprocessing step.
             # See https://github.com/owncloud/enterprise/issues/5919
-            {{/*
             {{- if .Values.features.policies.enabled }}
             {{- $_ := set . "postprocessingSteps" (append .postprocessingSteps "policies") -}}
             {{- end }}


### PR DESCRIPTION
## Description
fixes #370, it introduced a bug so that files will never leave the postprocessing state

## Related Issue
- fixes #370

## Motivation and Context

## How Has This Been Tested?
- office deployment example with policies configured

## Screenshots (if appropriate):

## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Technical debt
- [ ] Tests only (no source changes)

## Checklist:
- [x] Code changes
- [ ] Unit tests added
- [ ] Acceptance tests added
- [ ] Documentation generated (`make docs`) and committed
- [ ] Documentation ticket raised: <link>
- [ ] Documentation PR created: <link>
