### PR TITLE
consolidate examples persistence settings

### DIFF
--- a/deployments/development-install/helmfile.yaml
+++ b/deployments/development-install/helmfile.yaml
@@ -25,48 +25,31 @@ releases:
           idm:
             persistence:
               enabled: true
-              chownInitContainer: true
-              accessModes:
-                - ReadWriteOnce
 
           nats:
             persistence:
               enabled: true
-              chownInitContainer: true
-              accessModes:
-                - ReadWriteOnce
 
           search:
             persistence:
               enabled: true
-              chownInitContainer: true
-              accessModes:
-                - ReadWriteOnce
 
           storagesystem:
             persistence:
               enabled: true
-              chownInitContainer: true
-              accessModes:
-                - ReadWriteOnce
 
           storageusers:
             persistence:
               enabled: true
-              chownInitContainer: true
-              accessModes:
-                - ReadWriteOnce
 
           store:
             persistence:
               enabled: true
-              chownInitContainer: true
-              accessModes:
-                - ReadWriteOnce
 
           thumbnails:
             persistence:
               enabled: true
-              chownInitContainer: true
-              accessModes:
-                - ReadWriteOnce
+
+          web:
+            persistence:
+              enabled: true

--- a/deployments/external-user-management/helmfile.yaml
+++ b/deployments/external-user-management/helmfile.yaml
@@ -384,43 +384,31 @@ releases:
           nats:
             persistence:
               enabled: true
-              chownInitContainer: true
-              accessModes:
-                - ReadWriteOnce
 
           search:
             persistence:
               enabled: true
-              chownInitContainer: true
-              accessModes:
-                - ReadWriteOnce
 
           storagesystem:
             persistence:
               enabled: true
-              chownInitContainer: true
-              accessModes:
-                - ReadWriteOnce
 
           storageusers:
             persistence:
               enabled: true
-              chownInitContainer: true
-              accessModes:
-                - ReadWriteOnce
+
           store:
             persistence:
               enabled: true
-              chownInitContainer: true
-              accessModes:
-                - ReadWriteOnce
 
           thumbnails:
             persistence:
               enabled: true
-              chownInitContainer: true
-              accessModes:
-                - ReadWriteOnce
+
+          web:
+            persistence:
+              enabled: true
+
 
       - extraResources:
           - |

--- a/deployments/ocis-mail/helmfile.yaml
+++ b/deployments/ocis-mail/helmfile.yaml
@@ -49,21 +49,18 @@ releases:
           idm:
             persistence:
               enabled: true
-              chownInitContainer: true
+
           nats:
             persistence:
               enabled: true
-              chownInitContainer: true
 
           search:
             persistence:
               enabled: true
-              chownInitContainer: true
 
           storagesystem:
             persistence:
               enabled: true
-              chownInitContainer: true
 
           storageusers:
             persistence:
@@ -72,14 +69,11 @@ releases:
           store:
             persistence:
               enabled: true
-              chownInitContainer: true
 
           thumbnails:
             persistence:
               enabled: true
-              chownInitContainer: true
 
           web:
             persistence:
               enabled: true
-              chownInitContainer: true


### PR DESCRIPTION
## Description
consolidates the persistence settings across deployment examples. Makes it possible to switch between them.

## Related Issue

## Motivation and Context
I want to switch between deployment examples wherever possible

## How Has This Been Tested?

## Screenshots (if appropriate):

## Types of changes
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Technical debt
- [ ] Tests only (no source changes)

## Checklist:
- [x] Code changes
- [ ] Unit tests added
- [ ] Acceptance tests added
- [ ] Documentation generated (`make docs`) and committed
- [ ] Documentation ticket raised: <link>
- [ ] Documentation PR created: <link>
