### PR TITLE
create antivirus service only if antivirus is used

### DIFF
--- a/charts/ocis/templates/antivirus/service.yaml
+++ b/charts/ocis/templates/antivirus/service.yaml
@@ -1,3 +1,4 @@
+{{ if .Values.features.virusscan.enabled }}
 {{- include "ocis.basicServiceTemplates" (dict "scope" . "appName" "appNameAntivirus" "appNameSuffix" "") -}}
 apiVersion: v1
 kind: Service
@@ -15,3 +16,4 @@ spec:
     - name: metrics-debug
       port: 9277
       protocol: TCP
+{{ end }}


### PR DESCRIPTION
## Description
creates the antivirus Service only when antivirus is used

## Related Issue
- Fixes #416

## Motivation and Context

## How Has This Been Tested?
- run in minikube:
  - installation with master has antivirus Service, even if not enabled
  - installation with this PR has no antivirus Service, when not enabled

## Screenshots (if appropriate):

## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Technical debt
- [ ] Tests only (no source changes)

## Checklist:
- [x] Code changes
- [ ] Unit tests added
- [ ] Acceptance tests added
- [ ] Documentation generated (`make docs`) and committed
- [ ] Documentation ticket raised: <link>
- [ ] Documentation PR created: <link>
