### PR TITLE
support WEB_OPTION_USER_LIST_REQUIRES_FILTER

### DIFF
--- a/charts/ocis/docs/values.adoc.yaml
+++ b/charts/ocis/docs/values.adoc.yaml
@@ -1823,6 +1823,9 @@ services:
       privacyURL:
       # Specifies the login url
       loginURL:
+      # Defines whether one ore more filters must be set in order to list users in the Web admin settings.
+      userListRequiresFilter: false
+      # Embed mode settings
       embed:
         # Specifies if web "embed"-mode is enabled. Defaults to not being set (= disabled).
         enabled: ""

--- a/charts/ocis/templates/web/deployment.yaml
+++ b/charts/ocis/templates/web/deployment.yaml
@@ -137,6 +137,11 @@ spec:
               value: {{ . | quote }}
             {{- end }}
 
+            {{- with .Values.services.web.config.userListRequiresFilter }}
+            - name: WEB_OPTION_USER_LIST_REQUIRES_FILTER
+              value: {{ . | quote }}
+            {{- end }}
+
             - name: WEB_JWT_SECRET
               valueFrom:
                 secretKeyRef:

--- a/charts/ocis/values.yaml
+++ b/charts/ocis/values.yaml
@@ -1822,6 +1822,9 @@ services:
       privacyURL:
       # Specifies the login url
       loginURL:
+      # Defines whether one ore more filters must be set in order to list users in the Web admin settings.
+      userListRequiresFilter: false
+      # Embed mode settings
       embed:
         # Specifies if web "embed"-mode is enabled. Defaults to not being set (= disabled).
         enabled: ""


### PR DESCRIPTION
## Description
support WEB_OPTION_USER_LIST_REQUIRES_FILTER

## Related Issue
- add support for https://github.com/owncloud/ocis/pull/7866

## Motivation and Context

## How Has This Been Tested?
- in minikube:
```diff
diff --git a/deployments/development-install/helmfile.yaml b/deployments/development-install/helmfile.yaml
index a6353e7..a7f1f24 100644
--- a/deployments/development-install/helmfile.yaml
+++ b/deployments/development-install/helmfile.yaml
@@ -57,3 +57,6 @@ releases:
           web:
             persistence:
               enabled: true
+
+            config:
+              userListRequiresFilter: true
```

## Screenshots (if appropriate):

## Types of changes
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Technical debt
- [ ] Tests only (no source changes)

## Checklist:
- [x] Code changes
- [ ] Unit tests added
- [ ] Acceptance tests added
- [x] Documentation generated (`make docs`) and committed
- [ ] Documentation ticket raised: <link>
- [ ] Documentation PR created: <link>
