### PR TITLE
harden appprovider health check

### DIFF
--- a/charts/ocis/templates/appprovider/deployment.yaml
+++ b/charts/ocis/templates/appprovider/deployment.yaml
@@ -84,7 +84,7 @@ spec:
               command:
               - /bin/sh
               - -c
-              - curl --silent --fail http://frontend:9140/app/list | grep {{ $officeSuite.name }}
+              - curl --silent --fail http://frontend:9140/app/list | grep '"name":"{{ $officeSuite.name }}"'
             timeoutSeconds: 10
             initialDelaySeconds: 60
             periodSeconds: 20


### PR DESCRIPTION
## Description
This hardens the app provider health check in situations where you have two Office suites configured.
Previously the health check would also match the `default_application` configuration which is not a sign for the app provider being registered properly.


## Related Issue
- Fixes app provider registration healtcheck when more than one office suite is used

## Motivation and Context

## How Has This Been Tested?
- deployment example with Office

## Screenshots (if appropriate):

## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Technical debt
- [ ] Tests only (no source changes)

## Checklist:
- [x] Code changes
- [ ] Unit tests added
- [ ] Acceptance tests added
- [ ] Documentation generated (`make docs`) and committed
- [ ] Documentation ticket raised: <link>
- [ ] Documentation PR created: <link>
