### PR TITLE
use settings service account ids variable

### DIFF
--- a/charts/ocis/templates/settings/deployment.yaml
+++ b/charts/ocis/templates/settings/deployment.yaml
@@ -78,8 +78,7 @@ spec:
                   name: {{ include "secrets.jwtSecret" . }}
                   key: jwt-secret
 
-            # TODO: use SETTINGS_SERVICE_ACCOUNT_IDS once we have multiple to configure
-            - name: OCIS_SERVICE_ACCOUNT_ID
+            - name: SETTINGS_SERVICE_ACCOUNT_IDS
               valueFrom:
                 configMapKeyRef:
                   name: {{ include "config.authService" . }}


### PR DESCRIPTION
## Description
use SETTINGS_SERVICE_ACCOUNT_IDS for the settings service

## Related Issue
- fixes a code todo

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->

## How Has This Been Tested?
- not tested

## Screenshots (if appropriate):

## Types of changes
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [x] Technical debt
- [ ] Tests only (no source changes)

## Checklist:
- [x] Code changes
- [ ] Unit tests added
- [ ] Acceptance tests added
- [ ] Documentation generated (`make docs`) and committed
- [ ] Documentation ticket raised: <link>
- [ ] Documentation PR created: <link>
