### PR TITLE
Add missing tracing config to search service

### DIFF
--- a/charts/ocis/templates/search/deployment.yaml
+++ b/charts/ocis/templates/search/deployment.yaml
@@ -41,11 +41,21 @@ spec:
             - name: SEARCH_LOG_PRETTY
               value: {{ .Values.logging.pretty | quote }}
 
+            - name: SEARCH_GRPC_ADDR
+              value: 0.0.0.0:9220
+
+            - name: SEARCH_TRACING_ENABLED
+              value: "{{ .Values.tracing.enabled }}"
+            - name: SEARCH_TRACING_TYPE
+              value: {{ .Values.tracing.type | quote }}
+            - name: SEARCH_TRACING_ENDPOINT
+              value: {{ .Values.tracing.endpoint | quote }}
+            - name: SEARCH_TRACING_COLLECTOR
+              value: {{ .Values.tracing.collector | quote }}
+
             - name: SEARCH_DEBUG_PPROF
               value: {{ .Values.debug.profiling | quote }}
 
-            - name: SEARCH_GRPC_ADDR
-              value: 0.0.0.0:9220
             - name: SEARCH_DEBUG_ADDR
               value: 0.0.0.0:9224
 

--- a/charts/ocis/templates/search/deployment.yaml
+++ b/charts/ocis/templates/search/deployment.yaml
@@ -41,9 +41,6 @@ spec:
             - name: SEARCH_LOG_PRETTY
               value: {{ .Values.logging.pretty | quote }}
 
-            - name: SEARCH_GRPC_ADDR
-              value: 0.0.0.0:9220
-
             - name: SEARCH_TRACING_ENABLED
               value: "{{ .Values.tracing.enabled }}"
             - name: SEARCH_TRACING_TYPE
@@ -56,6 +53,8 @@ spec:
             - name: SEARCH_DEBUG_PPROF
               value: {{ .Values.debug.profiling | quote }}
 
+            - name: SEARCH_GRPC_ADDR
+              value: 0.0.0.0:9220
             - name: SEARCH_DEBUG_ADDR
               value: 0.0.0.0:9224
 


### PR DESCRIPTION
The search service was missing config for tracing. Added the proper env variables.
