### PR TITLE
switch to AUTH_SERVICE_JWT_SECRET

### DIFF
--- a/charts/ocis/docs/values-desc-table.adoc
+++ b/charts/ocis/docs/values-desc-table.adoc
@@ -802,7 +802,7 @@ a| [subs=-attributes]
 a| [subs=-attributes]
 +string+
 a| [subs=-attributes]
-`"c804f9b7120eebe276ec4d35975760e0d924fa197ba641e243ab22e118cec6ed"`
+`"7684100b5c469dbd311a92e2ce99c12f6f6dd390bb2088eb1c6a8b18a849c13e"`
 | Image sha / digest (optional).
 | image.tag
 a| [subs=-attributes]

--- a/charts/ocis/docs/values.adoc.yaml
+++ b/charts/ocis/docs/values.adoc.yaml
@@ -7,7 +7,7 @@ image:
   # -- Image tag. Defaults to the chart's appVersion.
   tag: "latest"
   # -- Image sha / digest (optional).
-  sha: "c804f9b7120eebe276ec4d35975760e0d924fa197ba641e243ab22e118cec6ed" # oCIS as of 18th October 2023
+  sha: "7684100b5c469dbd311a92e2ce99c12f6f6dd390bb2088eb1c6a8b18a849c13e" # oCIS as of 18th October 2023
   # -- Image pull policy
   pullPolicy: IfNotPresent
   # -- Names of the secret containing the credentials to pull an image from the registry. More
@@ -218,7 +218,8 @@ features:
       # the minimum amount of digits the password needs to have
       minDigits: 0
       # list of banned passwords
-      bannedPasswords: []
+      bannedPasswords:
+        []
         # - foo
         # - bar
   # Apps integration

--- a/charts/ocis/templates/authservice/deployment.yaml
+++ b/charts/ocis/templates/authservice/deployment.yaml
@@ -50,7 +50,7 @@ spec:
             - name: AUTH_SERVICE_DEBUG_ADDR
               value: 0.0.0.0:9617
 
-            - name: AUTH_MACHINE_JWT_SECRET
+            - name: AUTH_SERVICE_JWT_SECRET
               valueFrom:
                 secretKeyRef:
                   name: {{ include "secrets.jwtSecret" . }}

--- a/charts/ocis/values.yaml
+++ b/charts/ocis/values.yaml
@@ -6,7 +6,7 @@ image:
   # -- Image tag. Defaults to the chart's appVersion.
   tag: "latest"
   # -- Image sha / digest (optional).
-  sha: "c804f9b7120eebe276ec4d35975760e0d924fa197ba641e243ab22e118cec6ed" # oCIS as of 18th October 2023
+  sha: "7684100b5c469dbd311a92e2ce99c12f6f6dd390bb2088eb1c6a8b18a849c13e" # oCIS as of 18th October 2023
   # -- Image pull policy
   pullPolicy: IfNotPresent
   # -- Names of the secret containing the credentials to pull an image from the registry. More
@@ -217,7 +217,8 @@ features:
       # the minimum amount of digits the password needs to have
       minDigits: 0
       # list of banned passwords
-      bannedPasswords: []
+      bannedPasswords:
+        []
         # - foo
         # - bar
   # Apps integration


### PR DESCRIPTION
## Description
follow up of https://github.com/owncloud/ocis/pull/7523, to use the right env variable for auth service

## Related Issue
- Fixes a part of #406
- Follow up of https://github.com/owncloud/ocis/pull/7523

## Motivation and Context

## How Has This Been Tested?
- run it in minikube

## Screenshots (if appropriate):

## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Technical debt
- [ ] Tests only (no source changes)

## Checklist:
- [x] Code changes
- [ ] Unit tests added
- [ ] Acceptance tests added
- [ ] Documentation generated (`make docs`) and committed
- [ ] Documentation ticket raised: <link>
- [ ] Documentation PR created: <link>
