### PR TITLE
use nats also as cache in the nats deployment example

### DIFF
--- a/deployments/ocis-nats/helmfile.yaml
+++ b/deployments/ocis-nats/helmfile.yaml
@@ -97,6 +97,11 @@ releases:
           nodes:
             - nats.ocis-nats.svc.cluster.local:4222
 
+      - cache:
+          type: nats-js
+          nodes:
+            - nats.ocis-nats.svc.cluster.local:4222
+
       - store:
           type: nats-js
           nodes:

--- a/deployments/ocis-nats/streams/ocis.yaml
+++ b/deployments/ocis-nats/streams/ocis.yaml
@@ -15,6 +15,25 @@ spec:
 apiVersion: jetstream.nats.io/v1beta2
 kind: Stream
 metadata:
+  name: ocis
+spec:
+  name: OBJ_ocis
+  subjects:
+    - $O.ocis.C.>
+    - $O.ocis.M.>
+  replicas: 3
+  storage: file # TODO: default of oCIS is file, see https://github.com/owncloud/ocis/issues/7119
+  retention: limits
+  discard: old
+  duplicateWindow: "2m0s"
+  maxAge: "24m0s"
+  allowRollup: true
+  allowDirect: true
+  account: ocis-nats
+---
+apiVersion: jetstream.nats.io/v1beta2
+kind: Stream
+metadata:
   name: eventhistory
 spec:
   name: OBJ_eventhistory


### PR DESCRIPTION
## Description
Use NATS also as cache so it is used for everything possible in this example

## Related Issue
- Blocked by https://github.com/owncloud/ocis/issues/7049

## Motivation and Context
Have as less supporting processes as possible. In this example NATS is used as cache, store, messagebus and registry.

## How Has This Been Tested?
- run in minikube

## Screenshots (if appropriate):

## Types of changes
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Technical debt
- [ ] Tests only (no source changes)

## Checklist:
- [x] Code changes
- [ ] Unit tests added
- [ ] Acceptance tests added
- [ ] Documentation generated (`make docs`) and committed
- [ ] Documentation ticket raised: <link>
- [ ] Documentation PR created: <link>
