### PR TITLE
adapt streams to oCIS 5

### DIFF
--- a/deployments/ocis-nats/streams/ocis.yaml
+++ b/deployments/ocis-nats/streams/ocis.yaml
@@ -220,7 +220,7 @@ spec:
   description: oCIS service registry
   denyDelete: true
   discard: new
-  duplicateWindow: "2m0s"
+  duplicateWindow: "60s"
   maxAge: "60s"
   maxBytes: -1
   maxConsumers: -1

--- a/deployments/ocis-nats/streams/ocis.yaml
+++ b/deployments/ocis-nats/streams/ocis.yaml
@@ -1,93 +1,5 @@
 ---
 apiVersion: jetstream.nats.io/v1beta2
-kind: Stream
-metadata:
-  name: main-queue
-spec:
-  name: main-queue
-  replicas: 3
-  storage: file
-  retention: limits
-  discard: old
-  duplicateWindow: "2m0s"
-  account: ocis-nats
----
-apiVersion: jetstream.nats.io/v1beta2
-kind: Stream
-metadata:
-  name: eventhistory
-spec:
-  name: OBJ_eventhistory
-  subjects:
-    - $O.eventhistory.C.>
-    - $O.eventhistory.M.>
-  replicas: 3
-  storage: file
-  retention: limits
-  discard: old
-  duplicateWindow: "2m0s"
-  maxAge: "336h"
-  allowRollup: true
-  allowDirect: true
-  account: ocis-nats
----
-apiVersion: jetstream.nats.io/v1beta2
-kind: Stream
-metadata:
-  name: userlog
-spec:
-  name: OBJ_userlog
-  subjects:
-    - $O.userlog.C.>
-    - $O.userlog.M.>
-  replicas: 3
-  storage: file
-  retention: limits
-  discard: old
-  duplicateWindow: "2m0s"
-  allowRollup: true
-  allowDirect: true
-  maxAge: "336h"
-  account: ocis-nats
----
-apiVersion: jetstream.nats.io/v1beta2
-kind: Stream
-metadata:
-  name: postprocessing
-spec:
-  name: OBJ_postprocessing
-  subjects:
-    - $O.postprocessing.C.>
-    - $O.postprocessing.M.>
-  replicas: 3
-  storage: file
-  retention: limits
-  discard: old
-  duplicateWindow: "2m0s"
-  allowRollup: true
-  allowDirect: true
-  account: ocis-nats
----
-apiVersion: jetstream.nats.io/v1beta2
-kind: Stream
-metadata:
-  name: service-registry
-spec:
-  name: OBJ_service-registry
-  subjects:
-    - $O.service-registry.C.>
-    - $O.service-registry.M.>
-  replicas: 3
-  storage: file
-  retention: limits
-  discard: old
-  duplicateWindow: "2m0s"
-  maxAge: "0"
-  allowRollup: true
-  allowDirect: true
-  account: ocis-nats
----
-apiVersion: jetstream.nats.io/v1beta2
 kind: Account
 metadata:
   name: ocis-nats
@@ -95,3 +7,290 @@ spec:
   name: ocis-nats
   servers:
     - nats://nats.ocis-nats.svc.cluster.local:4222
+
+---
+apiVersion: jetstream.nats.io/v1beta2
+kind: Stream
+metadata:
+  name: main-queue
+spec:
+  account: ocis-nats
+  allowRollup: false
+  description: oCIS message bus
+  discard: old
+  duplicateWindow: "2m0s"
+  maxAge: "168h"
+  maxBytes: -1
+  maxConsumers: -1
+  maxMsgs: -1
+  maxMsgSize: -1
+  maxMsgsPerSubject: 0
+  name: main-queue
+  noAck: false
+  preventDelete: false
+  preventUpdate: false
+  replicas: 3
+  retention: limits
+  storage: file
+  subjects:
+    - main-queue
+
+---
+apiVersion: jetstream.nats.io/v1beta2
+kind: Stream
+metadata:
+  name: kv-cache-userinfo
+spec:
+  account: ocis-nats
+  allowRollup: true
+  description: oCIS proxy userinfo cache
+  denyDelete: true
+  discard: new
+  duplicateWindow: "10s"
+  maxAge: "10s"
+  maxBytes: -1
+  maxConsumers: -1
+  maxMsgs: -1
+  maxMsgSize: -1
+  maxMsgsPerSubject: 1
+  name: KV_cache-userinfo
+  noAck: false
+  allowDirect: true
+  preventDelete: false
+  preventUpdate: false
+  replicas: 3
+  retention: limits
+  storage: memory
+  subjects:
+    - $KV.cache-userinfo.>
+
+---
+apiVersion: jetstream.nats.io/v1beta2
+kind: Stream
+metadata:
+  name: kv-userlog
+spec:
+  account: ocis-nats
+  allowRollup: true
+  description: oCIS userlog store
+  denyDelete: true
+  discard: new
+  duplicateWindow: "2m0s"
+  maxAge: "336h"
+  maxBytes: -1
+  maxConsumers: -1
+  maxMsgs: -1
+  maxMsgSize: -1
+  maxMsgsPerSubject: 1
+  name: KV_userlog
+  noAck: false
+  allowDirect: true
+  preventDelete: false
+  preventUpdate: false
+  replicas: 3
+  retention: limits
+  storage: file
+  subjects:
+    - $KV.userlog.>
+
+---
+apiVersion: jetstream.nats.io/v1beta2
+kind: Stream
+metadata:
+  name: kv-postprocessing
+spec:
+  account: ocis-nats
+  allowRollup: true
+  description: oCIS postprocessing store
+  denyDelete: true
+  discard: new
+  duplicateWindow: "2m0s"
+  maxAge: "168h"
+  maxBytes: -1
+  maxConsumers: -1
+  maxMsgs: -1
+  maxMsgSize: -1
+  maxMsgsPerSubject: 1
+  name: KV_postprocessing
+  noAck: false
+  allowDirect: true
+  preventDelete: false
+  preventUpdate: false
+  replicas: 3
+  retention: limits
+  storage: file
+  subjects:
+    - $KV.postprocessing.>
+
+---
+apiVersion: jetstream.nats.io/v1beta2
+kind: Stream
+metadata:
+  name: kv-ids-storage-users
+spec:
+  account: ocis-nats
+  allowRollup: true
+  description: oCIS storageusers id cache
+  denyDelete: true
+  discard: new
+  duplicateWindow: "2m0s"
+  maxAge: "24h"
+  maxBytes: -1
+  maxConsumers: -1
+  maxMsgs: -1
+  maxMsgSize: -1
+  maxMsgsPerSubject: 1
+  name: KV_ids-storage-users
+  noAck: false
+  allowDirect: true
+  preventDelete: false
+  preventUpdate: false
+  replicas: 3
+  retention: limits
+  storage: memory
+  subjects:
+    - $KV.ids-storage-users.>
+
+---
+apiVersion: jetstream.nats.io/v1beta2
+kind: Stream
+metadata:
+  name: kv-storage-users
+spec:
+  account: ocis-nats
+  allowRollup: true
+  description: oCIS storageusers cache
+  denyDelete: true
+  discard: new
+  duplicateWindow: "2m0s"
+  maxAge: "24h"
+  maxBytes: -1
+  maxConsumers: -1
+  maxMsgs: -1
+  maxMsgSize: -1
+  maxMsgsPerSubject: 1
+  name: KV_storage-users
+  noAck: false
+  allowDirect: true
+  preventDelete: false
+  preventUpdate: false
+  replicas: 3
+  retention: limits
+  storage: memory
+  subjects:
+    - $KV.storage-users.>
+
+---
+apiVersion: jetstream.nats.io/v1beta2
+kind: Stream
+metadata:
+  name: kv-eventhistory
+spec:
+  account: ocis-nats
+  allowRollup: true
+  description: oCIS userlog store
+  denyDelete: true
+  discard: new
+  duplicateWindow: "2m0s"
+  maxAge: "336h"
+  maxBytes: -1
+  maxConsumers: -1
+  maxMsgs: -1
+  maxMsgSize: -1
+  maxMsgsPerSubject: 1
+  name: KV_eventhistory
+  noAck: false
+  allowDirect: true
+  preventDelete: false
+  preventUpdate: false
+  replicas: 3
+  retention: limits
+  storage: file
+  subjects:
+    - $KV.eventhistory.>
+
+---
+apiVersion: jetstream.nats.io/v1beta2
+kind: Stream
+metadata:
+  name: kv-service-registry
+spec:
+  account: ocis-nats
+  allowRollup: true
+  description: oCIS service registry
+  denyDelete: true
+  discard: new
+  duplicateWindow: "2m0s"
+  maxAge: "60s"
+  maxBytes: -1
+  maxConsumers: -1
+  maxMsgs: -1
+  maxMsgSize: -1
+  maxMsgsPerSubject: 1
+  name: KV_service-registry
+  noAck: false
+  allowDirect: true
+  preventDelete: false
+  preventUpdate: false
+  replicas: 3
+  retention: limits
+  storage: memory
+  subjects:
+    - $KV.service-registry.>
+
+---
+apiVersion: jetstream.nats.io/v1beta2
+kind: Stream
+metadata:
+  name: kv-settings-cache
+spec:
+  account: ocis-nats
+  allowRollup: true
+  description: oCIS settings cache
+  denyDelete: true
+  discard: new
+  duplicateWindow: "2m0s"
+  maxAge: "10m0s"
+  maxBytes: -1
+  maxConsumers: -1
+  maxMsgs: -1
+  maxMsgSize: -1
+  maxMsgsPerSubject: 1
+  name: KV_settings-cache
+  noAck: false
+  allowDirect: true
+  preventDelete: false
+  preventUpdate: false
+  replicas: 3
+  retention: limits
+  storage: memory
+  subjects:
+    - $KV.settings-cache.>
+---
+apiVersion: jetstream.nats.io/v1beta2
+kind: Stream
+metadata:
+  name: kv-storage-system
+spec:
+  account: ocis-nats
+  allowRollup: true
+  description: oCIS storagesystem cache
+  denyDelete: true
+  discard: new
+  duplicateWindow: "2m0s"
+  maxAge: "24h"
+  maxBytes: -1
+  maxConsumers: -1
+  maxMsgs: -1
+  maxMsgSize: -1
+  maxMsgsPerSubject: 1
+  name: KV_storage-system
+  noAck: false
+  allowDirect: true
+  preventDelete: false
+  preventUpdate: false
+  replicas: 3
+  retention: limits
+  storage: memory
+  subjects:
+    - $KV.storage-system.>


### PR DESCRIPTION
## Description

see also https://github.com/owncloud/ocis/issues/7272#issuecomment-1911847460

tested stream config with:

```diff
--- a/deployments/ocis-nats/helmfile.yaml
+++ b/deployments/ocis-nats/helmfile.yaml
@@ -73,6 +73,9 @@ releases:
     namespace: ocis
     chart: ../../charts/ocis
     values:
+      - image:
+          tag: latest
+          sha: 64ad9e99a4edc368f3702b44e6da51175b65d50e31133d02ccb4e551c0e4f49a
       - externalDomain: ocis.kube.owncloud.test
```

## Related Issue

## Motivation and Context
Update NACK to reflect streams used by oCIS 5 when using registry / cache / store on NATS

## How Has This Been Tested?
- run the ocis-nats example with the above patch

## Screenshots (if appropriate):

## Types of changes
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Technical debt
- [ ] Tests only (no source changes)

## Checklist:
- [x] Code changes
- [ ] Unit tests added
- [ ] Acceptance tests added
- [ ] Documentation generated (`make docs`) and committed
- [ ] Documentation ticket raised: <link>
- [ ] Documentation PR created: <link>
