### PR TITLE
cors: sanitize input

### DIFF
--- a/charts/ocis/templates/_common/_tplvalues.tpl
+++ b/charts/ocis/templates/_common/_tplvalues.tpl
@@ -236,7 +236,7 @@ oCIS deployment CORS template
 {{- define "ocis.cors" -}}
 {{- if .Values.http.cors.allow_origins }}
 - name: OCIS_CORS_ALLOW_ORIGINS
-  value: {{ .Values.http.cors.allow_origins | join "," | quote }}
+  value: {{ without .Values.http.cors.allow_origins "" | join "," | quote }}
 {{- end }}
 {{- end -}}
 


### PR DESCRIPTION
## Description

Imagine input like:

```
# HTTP settings for oCIS services.
http:
  #-- CORS settings for oCIS services.
  cors:
    #-- allow_origins is a list of origins a cross-domain request can be executed from.
    # If the special "*" value is present in the list, all origins will be allowed.
    allow_origins:
      - "fooo"
      - ""
      - bar
      - ""
```

Even with this "dirty" input, the CORS settings will look great after this PR:

```
            - name: OCIS_CORS_ALLOW_ORIGINS
              value: "fooo,bar"
```

## Related Issue
- Improved behaviour for "dirty" inputs

## Motivation and Context

## How Has This Been Tested?
- `helmfile template` with the above CORS settings

## Screenshots (if appropriate):

## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Technical debt
- [ ] Tests only (no source changes)

## Checklist:
- [x] Code changes
- [ ] Unit tests added
- [ ] Acceptance tests added
- [ ] Documentation generated (`make docs`) and committed
- [ ] Documentation ticket raised: <link>
- [ ] Documentation PR created: <link>
