### PR TITLE
add docxf to allowed file types to create with OnlyOffice and pin chart versions

### DIFF
--- a/deployments/ocis-office/helmfile.yaml
+++ b/deployments/ocis-office/helmfile.yaml
@@ -11,10 +11,10 @@ repositories:
     url: https://download.onlyoffice.com/charts/stable
 
 releases:
-
   - name: tika
     namespace: tika
     chart: tika/tika
+    version: 2.9.0
     values:
       - image:
           tag: "latest-full" # using "full" tag for OCR func.
@@ -26,18 +26,22 @@ releases:
   - name: rabbitmq
     namespace: onlyoffice
     chart: bitnami/rabbitmq
+    version: 12.5.4
 
   - name: redis
     namespace: onlyoffice
     chart: bitnami/redis
+    version: 18.4.0
 
   - name: postgresql
     namespace: onlyoffice
     chart: bitnami/postgresql
+    version: 13.2.21
 
   - name: onlyoffice
     namespace: onlyoffice
     chart: onlyoffice/docs
+    version: 3.5.0
     needs:
       - onlyoffice/addons-onlyoffice
       - onlyoffice/rabbitmq
@@ -74,6 +78,7 @@ releases:
   - name: collabora
     namespace: collabora
     chart: collabora/collabora-online
+    version: 1.1.5
     values:
       - collabora:
           aliasgroups:
@@ -100,6 +105,7 @@ releases:
   - name: wopiserver
     namespace: wopiserver
     chart: cs3org/wopiserver
+    version: 0.9.2
     values:
       - wopiserverUrl: http://wopiserver.wopiserver.svc.cluster.local:8880
       - config:
@@ -183,6 +189,13 @@ releases:
                 extension: pptx
                 name: Presentation
                 description: Presentation
+                icon: image-edit
+                default_app: "OnlyOffice"
+                allow_creation: true
+              - mime_type: application/vnd.openxmlformats-officedocument.wordprocessingml.form
+                extension: docxf
+                name: FormDocument
+                description: Form document
                 icon: image-edit
                 default_app: "OnlyOffice"
                 allow_creation: true


### PR DESCRIPTION
## Description
- allow to create docxf files with OnlyOffice
- pins the Chart versions since we now have renovate

## Related Issue
- Possible after https://github.com/owncloud/ocis/pull/7781

## Motivation and Context
Allow create form documents


## How Has This Been Tested?
- I ran it in minikube

## Screenshots (if appropriate):

## Types of changes
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Technical debt
- [ ] Tests only (no source changes)

## Checklist:
- [x ] Code changes
- [ ] Unit tests added
- [ ] Acceptance tests added
- [ ] Documentation generated (`make docs`) and committed
- [ ] Documentation ticket raised: <link>
- [ ] Documentation PR created: <link>
