### PR TITLE
fix WEBFINGER_DEBUG_PPROF configuration and some newlines

### DIFF
--- a/charts/ocis/templates/webdav/deployment.yaml
+++ b/charts/ocis/templates/webdav/deployment.yaml
@@ -40,6 +40,7 @@ spec:
               value: {{ .Values.tracing.type | quote }}
             - name: WEBDAV_TRACING_ENDPOINT
               value: {{ .Values.tracing.endpoint | quote }}
+
             - name: WEBDAV_TRACING_COLLECTOR
               value: {{ .Values.tracing.collector | quote }}
 

--- a/charts/ocis/templates/webfinger/deployment.yaml
+++ b/charts/ocis/templates/webfinger/deployment.yaml
@@ -33,22 +33,25 @@ spec:
               value: {{ .Values.logging.level | quote }}
             - name: WEBFINGER_LOG_PRETTY
               value: {{ .Values.logging.pretty | quote }}
+
             - name: WEBFINGER_TRACING_ENABLED
               value: "{{ .Values.tracing.enabled }}"
             - name: WEBFINGER_TRACING_TYPE
               value: {{ .Values.tracing.type | quote }}
             - name: WEBFINGER_TRACING_ENDPOINT
               value: {{ .Values.tracing.endpoint | quote }}
+
             - name: WEBFINGER_TRACING_COLLECTOR
               value: {{ .Values.tracing.collector | quote }}
+
             - name: WEBFINGER_DEBUG_PPROF
-              value: "{{ .Values.debug.enabled }}"
-            - name: WEBFINGER_DEBUG_ZPAGES
-              value: "{{ .Values.debug.enabled }}"
+              value: {{ .Values.debug.profiling | quote }}
+
             - name: WEBFINGER_HTTP_ADDR
               value: 0.0.0.0:8080
             - name: WEBFINGER_DEBUG_ADDR
               value: 0.0.0.0:8081
+
             - name: WEBFINGER_OIDC_ISSUER
             {{- if not .Values.features.externalUserManagement.enabled }}
               value: "https://{{ .Values.externalDomain }}"


### PR DESCRIPTION

## Description
- ZPAGES was only set for webfinger, therefore removed
- PPROF will now be configured by the right value for webfinger
- added newlines like already existing at other services

## Related Issue
- fixes my helm linter warnings

## Motivation and Context

## How Has This Been Tested?
- `helmfile template` when enabling `.Values.debug.profiling`

## Screenshots (if appropriate):

## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Technical debt
- [ ] Tests only (no source changes)

## Checklist:
- [x] Code changes
- [ ] Unit tests added
- [ ] Acceptance tests added
- [ ] Documentation generated (`make docs`) and committed
- [ ] Documentation ticket raised: <link>
- [ ] Documentation PR created: <link>
