### PR TITLE
remove non existing AUTH_SERVICE_API_KEY

### DIFF
--- a/charts/ocis/templates/authservice/deployment.yaml
+++ b/charts/ocis/templates/authservice/deployment.yaml
@@ -56,12 +56,6 @@ spec:
                   name: {{ include "secrets.jwtSecret" . }}
                   key: jwt-secret
 
-            - name: AUTH_SERVICE_API_KEY
-              valueFrom:
-                secretKeyRef:
-                  name: {{ include "secrets.machineAuthAPIKeySecret" . }}
-                  key: machine-auth-api-key
-
             - name: AUTH_SERVICE_SERVICE_ACCOUNT_ID
               valueFrom:
                 configMapKeyRef:


### PR DESCRIPTION
## Description
I was looking at the code and AUTH_SERVICE_API_KEY just does not exist

## Related Issue
- Fixes a aprt of https://github.com/owncloud/ocis-charts/issues/406

## Motivation and Context

## How Has This Been Tested?

## Screenshots (if appropriate):

## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Technical debt
- [ ] Tests only (no source changes)

## Checklist:
- [x] Code changes
- [ ] Unit tests added
- [ ] Acceptance tests added
- [ ] Documentation generated (`make docs`) and committed
- [ ] Documentation ticket raised: <link>
- [ ] Documentation PR created: <link>
