### PR TITLE
Solution for double ConfigMaps

### DIFF
--- a/charts/ocis/templates/sharing/config.yaml
+++ b/charts/ocis/templates/sharing/config.yaml
@@ -2,7 +2,7 @@
 apiVersion: v1
 kind: ConfigMap
 metadata:
-  name: sharing-banned-passwords
+  name: sharing-banned-passwords-{{ .appName }}
   namespace: {{ template "ocis.namespace" . }}
   labels:
     {{- include "ocis.labels" . | nindent 4 }}

--- a/charts/ocis/templates/sharing/deployment.yaml
+++ b/charts/ocis/templates/sharing/deployment.yaml
@@ -157,4 +157,4 @@ spec:
           {{ end }}
         - name: configs
           configMap:
-            name: sharing-banned-passwords
+            name: sharing-banned-passwords-{{ .appName }}


### PR DESCRIPTION
After a short discussion with Michael it turned out that the config will be removed from the frontend in the future. So I think for the meantime we could tolerate a doubled ConfigMap.

In this PR I added the needed changes to the sharing service as the name needs to be unique. I prefer adding the app name in the sharing service as 

1. every app-related ConfigMap should have the name of the app in it.
2. touching the frontend ConfigMap as well might leads to issues during upgrade of existing systems.
