### PR TITLE
remove auth machine secret where no longer needed

### DIFF
--- a/charts/ocis/templates/graph/deployment.yaml
+++ b/charts/ocis/templates/graph/deployment.yaml
@@ -192,12 +192,6 @@ spec:
               value: {{ .Values.features.quotas.default | quote }}
             {{- end }}
 
-            - name: USERLOG_MACHINE_AUTH_API_KEY
-              valueFrom:
-                secretKeyRef:
-                  name: {{ include "secrets.machineAuthAPIKeySecret" . }}
-                  key: machine-auth-api-key
-
             {{- if .Values.features.gdprReport.integrations.keycloak.enabled }}
             - name: GRAPH_KEYCLOAK_BASE_PATH
               value: {{ .Values.features.gdprReport.integrations.keycloak.basePath | quote }}

--- a/charts/ocis/templates/notifications/deployment.yaml
+++ b/charts/ocis/templates/notifications/deployment.yaml
@@ -97,12 +97,6 @@ spec:
               {{- end }}
             {{- end }}
 
-            - name: NOTIFICATIONS_MACHINE_AUTH_API_KEY
-              valueFrom:
-                secretKeyRef:
-                  name: {{ include "secrets.machineAuthAPIKeySecret" . }}
-                  key: machine-auth-api-key
-
             - name: NOTIFICATIONS_SERVICE_ACCOUNT_ID
               valueFrom:
                 configMapKeyRef:

--- a/charts/ocis/templates/ocs/deployment.yaml
+++ b/charts/ocis/templates/ocs/deployment.yaml
@@ -63,12 +63,6 @@ spec:
                   name: {{ include "secrets.jwtSecret" . }}
                   key: jwt-secret
 
-            - name: OCS_MACHINE_AUTH_API_KEY
-              valueFrom:
-                secretKeyRef:
-                  name: {{ include "secrets.machineAuthAPIKeySecret" . }}
-                  key: machine-auth-api-key
-
             {{- include "ocis.cors" . |nindent 12 }}
 
           {{- include "ocis.livenessProbe" . | nindent 10 }}

--- a/charts/ocis/templates/policies/deployment.yaml
+++ b/charts/ocis/templates/policies/deployment.yaml
@@ -78,11 +78,6 @@ spec:
                 secretKeyRef:
                   name: {{ include "secrets.jwtSecret" $ }}
                   key: jwt-secret
-            - name: POLICIES_MACHINE_AUTH_API_KEY
-              valueFrom:
-                secretKeyRef:
-                  name: {{ include "secrets.machineAuthAPIKeySecret" . }}
-                  key: machine-auth-api-key
 
             - name: POLICIES_DEBUG_PPROF
               value: {{ .Values.debug.profiling | quote }}

--- a/charts/ocis/templates/search/deployment.yaml
+++ b/charts/ocis/templates/search/deployment.yaml
@@ -105,12 +105,6 @@ spec:
                   name: {{ include "secrets.jwtSecret" . }}
                   key: jwt-secret
 
-            - name: SEARCH_MACHINE_AUTH_API_KEY
-              valueFrom:
-                secretKeyRef:
-                  name: {{ include "secrets.machineAuthAPIKeySecret" . }}
-                  key: machine-auth-api-key
-
             - name: SEARCH_SERVICE_ACCOUNT_ID
               valueFrom:
                 configMapKeyRef:

--- a/charts/ocis/templates/storageusers/deployment.yaml
+++ b/charts/ocis/templates/storageusers/deployment.yaml
@@ -132,12 +132,6 @@ spec:
             - name: STORAGE_USERS_PURGE_TRASH_BIN_PROJECT_DELETE_BEFORE
               value: {{ .Values.services.storageusers.maintenance.purgeExpiredTrashBinItems.projectDeleteBefore | quote }}
 
-            - name: OCIS_MACHINE_AUTH_API_KEY
-              valueFrom:
-                secretKeyRef:
-                  name: {{ include "secrets.machineAuthAPIKeySecret" . }}
-                  key: machine-auth-api-key
-
             - name: STORAGE_USERS_SERVICE_ACCOUNT_ID
               valueFrom:
                 configMapKeyRef:


### PR DESCRIPTION
## Description
by looking at the ocis code I removed the auth machine secrets where no longer needed

## Related Issue
- Fixes a part of https://github.com/owncloud/ocis-charts/issues/406

## Motivation and Context
- limit the scope of secrets

## How Has This Been Tested?
- only linting

## Screenshots (if appropriate):

## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Technical debt
- [ ] Tests only (no source changes)

## Checklist:
- [x] Code changes
- [ ] Unit tests added
- [ ] Acceptance tests added
- [ ] Documentation generated (`make docs`) and committed
- [ ] Documentation ticket raised: <link>
- [ ] Documentation PR created: <link>
