### PR TITLE
fix cors settings

### DIFF
--- a/charts/ocis/templates/clientlog/deployment.yaml
+++ b/charts/ocis/templates/clientlog/deployment.yaml
@@ -88,7 +88,6 @@ spec:
                 secretKeyRef:
                   name: {{ include "secrets.jwtSecret" . }}
                   key: jwt-secret
-            {{- include "ocis.cors" . |nindent 12 }}
 
           {{- include "ocis.livenessProbe" . | nindent 10 }}
 

--- a/charts/ocis/templates/frontend/deployment.yaml
+++ b/charts/ocis/templates/frontend/deployment.yaml
@@ -25,6 +25,7 @@ spec:
           {{- include "ocis.containerSecurityContext" . | nindent 10 }}
           env:
             {{- include "ocis.serviceRegistry" . | nindent 12 }}
+            {{- include "ocis.cors" . |nindent 12 }}
 
             - name: FRONTEND_LOG_COLOR
               value: {{ .Values.logging.color | quote }}
@@ -150,8 +151,6 @@ spec:
 
             - name: FRONTEND_AUTO_ACCEPT_SHARES
               value: {{ .Values.features.sharing.autoAcceptShares | quote }}
-
-            {{- include "ocis.cors" . |nindent 12 }}
 
             # password policies
             - name: FRONTEND_PASSWORD_POLICY_MIN_CHARACTERS

--- a/charts/ocis/templates/graph/deployment.yaml
+++ b/charts/ocis/templates/graph/deployment.yaml
@@ -25,6 +25,7 @@ spec:
           {{- include "ocis.containerSecurityContext" . | nindent 10 }}
           env:
             {{- include "ocis.serviceRegistry" . | nindent 12 }}
+            {{- include "ocis.cors" . |nindent 12 }}
 
             - name: GRAPH_LOG_COLOR
               value: {{ .Values.logging.color | quote }}
@@ -220,9 +221,6 @@ spec:
                 secretKeyRef:
                   name: {{ include "secrets.serviceAccountSecret" . }}
                   key: service-account-secret
-
-            {{- include "ocis.cors" . |nindent 12 }}
-
 
           {{- include "ocis.livenessProbe" . | nindent 10 }}
 

--- a/charts/ocis/templates/ocdav/deployment.yaml
+++ b/charts/ocis/templates/ocdav/deployment.yaml
@@ -25,6 +25,7 @@ spec:
           {{- include "ocis.containerSecurityContext" . | nindent 10 }}
           env:
             {{- include "ocis.serviceRegistry" . | nindent 12 }}
+            {{- include "ocis.cors" . |nindent 12 }}
 
             - name: OCDAV_LOG_COLOR
               value: {{ .Values.logging.color | quote }}
@@ -70,8 +71,6 @@ spec:
                 secretKeyRef:
                   name: {{ include "secrets.machineAuthAPIKeySecret" . }}
                   key: machine-auth-api-key
-
-            {{- include "ocis.cors" . |nindent 12 }}
 
           {{- include "ocis.livenessProbe" . | nindent 10 }}
 

--- a/charts/ocis/templates/ocs/deployment.yaml
+++ b/charts/ocis/templates/ocs/deployment.yaml
@@ -25,6 +25,7 @@ spec:
           {{- include "ocis.containerSecurityContext" . | nindent 10 }}
           env:
             {{- include "ocis.serviceRegistry" . | nindent 12 }}
+            {{- include "ocis.cors" . |nindent 12 }}
 
             - name: OCS_LOG_COLOR
               value: {{ .Values.logging.color | quote }}
@@ -62,8 +63,6 @@ spec:
                 secretKeyRef:
                   name: {{ include "secrets.jwtSecret" . }}
                   key: jwt-secret
-
-            {{- include "ocis.cors" . |nindent 12 }}
 
           {{- include "ocis.livenessProbe" . | nindent 10 }}
 

--- a/charts/ocis/templates/settings/deployment.yaml
+++ b/charts/ocis/templates/settings/deployment.yaml
@@ -25,6 +25,7 @@ spec:
           {{- include "ocis.containerSecurityContext" . | nindent 10 }}
           env:
             {{- include "ocis.serviceRegistry" . | nindent 12 }}
+            {{- include "ocis.cors" . |nindent 12 }}
 
             - name: OCIS_DEFAULT_LANGUAGE
               value: {{ default "en" .Values.features.language.default | quote }}
@@ -101,8 +102,6 @@ spec:
                 secretKeyRef:
                   name: {{ include "secrets.storageSystemSecret" . }}
                   key: user-id
-
-            {{- include "ocis.cors" . |nindent 12 }}
 
           {{- include "ocis.livenessProbe" . | nindent 10 }}
 

--- a/charts/ocis/templates/sse/deployment.yaml
+++ b/charts/ocis/templates/sse/deployment.yaml
@@ -27,6 +27,7 @@ spec:
           {{- include "ocis.containerSecurityContext" . | nindent 10 }}
           env:
             {{- include "ocis.serviceRegistry" . | nindent 12 }}
+            {{- include "ocis.cors" . |nindent 12 }}
 
             - name: SSE_LOG_COLOR
               value: {{ .Values.logging.color | quote }}
@@ -72,14 +73,12 @@ spec:
               value: "" # no cert needed
               {{- end }}
             {{- end }}
-            
+
             - name: SSE_JWT_SECRET
               valueFrom:
                 secretKeyRef:
                   name: {{ include "secrets.jwtSecret" . }}
                   key: jwt-secret
-            {{- include "ocis.cors" . |nindent 12 }}
-
 
             # {{- include "ocis.livenessProbe" . | nindent 10 }}
 

--- a/charts/ocis/templates/userlog/deployment.yaml
+++ b/charts/ocis/templates/userlog/deployment.yaml
@@ -26,7 +26,8 @@ spec:
           {{- include "ocis.containerSecurityContext" . | nindent 10 }}
           env:
             {{- include "ocis.serviceRegistry" . | nindent 12 }}
-            
+            {{- include "ocis.cors" . |nindent 12 }}
+
             - name: OCIS_DEFAULT_LANGUAGE
               value: {{ default "en" .Values.features.language.default | quote }}
 
@@ -104,7 +105,6 @@ spec:
                 secretKeyRef:
                   name: {{ include "secrets.jwtSecret" . }}
                   key: jwt-secret
-            {{- include "ocis.cors" . |nindent 12 }}
 
           {{- include "ocis.livenessProbe" . | nindent 10 }}
 

--- a/charts/ocis/templates/web/deployment.yaml
+++ b/charts/ocis/templates/web/deployment.yaml
@@ -25,6 +25,7 @@ spec:
           {{- include "ocis.containerSecurityContext" . | nindent 10 }}
           env:
             {{- include "ocis.serviceRegistry" . | nindent 12 }}
+            {{- include "ocis.cors" . |nindent 12 }}
 
             - name: WEB_LOG_COLOR
               value: {{ .Values.logging.color | quote }}

--- a/charts/ocis/templates/webdav/deployment.yaml
+++ b/charts/ocis/templates/webdav/deployment.yaml
@@ -25,6 +25,7 @@ spec:
           {{- include "ocis.containerSecurityContext" . | nindent 10 }}
           env:
             {{- include "ocis.serviceRegistry" . | nindent 12 }}
+            {{- include "ocis.cors" . |nindent 12 }}
 
             - name: WEBDAV_LOG_COLOR
               value: {{ .Values.logging.color | quote }}
@@ -52,8 +53,6 @@ spec:
 
             - name: OCIS_PUBLIC_URL
               value: "https://{{ .Values.externalDomain }}"
-
-            {{- include "ocis.cors" . |nindent 12 }}
 
           {{- include "ocis.livenessProbe" . | nindent 10 }}
 

--- a/charts/ocis/templates/webfinger/deployment.yaml
+++ b/charts/ocis/templates/webfinger/deployment.yaml
@@ -25,6 +25,7 @@ spec:
           {{- include "ocis.containerSecurityContext" . | nindent 10 }}
           env:
             {{- include "ocis.serviceRegistry" . | nindent 12 }}
+            {{- include "ocis.cors" . |nindent 12 }}
 
             - name: WEBFINGER_LOG_COLOR
               value: {{ .Values.logging.color | quote }}
@@ -48,7 +49,6 @@ spec:
               value: 0.0.0.0:8080
             - name: WEBFINGER_DEBUG_ADDR
               value: 0.0.0.0:8081
-            {{- include "ocis.cors" . |nindent 12 }}
             - name: WEBFINGER_OIDC_ISSUER
             {{- if not .Values.features.externalUserManagement.enabled }}
               value: "https://{{ .Values.externalDomain }}"


### PR DESCRIPTION
## Description

I was looking at the CORS settings of oCIS 5.0.0-rc.1 and fixed following discrepancies:

- add missing cors setting for web
- remove superfluous cors setting for clientlog
- move cors template next to registry template

## Related Issue
- Fixes wrong / missing CORS settings

## Motivation and Context
Make CORS actually work

## How Has This Been Tested?
- `helmfile template` with cors enabled

## Screenshots (if appropriate):

## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Technical debt
- [ ] Tests only (no source changes)

## Checklist:
- [x] Code changes
- [ ] Unit tests added
- [ ] Acceptance tests added
- [ ] Documentation generated (`make docs`) and committed
- [ ] Documentation ticket raised: <link>
- [ ] Documentation PR created: <link>
