### PR TITLE
fix clientlog restart loop

### DIFF
--- a/charts/ocis/templates/clientlog/deployment.yaml
+++ b/charts/ocis/templates/clientlog/deployment.yaml
@@ -45,8 +45,7 @@ spec:
             - name: CLIENTLOG_DEBUG_PPROF
               value: {{ .Values.debug.profiling | quote }}
 
-            # NOTE: change to CLIENTLOG... once fix has landed in master
-            - name: USERLOG_DEBUG_ADDR
+            - name: CLIENTLOG_DEBUG_ADDR
               value: 0.0.0.0:9260
 
             - name: CLIENTLOG_STORE


### PR DESCRIPTION
## Description
fixes the clientlog restart loop by making the healtcheck work again

## Related Issue
- Fixes parts of https://github.com/owncloud/ocis-charts/issues/406

## Motivation and Context
improve next

## How Has This Been Tested?
- run oCIS and see no mor restarts

## Screenshots (if appropriate):

## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Technical debt
- [ ] Tests only (no source changes)

## Checklist:
- [x] Code changes
- [ ] Unit tests added
- [ ] Acceptance tests added
- [ ] Documentation generated (`make docs`) and committed
- [ ] Documentation ticket raised: <link>
- [ ] Documentation PR created: <link>
