### PR TITLE
fix: regex in renovate.json was wrong

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -7,7 +7,7 @@
   "customManagers": [
     {
       "customType": "regex",
-      "fileMatch": ["^charts/ocis/.+Chart\\.ya?ml$"],
+      "fileMatch": ["^charts/.+Chart\\.ya?ml$"],
       "matchStrings": [
         "# renovate: datasource=(?<datasource>\\S+) depName=(?<depName>\\S+)( versioning=(?<versioning>.*?))?\\nappVersion:\\s?\\\"?(?<currentValue>.*?)\"?\\s"
       ]


### PR DESCRIPTION
## Description
This PR fixes the regex in `renovate.json` to that the docker image in Charts.yaml is checked automatically.

## Related Issue
- None

## Motivation and Context
Currently the ocis version of the chart was not checked against the ocis docker image version.

## How Has This Been Tested?
Manually

## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Technical debt
- [ ] Tests only (no source changes)

## Checklist:
- [ ] Code changes
- [ ] Unit tests added
- [ ] Acceptance tests added
- [ ] Documentation generated (`make docs`) and committed
- [ ] Documentation ticket raised: <link>
- [ ] Documentation PR created: <link>
