### PR TITLE
ci: cleanup starlark check

### DIFF
--- a/.drone.star
+++ b/.drone.star
@@ -171,20 +171,8 @@ def checkStarlark():
                 "image": "owncloudci/bazel-buildifier:latest",
                 "commands": [
                     "buildifier --mode=check .drone.star",
+                    "buildifier -d -diff_command='diff -u' .drone.star",
                 ],
-            },
-            {
-                "name": "show-diff",
-                "image": "owncloudci/bazel-buildifier:latest",
-                "commands": [
-                    "buildifier --mode=fix .drone.star",
-                    "git diff",
-                ],
-                "when": {
-                    "status": [
-                        "failure",
-                    ],
-                },
             },
         ],
         "depends_on": [],


### PR DESCRIPTION
## Description
This PR cleans up the starlark check in the CI. Similar to what we've done in https://github.com/owncloud-docker/helm-charts/pull/59. So the diff will be shown directly in the check step.

## Related Issue
- None

## Motivation and Context
Better visibility about what failed.

## How Has This Been Tested?
Working CI ;-) 

## Types of changes
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Technical debt
- [ ] Tests only (no source changes)

## Checklist:
- [ ] Code changes
- [ ] Unit tests added
- [ ] Acceptance tests added
- [ ] Documentation generated (`make docs`) and committed
- [ ] Documentation ticket raised: <link>
- [ ] Documentation PR created: <link>
