### PR TITLE
ensure compability to nats chart 1.0.0 and setup accounts

### DIFF
--- a/deployments/ocis-nats/helmfile.yaml
+++ b/deployments/ocis-nats/helmfile.yaml
@@ -7,12 +7,44 @@ releases:
     chart: nats/nats
     namespace: ocis-nats
     values:
-      - cluster:
-          enabled: true
-          name: "ocis-cluster"
-      - nats:
+      - config:
+          cluster:
+              enabled: true
+              replicas: 3
+              name: "ocis-cluster"
           jetstream:
             enabled: true
+            memoryStore:
+              enabled: true
+          websocket:
+            enabled: true
+
+      - config:
+          merge:
+            00$include: auth.conf
+
+      - configMap:
+          merge:
+            data:
+              auth.conf: |
+                accounts {
+                  $SYS {
+                    users = [
+                      { user: "nats-root",
+                        pass: "nats-root"
+                      }
+                    ]
+                  }
+                  $OCIS {
+                    jetstream: enabled
+                    users = [
+                      { user: "ocis",
+                        pass: "ocis"
+                      }
+                    ]
+                  }
+                }
+                no_auth_user: ocis
 
   - name: ocis
     chart: ../../charts/ocis

--- a/deployments/ocis-nats/helmfile.yaml
+++ b/deployments/ocis-nats/helmfile.yaml
@@ -14,10 +14,6 @@ releases:
               name: "ocis-cluster"
           jetstream:
             enabled: true
-            memoryStore:
-              enabled: true
-          websocket:
-            enabled: true
 
       - config:
           merge:

--- a/deployments/ocis-nats/helmfile.yaml
+++ b/deployments/ocis-nats/helmfile.yaml
@@ -22,20 +22,25 @@ releases:
       - configMap:
           merge:
             data:
+              # bcrypted password generated with `nats server passwd`:
+              # nats-sys: O0Z1O5WG2SIisXUToxUPxQUx
+              # ocis-admin: pwnnH3S42D5dZL90paHEsQop
               auth.conf: |
                 accounts {
                   $SYS {
                     users = [
-                      { user: "nats-root",
-                        pass: "nats-root"
+                      { user: "nats-sys",
+                        pass: "$2a$11$5BJO2C7WJLjuOm8FBjGjCugs//lL.Sp9gVIBWzU.fITE5MfCbHCMK"
                       }
                     ]
                   }
                   $OCIS {
                     jetstream: enabled
                     users = [
-                      { user: "ocis",
-                        pass: "ocis"
+                      { user: "ocis"
+                      },
+                      { user: "ocis-admin",
+                        pass: "$2a$11$6SAHUpN.m2TXOMSdSZVWsOjQ69VCQOBUmxD8FZ/aJpdvzSEOfRodC"
                       }
                     ]
                   }

--- a/deployments/ocis-nats/helmfile.yaml
+++ b/deployments/ocis-nats/helmfile.yaml
@@ -14,8 +14,6 @@ releases:
               name: "ocis-cluster"
           jetstream:
             enabled: true
-
-      - config:
           merge:
             00$include: auth.conf
 


### PR DESCRIPTION
## Description
Switches to valid configuration for the 1.0.0 NATS chart and sets up accounts so that nats-box can be used with an authenticated context (for debugging purposes).

## Related Issue

## Motivation and Context
Have nats-box at hand.

## How Has This Been Tested?
running the deployment example in minikube and using nats-box

## Screenshots (if appropriate):

## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Technical debt
- [ ] Tests only (no source changes)

## Checklist:
- [x] Code changes
- [ ] Unit tests added
- [ ] Acceptance tests added
- [ ] Documentation generated (`make docs`) and committed
- [ ] Documentation ticket raised: <link>
- [ ] Documentation PR created: <link>
