### PR TITLE
introduce wopiFolderURIPathTemplate setting

### DIFF
--- a/charts/ocis/docs/values-desc-table.adoc
+++ b/charts/ocis/docs/values-desc-table.adoc
@@ -180,6 +180,12 @@ a| [subs=-attributes]
 a| [subs=-attributes]
 `"https://{{ .Values.externalDomain }}"`
 | Base url to navigate back from the app to the containing folder in the file list.
+| features.appsIntegration.wopiIntegration.wopiFolderURIPathTemplate
+a| [subs=-attributes]
++string+
+a| [subs=-attributes]
+`nil`
+| Path template for the url to navigate back from the app to the containing folder in the file list. null uses the default value of oCIS, so that one also can set it to "" to not have a path template.
 | features.appsIntegration.wopiIntegration.wopiServerURI
 a| [subs=-attributes]
 +string+

--- a/charts/ocis/docs/values.adoc.yaml
+++ b/charts/ocis/docs/values.adoc.yaml
@@ -202,6 +202,9 @@ features:
       wopiServerURI: https://wopiserver.owncloud.test
       # -- Base url to navigate back from the app to the containing folder in the file list.
       wopiFolderURI: https://{{ .Values.externalDomain }}
+      # -- Path template for the url to navigate back from the app to the containing folder in the file list.
+      # null uses the default value of oCIS, so that one also can set it to "" to not have a path template.
+      wopiFolderURIPathTemplate: null
       # List of WOPI compliant office suites.
       officeSuites:
         - # -- Name of the office suite. Will be displayed to the users.

--- a/charts/ocis/templates/appprovider/deployment.yaml
+++ b/charts/ocis/templates/appprovider/deployment.yaml
@@ -72,6 +72,10 @@ spec:
               value: {{ $.Values.features.appsIntegration.wopiIntegration.wopiServerURI | quote }}
             - name: APP_PROVIDER_WOPI_FOLDER_URL_BASE_URL
               value: {{ tpl $.Values.features.appsIntegration.wopiIntegration.wopiFolderURI $ | quote }}
+            {{- if ne $.Values.features.appsIntegration.wopiIntegration.wopiFolderURIPathTemplate nil }}
+            - name: APP_PROVIDER_WOPI_FOLDER_URL_PATH_TEMPLATE
+              value: {{ $.Values.features.appsIntegration.wopiIntegration.wopiFolderURIPathTemplate | quote }}
+            {{- end }}
 
             - name: APP_PROVIDER_JWT_SECRET
               valueFrom:

--- a/charts/ocis/values.yaml
+++ b/charts/ocis/values.yaml
@@ -201,6 +201,9 @@ features:
       wopiServerURI: https://wopiserver.owncloud.test
       # -- Base url to navigate back from the app to the containing folder in the file list.
       wopiFolderURI: https://{{ .Values.externalDomain }}
+      # -- Path template for the url to navigate back from the app to the containing folder in the file list.
+      # null uses the default value of oCIS, so that one also can set it to "" to not have a path template.
+      wopiFolderURIPathTemplate: null
       # List of WOPI compliant office suites.
       officeSuites:
         - # -- Name of the office suite. Will be displayed to the users.


### PR DESCRIPTION
## Description
Allows on to set following:

```
features:
  wopiIntegration:
    wopiFolderURI: "/"
    wopiFolderURIPathTemplate: ""
```

This will remove the back button for eg. OnlyOffice. Behind the scences this makes BreadcrumbFolderUrl be not set.

## Related Issue
- Related to https://github.com/owncloud/enterprise/issues/5923

## Motivation and Context
Allow to remove the OnlyOffice back button

## How Has This Been Tested?
- office deployment example in minikube

## Screenshots (if appropriate):

## Types of changes
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Technical debt
- [ ] Tests only (no source changes)

## Checklist:
- [x] Code changes
- [ ] Unit tests added
- [ ] Acceptance tests added
- [x] Documentation generated (`make docs`) and committed
- [ ] Documentation ticket raised: <link>
- [ ] Documentation PR created: <link>
