### PR TITLE
per service image override (master)

### DIFF
--- a/charts/ocis/docs/values-desc-table.adoc
+++ b/charts/ocis/docs/values-desc-table.adoc
@@ -1116,6 +1116,36 @@ a| [subs=-attributes]
 a| [subs=-attributes]
 `{}`
 | Per-service custom labels
+| services.antivirus.image
+a| [subs=-attributes]
++object+
+a| [subs=-attributes]
+`{"pullPolicy":null,"repository":"","sha":"","tag":""}`
+| Per-service image configuration. Overrides the default setting from `image` if set.
+| services.antivirus.image.pullPolicy
+a| [subs=-attributes]
++string+
+a| [subs=-attributes]
+`nil`
+| Image pull policy
+| services.antivirus.image.repository
+a| [subs=-attributes]
++string+
+a| [subs=-attributes]
+`""`
+| Image repository
+| services.antivirus.image.sha
+a| [subs=-attributes]
++string+
+a| [subs=-attributes]
+`""`
+| Image sha / digest (optional).
+| services.antivirus.image.tag
+a| [subs=-attributes]
++string+
+a| [subs=-attributes]
+`""`
+| Image tag.
 | services.antivirus.nodeSelector
 a| [subs=-attributes]
 +object+
@@ -1158,6 +1188,36 @@ a| [subs=-attributes]
 a| [subs=-attributes]
 `{}`
 | Per-service custom labels
+| services.appprovider.image
+a| [subs=-attributes]
++object+
+a| [subs=-attributes]
+`{"pullPolicy":null,"repository":"","sha":"","tag":""}`
+| Per-service image configuration. Overrides the default setting from `image` if set.
+| services.appprovider.image.pullPolicy
+a| [subs=-attributes]
++string+
+a| [subs=-attributes]
+`nil`
+| Image pull policy
+| services.appprovider.image.repository
+a| [subs=-attributes]
++string+
+a| [subs=-attributes]
+`""`
+| Image repository
+| services.appprovider.image.sha
+a| [subs=-attributes]
++string+
+a| [subs=-attributes]
+`""`
+| Image sha / digest (optional).
+| services.appprovider.image.tag
+a| [subs=-attributes]
++string+
+a| [subs=-attributes]
+`""`
+| Image tag.
 | services.appprovider.nodeSelector
 a| [subs=-attributes]
 +object+
@@ -1194,6 +1254,36 @@ a| [subs=-attributes]
 a| [subs=-attributes]
 `{}`
 | Per-service custom labels
+| services.appregistry.image
+a| [subs=-attributes]
++object+
+a| [subs=-attributes]
+`{"pullPolicy":null,"repository":"","sha":"","tag":""}`
+| Per-service image configuration. Overrides the default setting from `image` if set.
+| services.appregistry.image.pullPolicy
+a| [subs=-attributes]
++string+
+a| [subs=-attributes]
+`nil`
+| Image pull policy
+| services.appregistry.image.repository
+a| [subs=-attributes]
++string+
+a| [subs=-attributes]
+`""`
+| Image repository
+| services.appregistry.image.sha
+a| [subs=-attributes]
++string+
+a| [subs=-attributes]
+`""`
+| Image sha / digest (optional).
+| services.appregistry.image.tag
+a| [subs=-attributes]
++string+
+a| [subs=-attributes]
+`""`
+| Image tag.
 | services.appregistry.nodeSelector
 a| [subs=-attributes]
 +object+
@@ -1236,6 +1326,36 @@ a| [subs=-attributes]
 a| [subs=-attributes]
 `{}`
 | Per-service custom labels
+| services.audit.image
+a| [subs=-attributes]
++object+
+a| [subs=-attributes]
+`{"pullPolicy":null,"repository":"","sha":"","tag":""}`
+| Per-service image configuration. Overrides the default setting from `image` if set.
+| services.audit.image.pullPolicy
+a| [subs=-attributes]
++string+
+a| [subs=-attributes]
+`nil`
+| Image pull policy
+| services.audit.image.repository
+a| [subs=-attributes]
++string+
+a| [subs=-attributes]
+`""`
+| Image repository
+| services.audit.image.sha
+a| [subs=-attributes]
++string+
+a| [subs=-attributes]
+`""`
+| Image sha / digest (optional).
+| services.audit.image.tag
+a| [subs=-attributes]
++string+
+a| [subs=-attributes]
+`""`
+| Image tag.
 | services.audit.nodeSelector
 a| [subs=-attributes]
 +object+
@@ -1284,6 +1404,36 @@ a| [subs=-attributes]
 a| [subs=-attributes]
 `{}`
 | Per-service custom labels
+| services.authbasic.image
+a| [subs=-attributes]
++object+
+a| [subs=-attributes]
+`{"pullPolicy":null,"repository":"","sha":"","tag":""}`
+| Per-service image configuration. Overrides the default setting from `image` if set.
+| services.authbasic.image.pullPolicy
+a| [subs=-attributes]
++string+
+a| [subs=-attributes]
+`nil`
+| Image pull policy
+| services.authbasic.image.repository
+a| [subs=-attributes]
++string+
+a| [subs=-attributes]
+`""`
+| Image repository
+| services.authbasic.image.sha
+a| [subs=-attributes]
++string+
+a| [subs=-attributes]
+`""`
+| Image sha / digest (optional).
+| services.authbasic.image.tag
+a| [subs=-attributes]
++string+
+a| [subs=-attributes]
+`""`
+| Image tag.
 | services.authbasic.nodeSelector
 a| [subs=-attributes]
 +object+
@@ -1332,6 +1482,36 @@ a| [subs=-attributes]
 a| [subs=-attributes]
 `{}`
 | Per-service custom labels
+| services.authmachine.image
+a| [subs=-attributes]
++object+
+a| [subs=-attributes]
+`{"pullPolicy":null,"repository":"","sha":"","tag":""}`
+| Per-service image configuration. Overrides the default setting from `image` if set.
+| services.authmachine.image.pullPolicy
+a| [subs=-attributes]
++string+
+a| [subs=-attributes]
+`nil`
+| Image pull policy
+| services.authmachine.image.repository
+a| [subs=-attributes]
++string+
+a| [subs=-attributes]
+`""`
+| Image repository
+| services.authmachine.image.sha
+a| [subs=-attributes]
++string+
+a| [subs=-attributes]
+`""`
+| Image sha / digest (optional).
+| services.authmachine.image.tag
+a| [subs=-attributes]
++string+
+a| [subs=-attributes]
+`""`
+| Image tag.
 | services.authmachine.nodeSelector
 a| [subs=-attributes]
 +object+
@@ -1380,6 +1560,36 @@ a| [subs=-attributes]
 a| [subs=-attributes]
 `{}`
 | Per-service custom labels
+| services.eventhistory.image
+a| [subs=-attributes]
++object+
+a| [subs=-attributes]
+`{"pullPolicy":null,"repository":"","sha":"","tag":""}`
+| Per-service image configuration. Overrides the default setting from `image` if set.
+| services.eventhistory.image.pullPolicy
+a| [subs=-attributes]
++string+
+a| [subs=-attributes]
+`nil`
+| Image pull policy
+| services.eventhistory.image.repository
+a| [subs=-attributes]
++string+
+a| [subs=-attributes]
+`""`
+| Image repository
+| services.eventhistory.image.sha
+a| [subs=-attributes]
++string+
+a| [subs=-attributes]
+`""`
+| Image sha / digest (optional).
+| services.eventhistory.image.tag
+a| [subs=-attributes]
++string+
+a| [subs=-attributes]
+`""`
+| Image tag.
 | services.eventhistory.nodeSelector
 a| [subs=-attributes]
 +object+
@@ -1434,6 +1644,36 @@ a| [subs=-attributes]
 a| [subs=-attributes]
 `{}`
 | Per-service custom labels
+| services.frontend.image
+a| [subs=-attributes]
++object+
+a| [subs=-attributes]
+`{"pullPolicy":null,"repository":"","sha":"","tag":""}`
+| Per-service image configuration. Overrides the default setting from `image` if set.
+| services.frontend.image.pullPolicy
+a| [subs=-attributes]
++string+
+a| [subs=-attributes]
+`nil`
+| Image pull policy
+| services.frontend.image.repository
+a| [subs=-attributes]
++string+
+a| [subs=-attributes]
+`""`
+| Image repository
+| services.frontend.image.sha
+a| [subs=-attributes]
++string+
+a| [subs=-attributes]
+`""`
+| Image sha / digest (optional).
+| services.frontend.image.tag
+a| [subs=-attributes]
++string+
+a| [subs=-attributes]
+`""`
+| Image tag.
 | services.frontend.nodeSelector
 a| [subs=-attributes]
 +object+
@@ -1482,6 +1722,36 @@ a| [subs=-attributes]
 a| [subs=-attributes]
 `{}`
 | Per-service custom labels
+| services.gateway.image
+a| [subs=-attributes]
++object+
+a| [subs=-attributes]
+`{"pullPolicy":null,"repository":"","sha":"","tag":""}`
+| Per-service image configuration. Overrides the default setting from `image` if set.
+| services.gateway.image.pullPolicy
+a| [subs=-attributes]
++string+
+a| [subs=-attributes]
+`nil`
+| Image pull policy
+| services.gateway.image.repository
+a| [subs=-attributes]
++string+
+a| [subs=-attributes]
+`""`
+| Image repository
+| services.gateway.image.sha
+a| [subs=-attributes]
++string+
+a| [subs=-attributes]
+`""`
+| Image sha / digest (optional).
+| services.gateway.image.tag
+a| [subs=-attributes]
++string+
+a| [subs=-attributes]
+`""`
+| Image tag.
 | services.gateway.nodeSelector
 a| [subs=-attributes]
 +object+
@@ -1530,6 +1800,36 @@ a| [subs=-attributes]
 a| [subs=-attributes]
 `{}`
 | Per-service custom labels
+| services.graph.image
+a| [subs=-attributes]
++object+
+a| [subs=-attributes]
+`{"pullPolicy":null,"repository":"","sha":"","tag":""}`
+| Per-service image configuration. Overrides the default setting from `image` if set.
+| services.graph.image.pullPolicy
+a| [subs=-attributes]
++string+
+a| [subs=-attributes]
+`nil`
+| Image pull policy
+| services.graph.image.repository
+a| [subs=-attributes]
++string+
+a| [subs=-attributes]
+`""`
+| Image repository
+| services.graph.image.sha
+a| [subs=-attributes]
++string+
+a| [subs=-attributes]
+`""`
+| Image sha / digest (optional).
+| services.graph.image.tag
+a| [subs=-attributes]
++string+
+a| [subs=-attributes]
+`""`
+| Image tag.
 | services.graph.nodeSelector
 a| [subs=-attributes]
 +object+
@@ -1578,6 +1878,36 @@ a| [subs=-attributes]
 a| [subs=-attributes]
 `{}`
 | Per-service custom labels
+| services.groups.image
+a| [subs=-attributes]
++object+
+a| [subs=-attributes]
+`{"pullPolicy":null,"repository":"","sha":"","tag":""}`
+| Per-service image configuration. Overrides the default setting from `image` if set.
+| services.groups.image.pullPolicy
+a| [subs=-attributes]
++string+
+a| [subs=-attributes]
+`nil`
+| Image pull policy
+| services.groups.image.repository
+a| [subs=-attributes]
++string+
+a| [subs=-attributes]
+`""`
+| Image repository
+| services.groups.image.sha
+a| [subs=-attributes]
++string+
+a| [subs=-attributes]
+`""`
+| Image sha / digest (optional).
+| services.groups.image.tag
+a| [subs=-attributes]
++string+
+a| [subs=-attributes]
+`""`
+| Image tag.
 | services.groups.nodeSelector
 a| [subs=-attributes]
 +object+
@@ -1620,6 +1950,36 @@ a| [subs=-attributes]
 a| [subs=-attributes]
 `{}`
 | Per-service custom labels
+| services.idm.image
+a| [subs=-attributes]
++object+
+a| [subs=-attributes]
+`{"pullPolicy":null,"repository":"","sha":"","tag":""}`
+| Per-service image configuration. Overrides the default setting from `image` if set.
+| services.idm.image.pullPolicy
+a| [subs=-attributes]
++string+
+a| [subs=-attributes]
+`nil`
+| Image pull policy
+| services.idm.image.repository
+a| [subs=-attributes]
++string+
+a| [subs=-attributes]
+`""`
+| Image repository
+| services.idm.image.sha
+a| [subs=-attributes]
++string+
+a| [subs=-attributes]
+`""`
+| Image sha / digest (optional).
+| services.idm.image.tag
+a| [subs=-attributes]
++string+
+a| [subs=-attributes]
+`""`
+| Image tag.
 | services.idm.nodeSelector
 a| [subs=-attributes]
 +object+
@@ -1722,6 +2082,36 @@ a| [subs=-attributes]
 a| [subs=-attributes]
 `{}`
 | Per-service custom labels
+| services.idp.image
+a| [subs=-attributes]
++object+
+a| [subs=-attributes]
+`{"pullPolicy":null,"repository":"","sha":"","tag":""}`
+| Per-service image configuration. Overrides the default setting from `image` if set.
+| services.idp.image.pullPolicy
+a| [subs=-attributes]
++string+
+a| [subs=-attributes]
+`nil`
+| Image pull policy
+| services.idp.image.repository
+a| [subs=-attributes]
++string+
+a| [subs=-attributes]
+`""`
+| Image repository
+| services.idp.image.sha
+a| [subs=-attributes]
++string+
+a| [subs=-attributes]
+`""`
+| Image sha / digest (optional).
+| services.idp.image.tag
+a| [subs=-attributes]
++string+
+a| [subs=-attributes]
+`""`
+| Image tag.
 | services.idp.nodeSelector
 a| [subs=-attributes]
 +object+
@@ -1758,6 +2148,36 @@ a| [subs=-attributes]
 a| [subs=-attributes]
 `{}`
 | Per-service custom labels
+| services.nats.image
+a| [subs=-attributes]
++object+
+a| [subs=-attributes]
+`{"pullPolicy":null,"repository":"","sha":"","tag":""}`
+| Per-service image configuration. Overrides the default setting from `image` if set.
+| services.nats.image.pullPolicy
+a| [subs=-attributes]
++string+
+a| [subs=-attributes]
+`nil`
+| Image pull policy
+| services.nats.image.repository
+a| [subs=-attributes]
++string+
+a| [subs=-attributes]
+`""`
+| Image repository
+| services.nats.image.sha
+a| [subs=-attributes]
++string+
+a| [subs=-attributes]
+`""`
+| Image sha / digest (optional).
+| services.nats.image.tag
+a| [subs=-attributes]
++string+
+a| [subs=-attributes]
+`""`
+| Image tag.
 | services.nats.nodeSelector
 a| [subs=-attributes]
 +object+
@@ -1866,6 +2286,36 @@ a| [subs=-attributes]
 a| [subs=-attributes]
 `{}`
 | Per-service custom labels
+| services.notifications.image
+a| [subs=-attributes]
++object+
+a| [subs=-attributes]
+`{"pullPolicy":null,"repository":"","sha":"","tag":""}`
+| Per-service image configuration. Overrides the default setting from `image` if set.
+| services.notifications.image.pullPolicy
+a| [subs=-attributes]
++string+
+a| [subs=-attributes]
+`nil`
+| Image pull policy
+| services.notifications.image.repository
+a| [subs=-attributes]
++string+
+a| [subs=-attributes]
+`""`
+| Image repository
+| services.notifications.image.sha
+a| [subs=-attributes]
++string+
+a| [subs=-attributes]
+`""`
+| Image sha / digest (optional).
+| services.notifications.image.tag
+a| [subs=-attributes]
++string+
+a| [subs=-attributes]
+`""`
+| Image tag.
 | services.notifications.nodeSelector
 a| [subs=-attributes]
 +object+
@@ -1914,6 +2364,36 @@ a| [subs=-attributes]
 a| [subs=-attributes]
 `{}`
 | Per-service custom labels
+| services.ocdav.image
+a| [subs=-attributes]
++object+
+a| [subs=-attributes]
+`{"pullPolicy":null,"repository":"","sha":"","tag":""}`
+| Per-service image configuration. Overrides the default setting from `image` if set.
+| services.ocdav.image.pullPolicy
+a| [subs=-attributes]
++string+
+a| [subs=-attributes]
+`nil`
+| Image pull policy
+| services.ocdav.image.repository
+a| [subs=-attributes]
++string+
+a| [subs=-attributes]
+`""`
+| Image repository
+| services.ocdav.image.sha
+a| [subs=-attributes]
++string+
+a| [subs=-attributes]
+`""`
+| Image sha / digest (optional).
+| services.ocdav.image.tag
+a| [subs=-attributes]
++string+
+a| [subs=-attributes]
+`""`
+| Image tag.
 | services.ocdav.nodeSelector
 a| [subs=-attributes]
 +object+
@@ -1962,6 +2442,36 @@ a| [subs=-attributes]
 a| [subs=-attributes]
 `{}`
 | Per-service custom labels
+| services.ocs.image
+a| [subs=-attributes]
++object+
+a| [subs=-attributes]
+`{"pullPolicy":null,"repository":"","sha":"","tag":""}`
+| Per-service image configuration. Overrides the default setting from `image` if set.
+| services.ocs.image.pullPolicy
+a| [subs=-attributes]
++string+
+a| [subs=-attributes]
+`nil`
+| Image pull policy
+| services.ocs.image.repository
+a| [subs=-attributes]
++string+
+a| [subs=-attributes]
+`""`
+| Image repository
+| services.ocs.image.sha
+a| [subs=-attributes]
++string+
+a| [subs=-attributes]
+`""`
+| Image sha / digest (optional).
+| services.ocs.image.tag
+a| [subs=-attributes]
++string+
+a| [subs=-attributes]
+`""`
+| Image tag.
 | services.ocs.nodeSelector
 a| [subs=-attributes]
 +object+
@@ -2010,6 +2520,36 @@ a| [subs=-attributes]
 a| [subs=-attributes]
 `{}`
 | Per-service custom labels
+| services.policies.image
+a| [subs=-attributes]
++object+
+a| [subs=-attributes]
+`{"pullPolicy":null,"repository":"","sha":"","tag":""}`
+| Per-service image configuration. Overrides the default setting from `image` if set.
+| services.policies.image.pullPolicy
+a| [subs=-attributes]
++string+
+a| [subs=-attributes]
+`nil`
+| Image pull policy
+| services.policies.image.repository
+a| [subs=-attributes]
++string+
+a| [subs=-attributes]
+`""`
+| Image repository
+| services.policies.image.sha
+a| [subs=-attributes]
++string+
+a| [subs=-attributes]
+`""`
+| Image sha / digest (optional).
+| services.policies.image.tag
+a| [subs=-attributes]
++string+
+a| [subs=-attributes]
+`""`
+| Image tag.
 | services.policies.nodeSelector
 a| [subs=-attributes]
 +object+
@@ -2058,6 +2598,36 @@ a| [subs=-attributes]
 a| [subs=-attributes]
 `{}`
 | Per-service custom labels
+| services.postprocessing.image
+a| [subs=-attributes]
++object+
+a| [subs=-attributes]
+`{"pullPolicy":null,"repository":"","sha":"","tag":""}`
+| Per-service image configuration. Overrides the default setting from `image` if set.
+| services.postprocessing.image.pullPolicy
+a| [subs=-attributes]
++string+
+a| [subs=-attributes]
+`nil`
+| Image pull policy
+| services.postprocessing.image.repository
+a| [subs=-attributes]
++string+
+a| [subs=-attributes]
+`""`
+| Image repository
+| services.postprocessing.image.sha
+a| [subs=-attributes]
++string+
+a| [subs=-attributes]
+`""`
+| Image sha / digest (optional).
+| services.postprocessing.image.tag
+a| [subs=-attributes]
++string+
+a| [subs=-attributes]
+`""`
+| Image tag.
 | services.postprocessing.nodeSelector
 a| [subs=-attributes]
 +object+
@@ -2112,6 +2682,36 @@ a| [subs=-attributes]
 a| [subs=-attributes]
 `{}`
 | Per-service custom labels
+| services.proxy.image
+a| [subs=-attributes]
++object+
+a| [subs=-attributes]
+`{"pullPolicy":null,"repository":"","sha":"","tag":""}`
+| Per-service image configuration. Overrides the default setting from `image` if set.
+| services.proxy.image.pullPolicy
+a| [subs=-attributes]
++string+
+a| [subs=-attributes]
+`nil`
+| Image pull policy
+| services.proxy.image.repository
+a| [subs=-attributes]
++string+
+a| [subs=-attributes]
+`""`
+| Image repository
+| services.proxy.image.sha
+a| [subs=-attributes]
++string+
+a| [subs=-attributes]
+`""`
+| Image sha / digest (optional).
+| services.proxy.image.tag
+a| [subs=-attributes]
++string+
+a| [subs=-attributes]
+`""`
+| Image tag.
 | services.proxy.nodeSelector
 a| [subs=-attributes]
 +object+
@@ -2178,6 +2778,36 @@ a| [subs=-attributes]
 a| [subs=-attributes]
 `"basic"`
 | Configures the search extractor type to be used. Possible extractors: - `basic`: the default search extractor. - `tika`: the Tika search extractor. If set to this value, additional settings in the `tika` section apply.
+| services.search.image
+a| [subs=-attributes]
++object+
+a| [subs=-attributes]
+`{"pullPolicy":null,"repository":"","sha":"","tag":""}`
+| Per-service image configuration. Overrides the default setting from `image` if set.
+| services.search.image.pullPolicy
+a| [subs=-attributes]
++string+
+a| [subs=-attributes]
+`nil`
+| Image pull policy
+| services.search.image.repository
+a| [subs=-attributes]
++string+
+a| [subs=-attributes]
+`""`
+| Image repository
+| services.search.image.sha
+a| [subs=-attributes]
++string+
+a| [subs=-attributes]
+`""`
+| Image sha / digest (optional).
+| services.search.image.tag
+a| [subs=-attributes]
++string+
+a| [subs=-attributes]
+`""`
+| Image tag.
 | services.search.nodeSelector
 a| [subs=-attributes]
 +object+
@@ -2292,6 +2922,36 @@ a| [subs=-attributes]
 a| [subs=-attributes]
 `{}`
 | Per-service custom labels
+| services.settings.image
+a| [subs=-attributes]
++object+
+a| [subs=-attributes]
+`{"pullPolicy":null,"repository":"","sha":"","tag":""}`
+| Per-service image configuration. Overrides the default setting from `image` if set.
+| services.settings.image.pullPolicy
+a| [subs=-attributes]
++string+
+a| [subs=-attributes]
+`nil`
+| Image pull policy
+| services.settings.image.repository
+a| [subs=-attributes]
++string+
+a| [subs=-attributes]
+`""`
+| Image repository
+| services.settings.image.sha
+a| [subs=-attributes]
++string+
+a| [subs=-attributes]
+`""`
+| Image sha / digest (optional).
+| services.settings.image.tag
+a| [subs=-attributes]
++string+
+a| [subs=-attributes]
+`""`
+| Image tag.
 | services.settings.nodeSelector
 a| [subs=-attributes]
 +object+
@@ -2340,6 +3000,36 @@ a| [subs=-attributes]
 a| [subs=-attributes]
 `{}`
 | Per-service custom labels
+| services.sharing.image
+a| [subs=-attributes]
++object+
+a| [subs=-attributes]
+`{"pullPolicy":null,"repository":"","sha":"","tag":""}`
+| Per-service image configuration. Overrides the default setting from `image` if set.
+| services.sharing.image.pullPolicy
+a| [subs=-attributes]
++string+
+a| [subs=-attributes]
+`nil`
+| Image pull policy
+| services.sharing.image.repository
+a| [subs=-attributes]
++string+
+a| [subs=-attributes]
+`""`
+| Image repository
+| services.sharing.image.sha
+a| [subs=-attributes]
++string+
+a| [subs=-attributes]
+`""`
+| Image sha / digest (optional).
+| services.sharing.image.tag
+a| [subs=-attributes]
++string+
+a| [subs=-attributes]
+`""`
+| Image tag.
 | services.sharing.nodeSelector
 a| [subs=-attributes]
 +object+
@@ -2388,6 +3078,36 @@ a| [subs=-attributes]
 a| [subs=-attributes]
 `{}`
 | Per-service custom labels
+| services.storagepubliclink.image
+a| [subs=-attributes]
++object+
+a| [subs=-attributes]
+`{"pullPolicy":null,"repository":"","sha":"","tag":""}`
+| Per-service image configuration. Overrides the default setting from `image` if set.
+| services.storagepubliclink.image.pullPolicy
+a| [subs=-attributes]
++string+
+a| [subs=-attributes]
+`nil`
+| Image pull policy
+| services.storagepubliclink.image.repository
+a| [subs=-attributes]
++string+
+a| [subs=-attributes]
+`""`
+| Image repository
+| services.storagepubliclink.image.sha
+a| [subs=-attributes]
++string+
+a| [subs=-attributes]
+`""`
+| Image sha / digest (optional).
+| services.storagepubliclink.image.tag
+a| [subs=-attributes]
++string+
+a| [subs=-attributes]
+`""`
+| Image tag.
 | services.storagepubliclink.nodeSelector
 a| [subs=-attributes]
 +object+
@@ -2436,6 +3156,36 @@ a| [subs=-attributes]
 a| [subs=-attributes]
 `{}`
 | Per-service custom labels
+| services.storageshares.image
+a| [subs=-attributes]
++object+
+a| [subs=-attributes]
+`{"pullPolicy":null,"repository":"","sha":"","tag":""}`
+| Per-service image configuration. Overrides the default setting from `image` if set.
+| services.storageshares.image.pullPolicy
+a| [subs=-attributes]
++string+
+a| [subs=-attributes]
+`nil`
+| Image pull policy
+| services.storageshares.image.repository
+a| [subs=-attributes]
++string+
+a| [subs=-attributes]
+`""`
+| Image repository
+| services.storageshares.image.sha
+a| [subs=-attributes]
++string+
+a| [subs=-attributes]
+`""`
+| Image sha / digest (optional).
+| services.storageshares.image.tag
+a| [subs=-attributes]
++string+
+a| [subs=-attributes]
+`""`
+| Image tag.
 | services.storageshares.nodeSelector
 a| [subs=-attributes]
 +object+
@@ -2484,6 +3234,36 @@ a| [subs=-attributes]
 a| [subs=-attributes]
 `{}`
 | Per-service custom labels
+| services.storagesystem.image
+a| [subs=-attributes]
++object+
+a| [subs=-attributes]
+`{"pullPolicy":null,"repository":"","sha":"","tag":""}`
+| Per-service image configuration. Overrides the default setting from `image` if set.
+| services.storagesystem.image.pullPolicy
+a| [subs=-attributes]
++string+
+a| [subs=-attributes]
+`nil`
+| Image pull policy
+| services.storagesystem.image.repository
+a| [subs=-attributes]
++string+
+a| [subs=-attributes]
+`""`
+| Image repository
+| services.storagesystem.image.sha
+a| [subs=-attributes]
++string+
+a| [subs=-attributes]
+`""`
+| Image sha / digest (optional).
+| services.storagesystem.image.tag
+a| [subs=-attributes]
++string+
+a| [subs=-attributes]
+`""`
+| Image tag.
 | services.storagesystem.nodeSelector
 a| [subs=-attributes]
 +object+
@@ -2598,6 +3378,36 @@ a| [subs=-attributes]
 a| [subs=-attributes]
 `{}`
 | Per-service custom labels
+| services.storageusers.image
+a| [subs=-attributes]
++object+
+a| [subs=-attributes]
+`{"pullPolicy":null,"repository":"","sha":"","tag":""}`
+| Per-service image configuration. Overrides the default setting from `image` if set.
+| services.storageusers.image.pullPolicy
+a| [subs=-attributes]
++string+
+a| [subs=-attributes]
+`nil`
+| Image pull policy
+| services.storageusers.image.repository
+a| [subs=-attributes]
++string+
+a| [subs=-attributes]
+`""`
+| Image repository
+| services.storageusers.image.sha
+a| [subs=-attributes]
++string+
+a| [subs=-attributes]
+`""`
+| Image sha / digest (optional).
+| services.storageusers.image.tag
+a| [subs=-attributes]
++string+
+a| [subs=-attributes]
+`""`
+| Image tag.
 | services.storageusers.jobNodeSelector
 a| [subs=-attributes]
 +object+
@@ -2850,6 +3660,36 @@ a| [subs=-attributes]
 a| [subs=-attributes]
 `{}`
 | Per-service custom labels
+| services.store.image
+a| [subs=-attributes]
++object+
+a| [subs=-attributes]
+`{"pullPolicy":null,"repository":"","sha":"","tag":""}`
+| Per-service image configuration. Overrides the default setting from `image` if set.
+| services.store.image.pullPolicy
+a| [subs=-attributes]
++string+
+a| [subs=-attributes]
+`nil`
+| Image pull policy
+| services.store.image.repository
+a| [subs=-attributes]
++string+
+a| [subs=-attributes]
+`""`
+| Image repository
+| services.store.image.sha
+a| [subs=-attributes]
++string+
+a| [subs=-attributes]
+`""`
+| Image sha / digest (optional).
+| services.store.image.tag
+a| [subs=-attributes]
++string+
+a| [subs=-attributes]
+`""`
+| Image tag.
 | services.store.nodeSelector
 a| [subs=-attributes]
 +object+
@@ -2958,6 +3798,36 @@ a| [subs=-attributes]
 a| [subs=-attributes]
 `{}`
 | Per-service custom labels
+| services.thumbnails.image
+a| [subs=-attributes]
++object+
+a| [subs=-attributes]
+`{"pullPolicy":null,"repository":"","sha":"","tag":""}`
+| Per-service image configuration. Overrides the default setting from `image` if set.
+| services.thumbnails.image.pullPolicy
+a| [subs=-attributes]
++string+
+a| [subs=-attributes]
+`nil`
+| Image pull policy
+| services.thumbnails.image.repository
+a| [subs=-attributes]
++string+
+a| [subs=-attributes]
+`""`
+| Image repository
+| services.thumbnails.image.sha
+a| [subs=-attributes]
++string+
+a| [subs=-attributes]
+`""`
+| Image sha / digest (optional).
+| services.thumbnails.image.tag
+a| [subs=-attributes]
++string+
+a| [subs=-attributes]
+`""`
+| Image tag.
 | services.thumbnails.jobNodeSelector
 a| [subs=-attributes]
 +object+
@@ -3144,6 +4014,36 @@ a| [subs=-attributes]
 a| [subs=-attributes]
 `{}`
 | Per-service custom labels
+| services.userlog.image
+a| [subs=-attributes]
++object+
+a| [subs=-attributes]
+`{"pullPolicy":null,"repository":"","sha":"","tag":""}`
+| Per-service image configuration. Overrides the default setting from `image` if set.
+| services.userlog.image.pullPolicy
+a| [subs=-attributes]
++string+
+a| [subs=-attributes]
+`nil`
+| Image pull policy
+| services.userlog.image.repository
+a| [subs=-attributes]
++string+
+a| [subs=-attributes]
+`""`
+| Image repository
+| services.userlog.image.sha
+a| [subs=-attributes]
++string+
+a| [subs=-attributes]
+`""`
+| Image sha / digest (optional).
+| services.userlog.image.tag
+a| [subs=-attributes]
++string+
+a| [subs=-attributes]
+`""`
+| Image tag.
 | services.userlog.nodeSelector
 a| [subs=-attributes]
 +object+
@@ -3198,6 +4098,36 @@ a| [subs=-attributes]
 a| [subs=-attributes]
 `{}`
 | Per-service custom labels
+| services.users.image
+a| [subs=-attributes]
++object+
+a| [subs=-attributes]
+`{"pullPolicy":null,"repository":"","sha":"","tag":""}`
+| Per-service image configuration. Overrides the default setting from `image` if set.
+| services.users.image.pullPolicy
+a| [subs=-attributes]
++string+
+a| [subs=-attributes]
+`nil`
+| Image pull policy
+| services.users.image.repository
+a| [subs=-attributes]
++string+
+a| [subs=-attributes]
+`""`
+| Image repository
+| services.users.image.sha
+a| [subs=-attributes]
++string+
+a| [subs=-attributes]
+`""`
+| Image sha / digest (optional).
+| services.users.image.tag
+a| [subs=-attributes]
++string+
+a| [subs=-attributes]
+`""`
+| Image tag.
 | services.users.nodeSelector
 a| [subs=-attributes]
 +object+
@@ -3330,6 +4260,36 @@ a| [subs=-attributes]
 a| [subs=-attributes]
 `{}`
 | Per-service custom labels
+| services.web.image
+a| [subs=-attributes]
++object+
+a| [subs=-attributes]
+`{"pullPolicy":null,"repository":"","sha":"","tag":""}`
+| Per-service image configuration. Overrides the default setting from `image` if set.
+| services.web.image.pullPolicy
+a| [subs=-attributes]
++string+
+a| [subs=-attributes]
+`nil`
+| Image pull policy
+| services.web.image.repository
+a| [subs=-attributes]
++string+
+a| [subs=-attributes]
+`""`
+| Image repository
+| services.web.image.sha
+a| [subs=-attributes]
++string+
+a| [subs=-attributes]
+`""`
+| Image sha / digest (optional).
+| services.web.image.tag
+a| [subs=-attributes]
++string+
+a| [subs=-attributes]
+`""`
+| Image tag.
 | services.web.nodeSelector
 a| [subs=-attributes]
 +object+
@@ -3444,6 +4404,36 @@ a| [subs=-attributes]
 a| [subs=-attributes]
 `{}`
 | Per-service custom labels
+| services.webdav.image
+a| [subs=-attributes]
++object+
+a| [subs=-attributes]
+`{"pullPolicy":null,"repository":"","sha":"","tag":""}`
+| Per-service image configuration. Overrides the default setting from `image` if set.
+| services.webdav.image.pullPolicy
+a| [subs=-attributes]
++string+
+a| [subs=-attributes]
+`nil`
+| Image pull policy
+| services.webdav.image.repository
+a| [subs=-attributes]
++string+
+a| [subs=-attributes]
+`""`
+| Image repository
+| services.webdav.image.sha
+a| [subs=-attributes]
++string+
+a| [subs=-attributes]
+`""`
+| Image sha / digest (optional).
+| services.webdav.image.tag
+a| [subs=-attributes]
++string+
+a| [subs=-attributes]
+`""`
+| Image tag.
 | services.webdav.nodeSelector
 a| [subs=-attributes]
 +object+
@@ -3492,6 +4482,36 @@ a| [subs=-attributes]
 a| [subs=-attributes]
 `{}`
 | Per-service custom labels
+| services.webfinger.image
+a| [subs=-attributes]
++object+
+a| [subs=-attributes]
+`{"pullPolicy":null,"repository":"","sha":"","tag":""}`
+| Per-service image configuration. Overrides the default setting from `image` if set.
+| services.webfinger.image.pullPolicy
+a| [subs=-attributes]
++string+
+a| [subs=-attributes]
+`nil`
+| Image pull policy
+| services.webfinger.image.repository
+a| [subs=-attributes]
++string+
+a| [subs=-attributes]
+`""`
+| Image repository
+| services.webfinger.image.sha
+a| [subs=-attributes]
++string+
+a| [subs=-attributes]
+`""`
+| Image sha / digest (optional).
+| services.webfinger.image.tag
+a| [subs=-attributes]
++string+
+a| [subs=-attributes]
+`""`
+| Image tag.
 | services.webfinger.nodeSelector
 a| [subs=-attributes]
 +object+

--- a/charts/ocis/docs/values.adoc.yaml
+++ b/charts/ocis/docs/values.adoc.yaml
@@ -747,6 +747,16 @@ services:
     # Do note that the value will be different for each service.
     # -- Per-service custom labels
     extraLabels: {}
+    # -- Per-service image configuration. Overrides the default setting from `image` if set.
+    image:
+      # -- Image repository
+      repository: ""
+      # -- Image tag.
+      tag: ""
+      # -- Image sha / digest (optional).
+      sha: ""
+      # -- Image pull policy
+      pullPolicy:
 
   # -- APP REGISTRY service. Not used if `features.appsIntegration.enabled` equals `false`.
   # @default -- see detailed service configuration options below
@@ -761,6 +771,16 @@ services:
     affinity: {}
     # -- Per-service custom labels
     extraLabels: {}
+    # -- Per-service image configuration. Overrides the default setting from `image` if set.
+    image:
+      # -- Image repository
+      repository: ""
+      # -- Image tag.
+      tag: ""
+      # -- Image sha / digest (optional).
+      sha: ""
+      # -- Image pull policy
+      pullPolicy:
 
   # -- AUDIT service.
   # @default -- see detailed service configuration options below
@@ -779,6 +799,16 @@ services:
     affinity: {}
     # -- Per-service custom labels
     extraLabels: {}
+    # -- Per-service image configuration. Overrides the default setting from `image` if set.
+    image:
+      # -- Image repository
+      repository: ""
+      # -- Image tag.
+      tag: ""
+      # -- Image sha / digest (optional).
+      sha: ""
+      # -- Image pull policy
+      pullPolicy:
 
   # -- AUTH BASIC service. Not used if `features.externalUserManagement.enabled` equals `true`.
   # @default -- see detailed service configuration options below
@@ -797,6 +827,16 @@ services:
     affinity: {}
     # -- Per-service custom labels
     extraLabels: {}
+    # -- Per-service image configuration. Overrides the default setting from `image` if set.
+    image:
+      # -- Image repository
+      repository: ""
+      # -- Image tag.
+      tag: ""
+      # -- Image sha / digest (optional).
+      sha: ""
+      # -- Image pull policy
+      pullPolicy:
 
   # -- AUTH MACHINE service.
   # @default -- see detailed service configuration options below
@@ -815,6 +855,16 @@ services:
     affinity: {}
     # -- Per-service custom labels
     extraLabels: {}
+    # -- Per-service image configuration. Overrides the default setting from `image` if set.
+    image:
+      # -- Image repository
+      repository: ""
+      # -- Image tag.
+      tag: ""
+      # -- Image sha / digest (optional).
+      sha: ""
+      # -- Image pull policy
+      pullPolicy:
 
   # -- ANTIVIRUS service. Not used if `features.virusscan.enabled` equals `false`.
   # @default -- see detailed service configuration options below
@@ -833,6 +883,16 @@ services:
     affinity: {}
     # -- Per-service custom labels
     extraLabels: {}
+    # -- Per-service image configuration. Overrides the default setting from `image` if set.
+    image:
+      # -- Image repository
+      repository: ""
+      # -- Image tag.
+      tag: ""
+      # -- Image sha / digest (optional).
+      sha: ""
+      # -- Image pull policy
+      pullPolicy:
 
   # -- EVENT HISTORY service.
   # @default -- see detailed service configuration options below
@@ -861,6 +921,16 @@ services:
     affinity: {}
     # -- Per-service custom labels
     extraLabels: {}
+    # -- Per-service image configuration. Overrides the default setting from `image` if set.
+    image:
+      # -- Image repository
+      repository: ""
+      # -- Image tag.
+      tag: ""
+      # -- Image sha / digest (optional).
+      sha: ""
+      # -- Image pull policy
+      pullPolicy:
 
   # -- FRONTEND service.
   # @default -- see detailed service configuration options below
@@ -879,6 +949,16 @@ services:
     affinity: {}
     # -- Per-service custom labels
     extraLabels: {}
+    # -- Per-service image configuration. Overrides the default setting from `image` if set.
+    image:
+      # -- Image repository
+      repository: ""
+      # -- Image tag.
+      tag: ""
+      # -- Image sha / digest (optional).
+      sha: ""
+      # -- Image pull policy
+      pullPolicy:
 
   # -- GATEWAY service.
   # @default -- see detailed service configuration options below
@@ -897,6 +977,16 @@ services:
     affinity: {}
     # -- Per-service custom labels
     extraLabels: {}
+    # -- Per-service image configuration. Overrides the default setting from `image` if set.
+    image:
+      # -- Image repository
+      repository: ""
+      # -- Image tag.
+      tag: ""
+      # -- Image sha / digest (optional).
+      sha: ""
+      # -- Image pull policy
+      pullPolicy:
 
   # -- GRAPH service.
   # @default -- see detailed service configuration options below
@@ -915,6 +1005,16 @@ services:
     affinity: {}
     # -- Per-service custom labels
     extraLabels: {}
+    # -- Per-service image configuration. Overrides the default setting from `image` if set.
+    image:
+      # -- Image repository
+      repository: ""
+      # -- Image tag.
+      tag: ""
+      # -- Image sha / digest (optional).
+      sha: ""
+      # -- Image pull policy
+      pullPolicy:
 
   # -- GROUPS service.
   # @default -- see detailed service configuration options below
@@ -933,6 +1033,16 @@ services:
     affinity: {}
     # -- Per-service custom labels
     extraLabels: {}
+    # -- Per-service image configuration. Overrides the default setting from `image` if set.
+    image:
+      # -- Image repository
+      repository: ""
+      # -- Image tag.
+      tag: ""
+      # -- Image sha / digest (optional).
+      sha: ""
+      # -- Image pull policy
+      pullPolicy:
 
   # -- IDM service. Not used if `features.externalUserManagement.enabled` equals `true`.
   # @default -- see detailed service configuration options below
@@ -979,6 +1089,16 @@ services:
     affinity: {}
     # -- Per-service custom labels
     extraLabels: {}
+    # -- Per-service image configuration. Overrides the default setting from `image` if set.
+    image:
+      # -- Image repository
+      repository: ""
+      # -- Image tag.
+      tag: ""
+      # -- Image sha / digest (optional).
+      sha: ""
+      # -- Image pull policy
+      pullPolicy:
 
   # -- IDP service. Not used if `features.externalUserManagement.enabled` equals `true`.
   # @default -- see detailed service configuration options below
@@ -993,6 +1113,16 @@ services:
     affinity: {}
     # -- Per-service custom labels
     extraLabels: {}
+    # -- Per-service image configuration. Overrides the default setting from `image` if set.
+    image:
+      # -- Image repository
+      repository: ""
+      # -- Image tag.
+      tag: ""
+      # -- Image sha / digest (optional).
+      sha: ""
+      # -- Image pull policy
+      pullPolicy:
 
   # -- NATS service. Not used if `messagingSystem.external.enabled` equals `true`.
   # @default -- see detailed service configuration options below
@@ -1039,6 +1169,16 @@ services:
     affinity: {}
     # -- Per-service custom labels
     extraLabels: {}
+    # -- Per-service image configuration. Overrides the default setting from `image` if set.
+    image:
+      # -- Image repository
+      repository: ""
+      # -- Image tag.
+      tag: ""
+      # -- Image sha / digest (optional).
+      sha: ""
+      # -- Image pull policy
+      pullPolicy:
 
   # -- NOTIFICATIONS service. Not used if `features.emailNotifications.enabled` equals `true`.
   # @default -- see detailed service configuration options below
@@ -1057,6 +1197,16 @@ services:
     affinity: {}
     # -- Per-service custom labels
     extraLabels: {}
+    # -- Per-service image configuration. Overrides the default setting from `image` if set.
+    image:
+      # -- Image repository
+      repository: ""
+      # -- Image tag.
+      tag: ""
+      # -- Image sha / digest (optional).
+      sha: ""
+      # -- Image pull policy
+      pullPolicy:
 
   # -- OCDAV service.
   # @default -- see detailed service configuration options below
@@ -1075,6 +1225,16 @@ services:
     affinity: {}
     # -- Per-service custom labels
     extraLabels: {}
+    # -- Per-service image configuration. Overrides the default setting from `image` if set.
+    image:
+      # -- Image repository
+      repository: ""
+      # -- Image tag.
+      tag: ""
+      # -- Image sha / digest (optional).
+      sha: ""
+      # -- Image pull policy
+      pullPolicy:
 
   # -- OCS service.
   # @default -- see detailed service configuration options below
@@ -1093,6 +1253,16 @@ services:
     affinity: {}
     # -- Per-service custom labels
     extraLabels: {}
+    # -- Per-service image configuration. Overrides the default setting from `image` if set.
+    image:
+      # -- Image repository
+      repository: ""
+      # -- Image tag.
+      tag: ""
+      # -- Image sha / digest (optional).
+      sha: ""
+      # -- Image pull policy
+      pullPolicy:
 
   # -- POLICIES service.
   # @default -- see detailed service configuration options below
@@ -1111,6 +1281,16 @@ services:
     affinity: {}
     # -- Per-service custom labels
     extraLabels: {}
+    # -- Per-service image configuration. Overrides the default setting from `image` if set.
+    image:
+      # -- Image repository
+      repository: ""
+      # -- Image tag.
+      tag: ""
+      # -- Image sha / digest (optional).
+      sha: ""
+      # -- Image pull policy
+      pullPolicy:
 
   # -- POSTPROCESSING service.
   # @default -- see detailed service configuration options below
@@ -1131,6 +1311,16 @@ services:
     affinity: {}
     # -- Per-service custom labels
     extraLabels: {}
+    # -- Per-service image configuration. Overrides the default setting from `image` if set.
+    image:
+      # -- Image repository
+      repository: ""
+      # -- Image tag.
+      tag: ""
+      # -- Image sha / digest (optional).
+      sha: ""
+      # -- Image pull policy
+      pullPolicy:
 
   # -- PROXY service.
   # @default -- see detailed service configuration options below
@@ -1149,6 +1339,16 @@ services:
     affinity: {}
     # -- Per-service custom labels
     extraLabels: {}
+    # -- Per-service image configuration. Overrides the default setting from `image` if set.
+    image:
+      # -- Image repository
+      repository: ""
+      # -- Image tag.
+      tag: ""
+      # -- Image sha / digest (optional).
+      sha: ""
+      # -- Image pull policy
+      pullPolicy:
 
   # -- SEARCH service.
   # @default -- see detailed service configuration options below
@@ -1210,6 +1410,16 @@ services:
     affinity: {}
     # -- Per-service custom labels
     extraLabels: {}
+    # -- Per-service image configuration. Overrides the default setting from `image` if set.
+    image:
+      # -- Image repository
+      repository: ""
+      # -- Image tag.
+      tag: ""
+      # -- Image sha / digest (optional).
+      sha: ""
+      # -- Image pull policy
+      pullPolicy:
 
   # -- SETTINGS service.
   # @default -- see detailed service configuration options below
@@ -1228,6 +1438,16 @@ services:
     affinity: {}
     # -- Per-service custom labels
     extraLabels: {}
+    # -- Per-service image configuration. Overrides the default setting from `image` if set.
+    image:
+      # -- Image repository
+      repository: ""
+      # -- Image tag.
+      tag: ""
+      # -- Image sha / digest (optional).
+      sha: ""
+      # -- Image pull policy
+      pullPolicy:
 
   # -- SHARING service.
   # @default -- see detailed service configuration options below
@@ -1246,6 +1466,16 @@ services:
     affinity: {}
     # -- Per-service custom labels
     extraLabels: {}
+    # -- Per-service image configuration. Overrides the default setting from `image` if set.
+    image:
+      # -- Image repository
+      repository: ""
+      # -- Image tag.
+      tag: ""
+      # -- Image sha / digest (optional).
+      sha: ""
+      # -- Image pull policy
+      pullPolicy:
 
   # -- STORAGE-PUBLICLINK service.
   # @default -- see detailed service configuration options below
@@ -1264,6 +1494,16 @@ services:
     affinity: {}
     # -- Per-service custom labels
     extraLabels: {}
+    # -- Per-service image configuration. Overrides the default setting from `image` if set.
+    image:
+      # -- Image repository
+      repository: ""
+      # -- Image tag.
+      tag: ""
+      # -- Image sha / digest (optional).
+      sha: ""
+      # -- Image pull policy
+      pullPolicy:
 
   # -- STORAGE-SHARES service.
   # @default -- see detailed service configuration options below
@@ -1282,6 +1522,16 @@ services:
     affinity: {}
     # -- Per-service custom labels
     extraLabels: {}
+    # -- Per-service image configuration. Overrides the default setting from `image` if set.
+    image:
+      # -- Image repository
+      repository: ""
+      # -- Image tag.
+      tag: ""
+      # -- Image sha / digest (optional).
+      sha: ""
+      # -- Image pull policy
+      pullPolicy:
 
   # -- STORAGE-SYSTEM service.
   # @default -- see detailed service configuration options below
@@ -1332,6 +1582,16 @@ services:
     affinity: {}
     # -- Per-service custom labels
     extraLabels: {}
+    # -- Per-service image configuration. Overrides the default setting from `image` if set.
+    image:
+      # -- Image repository
+      repository: ""
+      # -- Image tag.
+      tag: ""
+      # -- Image sha / digest (optional).
+      sha: ""
+      # -- Image pull policy
+      pullPolicy:
 
   # -- STORAGE-USERS service.
   # @default -- see detailed service configuration options below
@@ -1466,6 +1726,16 @@ services:
     affinity: {}
     # -- Per-service custom labels
     extraLabels: {}
+    # -- Per-service image configuration. Overrides the default setting from `image` if set.
+    image:
+      # -- Image repository
+      repository: ""
+      # -- Image tag.
+      tag: ""
+      # -- Image sha / digest (optional).
+      sha: ""
+      # -- Image pull policy
+      pullPolicy:
 
   # -- STORE service.
   # @default -- see detailed service configuration options below
@@ -1512,6 +1782,16 @@ services:
     affinity: {}
     # -- Per-service custom labels
     extraLabels: {}
+    # -- Per-service image configuration. Overrides the default setting from `image` if set.
+    image:
+      # -- Image repository
+      repository: ""
+      # -- Image tag.
+      tag: ""
+      # -- Image sha / digest (optional).
+      sha: ""
+      # -- Image pull policy
+      pullPolicy:
 
   # -- THUMBNAILS service.
   # @default -- see detailed service configuration options below
@@ -1588,6 +1868,16 @@ services:
     affinity: {}
     # -- Per-service custom labels
     extraLabels: {}
+    # -- Per-service image configuration. Overrides the default setting from `image` if set.
+    image:
+      # -- Image repository
+      repository: ""
+      # -- Image tag.
+      tag: ""
+      # -- Image sha / digest (optional).
+      sha: ""
+      # -- Image pull policy
+      pullPolicy:
 
   # -- USERLOG service.
   # @default -- see detailed service configuration options below
@@ -1616,6 +1906,16 @@ services:
     affinity: {}
     # -- Per-service custom labels
     extraLabels: {}
+    # -- Per-service image configuration. Overrides the default setting from `image` if set.
+    image:
+      # -- Image repository
+      repository: ""
+      # -- Image tag.
+      tag: ""
+      # -- Image sha / digest (optional).
+      sha: ""
+      # -- Image pull policy
+      pullPolicy:
 
   # -- USERS service.
   # @default -- see detailed service configuration options below
@@ -1634,6 +1934,16 @@ services:
     affinity: {}
     # -- Per-service custom labels
     extraLabels: {}
+    # -- Per-service image configuration. Overrides the default setting from `image` if set.
+    image:
+      # -- Image repository
+      repository: ""
+      # -- Image tag.
+      tag: ""
+      # -- Image sha / digest (optional).
+      sha: ""
+      # -- Image pull policy
+      pullPolicy:
 
   # -- ownCloud WEB service.
   # @default -- see detailed service configuration options below
@@ -1772,6 +2082,16 @@ services:
     affinity: {}
     # -- Per-service custom labels
     extraLabels: {}
+    # -- Per-service image configuration. Overrides the default setting from `image` if set.
+    image:
+      # -- Image repository
+      repository: ""
+      # -- Image tag.
+      tag: ""
+      # -- Image sha / digest (optional).
+      sha: ""
+      # -- Image pull policy
+      pullPolicy:
 
   # -- WEBDAV service.
   # @default -- see detailed service configuration options below
@@ -1790,6 +2110,16 @@ services:
     affinity: {}
     # -- Per-service custom labels
     extraLabels: {}
+    # -- Per-service image configuration. Overrides the default setting from `image` if set.
+    image:
+      # -- Image repository
+      repository: ""
+      # -- Image tag.
+      tag: ""
+      # -- Image sha / digest (optional).
+      sha: ""
+      # -- Image pull policy
+      pullPolicy:
 
   # -- WEBFINGER service.
   # @default -- see detailed service configuration options below
@@ -1808,6 +2138,16 @@ services:
     affinity: {}
     # -- Per-service custom labels
     extraLabels: {}
+    # -- Per-service image configuration. Overrides the default setting from `image` if set.
+    image:
+      # -- Image repository
+      repository: ""
+      # -- Image tag.
+      tag: ""
+      # -- Image sha / digest (optional).
+      sha: ""
+      # -- Image pull policy
+      pullPolicy:
 
 # -- Service monitoring configuration. Requires the monitoring.coreos.com/v1 CRDs to be installed.
 monitoring:

--- a/charts/ocis/templates/_common/images.tpl
+++ b/charts/ocis/templates/_common/images.tpl
@@ -30,13 +30,12 @@ imagePullPolicy: {{ .pullPolicy }}
 oCIS image logic
 */}}
 {{- define "ocis.image" -}}
-{{- $repo := $.Values.image.repository -}}
-{{- $tag := default $.Chart.AppVersion $.Values.image.tag -}}
-{{- $sha := $.Values.image.sha -}}
-{{- $pullPolicy := $.Values.image.pullPolicy -}}
+{{- $repo := default $.Values.image.repository .appSpecificConfig.image.repository -}}
+{{- $tag := default (default $.Chart.AppVersion $.Values.image.tag) .appSpecificConfig.image.tag -}}
+{{- $sha := default $.Values.image.sha .appSpecificConfig.image.sha -}}
+{{- $pullPolicy := default $.Values.image.pullPolicy .appSpecificConfig.image.pullPolicy -}}
 {{ template "ocis.imageTemplateHelper" (dict "repo" $repo "tag" $tag "sha" $sha "pullPolicy" $pullPolicy) }}
 {{- end -}}
-
 
 {{/*
 jobContainerOcis image logic for oCIS based containers

--- a/charts/ocis/values.yaml
+++ b/charts/ocis/values.yaml
@@ -746,6 +746,16 @@ services:
     # Do note that the value will be different for each service.
     # -- Per-service custom labels
     extraLabels: {}
+    # -- Per-service image configuration. Overrides the default setting from `image` if set.
+    image:
+      # -- Image repository
+      repository: ""
+      # -- Image tag.
+      tag: ""
+      # -- Image sha / digest (optional).
+      sha: ""
+      # -- Image pull policy
+      pullPolicy:
 
   # -- APP REGISTRY service. Not used if `features.appsIntegration.enabled` equals `false`.
   # @default -- see detailed service configuration options below
@@ -760,6 +770,16 @@ services:
     affinity: {}
     # -- Per-service custom labels
     extraLabels: {}
+    # -- Per-service image configuration. Overrides the default setting from `image` if set.
+    image:
+      # -- Image repository
+      repository: ""
+      # -- Image tag.
+      tag: ""
+      # -- Image sha / digest (optional).
+      sha: ""
+      # -- Image pull policy
+      pullPolicy:
 
   # -- AUDIT service.
   # @default -- see detailed service configuration options below
@@ -778,6 +798,16 @@ services:
     affinity: {}
     # -- Per-service custom labels
     extraLabels: {}
+    # -- Per-service image configuration. Overrides the default setting from `image` if set.
+    image:
+      # -- Image repository
+      repository: ""
+      # -- Image tag.
+      tag: ""
+      # -- Image sha / digest (optional).
+      sha: ""
+      # -- Image pull policy
+      pullPolicy:
 
   # -- AUTH BASIC service. Not used if `features.externalUserManagement.enabled` equals `true`.
   # @default -- see detailed service configuration options below
@@ -796,6 +826,16 @@ services:
     affinity: {}
     # -- Per-service custom labels
     extraLabels: {}
+    # -- Per-service image configuration. Overrides the default setting from `image` if set.
+    image:
+      # -- Image repository
+      repository: ""
+      # -- Image tag.
+      tag: ""
+      # -- Image sha / digest (optional).
+      sha: ""
+      # -- Image pull policy
+      pullPolicy:
 
   # -- AUTH MACHINE service.
   # @default -- see detailed service configuration options below
@@ -814,6 +854,16 @@ services:
     affinity: {}
     # -- Per-service custom labels
     extraLabels: {}
+    # -- Per-service image configuration. Overrides the default setting from `image` if set.
+    image:
+      # -- Image repository
+      repository: ""
+      # -- Image tag.
+      tag: ""
+      # -- Image sha / digest (optional).
+      sha: ""
+      # -- Image pull policy
+      pullPolicy:
 
   # -- ANTIVIRUS service. Not used if `features.virusscan.enabled` equals `false`.
   # @default -- see detailed service configuration options below
@@ -832,6 +882,16 @@ services:
     affinity: {}
     # -- Per-service custom labels
     extraLabels: {}
+    # -- Per-service image configuration. Overrides the default setting from `image` if set.
+    image:
+      # -- Image repository
+      repository: ""
+      # -- Image tag.
+      tag: ""
+      # -- Image sha / digest (optional).
+      sha: ""
+      # -- Image pull policy
+      pullPolicy:
 
   # -- EVENT HISTORY service.
   # @default -- see detailed service configuration options below
@@ -860,6 +920,16 @@ services:
     affinity: {}
     # -- Per-service custom labels
     extraLabels: {}
+    # -- Per-service image configuration. Overrides the default setting from `image` if set.
+    image:
+      # -- Image repository
+      repository: ""
+      # -- Image tag.
+      tag: ""
+      # -- Image sha / digest (optional).
+      sha: ""
+      # -- Image pull policy
+      pullPolicy:
 
   # -- FRONTEND service.
   # @default -- see detailed service configuration options below
@@ -878,6 +948,16 @@ services:
     affinity: {}
     # -- Per-service custom labels
     extraLabels: {}
+    # -- Per-service image configuration. Overrides the default setting from `image` if set.
+    image:
+      # -- Image repository
+      repository: ""
+      # -- Image tag.
+      tag: ""
+      # -- Image sha / digest (optional).
+      sha: ""
+      # -- Image pull policy
+      pullPolicy:
 
   # -- GATEWAY service.
   # @default -- see detailed service configuration options below
@@ -896,6 +976,16 @@ services:
     affinity: {}
     # -- Per-service custom labels
     extraLabels: {}
+    # -- Per-service image configuration. Overrides the default setting from `image` if set.
+    image:
+      # -- Image repository
+      repository: ""
+      # -- Image tag.
+      tag: ""
+      # -- Image sha / digest (optional).
+      sha: ""
+      # -- Image pull policy
+      pullPolicy:
 
   # -- GRAPH service.
   # @default -- see detailed service configuration options below
@@ -914,6 +1004,16 @@ services:
     affinity: {}
     # -- Per-service custom labels
     extraLabels: {}
+    # -- Per-service image configuration. Overrides the default setting from `image` if set.
+    image:
+      # -- Image repository
+      repository: ""
+      # -- Image tag.
+      tag: ""
+      # -- Image sha / digest (optional).
+      sha: ""
+      # -- Image pull policy
+      pullPolicy:
 
   # -- GROUPS service.
   # @default -- see detailed service configuration options below
@@ -932,6 +1032,16 @@ services:
     affinity: {}
     # -- Per-service custom labels
     extraLabels: {}
+    # -- Per-service image configuration. Overrides the default setting from `image` if set.
+    image:
+      # -- Image repository
+      repository: ""
+      # -- Image tag.
+      tag: ""
+      # -- Image sha / digest (optional).
+      sha: ""
+      # -- Image pull policy
+      pullPolicy:
 
   # -- IDM service. Not used if `features.externalUserManagement.enabled` equals `true`.
   # @default -- see detailed service configuration options below
@@ -978,6 +1088,16 @@ services:
     affinity: {}
     # -- Per-service custom labels
     extraLabels: {}
+    # -- Per-service image configuration. Overrides the default setting from `image` if set.
+    image:
+      # -- Image repository
+      repository: ""
+      # -- Image tag.
+      tag: ""
+      # -- Image sha / digest (optional).
+      sha: ""
+      # -- Image pull policy
+      pullPolicy:
 
   # -- IDP service. Not used if `features.externalUserManagement.enabled` equals `true`.
   # @default -- see detailed service configuration options below
@@ -992,6 +1112,16 @@ services:
     affinity: {}
     # -- Per-service custom labels
     extraLabels: {}
+    # -- Per-service image configuration. Overrides the default setting from `image` if set.
+    image:
+      # -- Image repository
+      repository: ""
+      # -- Image tag.
+      tag: ""
+      # -- Image sha / digest (optional).
+      sha: ""
+      # -- Image pull policy
+      pullPolicy:
 
   # -- NATS service. Not used if `messagingSystem.external.enabled` equals `true`.
   # @default -- see detailed service configuration options below
@@ -1038,6 +1168,16 @@ services:
     affinity: {}
     # -- Per-service custom labels
     extraLabels: {}
+    # -- Per-service image configuration. Overrides the default setting from `image` if set.
+    image:
+      # -- Image repository
+      repository: ""
+      # -- Image tag.
+      tag: ""
+      # -- Image sha / digest (optional).
+      sha: ""
+      # -- Image pull policy
+      pullPolicy:
 
   # -- NOTIFICATIONS service. Not used if `features.emailNotifications.enabled` equals `true`.
   # @default -- see detailed service configuration options below
@@ -1056,6 +1196,16 @@ services:
     affinity: {}
     # -- Per-service custom labels
     extraLabels: {}
+    # -- Per-service image configuration. Overrides the default setting from `image` if set.
+    image:
+      # -- Image repository
+      repository: ""
+      # -- Image tag.
+      tag: ""
+      # -- Image sha / digest (optional).
+      sha: ""
+      # -- Image pull policy
+      pullPolicy:
 
   # -- OCDAV service.
   # @default -- see detailed service configuration options below
@@ -1074,6 +1224,16 @@ services:
     affinity: {}
     # -- Per-service custom labels
     extraLabels: {}
+    # -- Per-service image configuration. Overrides the default setting from `image` if set.
+    image:
+      # -- Image repository
+      repository: ""
+      # -- Image tag.
+      tag: ""
+      # -- Image sha / digest (optional).
+      sha: ""
+      # -- Image pull policy
+      pullPolicy:
 
   # -- OCS service.
   # @default -- see detailed service configuration options below
@@ -1092,6 +1252,16 @@ services:
     affinity: {}
     # -- Per-service custom labels
     extraLabels: {}
+    # -- Per-service image configuration. Overrides the default setting from `image` if set.
+    image:
+      # -- Image repository
+      repository: ""
+      # -- Image tag.
+      tag: ""
+      # -- Image sha / digest (optional).
+      sha: ""
+      # -- Image pull policy
+      pullPolicy:
 
   # -- POLICIES service.
   # @default -- see detailed service configuration options below
@@ -1110,6 +1280,16 @@ services:
     affinity: {}
     # -- Per-service custom labels
     extraLabels: {}
+    # -- Per-service image configuration. Overrides the default setting from `image` if set.
+    image:
+      # -- Image repository
+      repository: ""
+      # -- Image tag.
+      tag: ""
+      # -- Image sha / digest (optional).
+      sha: ""
+      # -- Image pull policy
+      pullPolicy:
 
   # -- POSTPROCESSING service.
   # @default -- see detailed service configuration options below
@@ -1130,6 +1310,16 @@ services:
     affinity: {}
     # -- Per-service custom labels
     extraLabels: {}
+    # -- Per-service image configuration. Overrides the default setting from `image` if set.
+    image:
+      # -- Image repository
+      repository: ""
+      # -- Image tag.
+      tag: ""
+      # -- Image sha / digest (optional).
+      sha: ""
+      # -- Image pull policy
+      pullPolicy:
 
   # -- PROXY service.
   # @default -- see detailed service configuration options below
@@ -1148,6 +1338,16 @@ services:
     affinity: {}
     # -- Per-service custom labels
     extraLabels: {}
+    # -- Per-service image configuration. Overrides the default setting from `image` if set.
+    image:
+      # -- Image repository
+      repository: ""
+      # -- Image tag.
+      tag: ""
+      # -- Image sha / digest (optional).
+      sha: ""
+      # -- Image pull policy
+      pullPolicy:
 
   # -- SEARCH service.
   # @default -- see detailed service configuration options below
@@ -1209,6 +1409,16 @@ services:
     affinity: {}
     # -- Per-service custom labels
     extraLabels: {}
+    # -- Per-service image configuration. Overrides the default setting from `image` if set.
+    image:
+      # -- Image repository
+      repository: ""
+      # -- Image tag.
+      tag: ""
+      # -- Image sha / digest (optional).
+      sha: ""
+      # -- Image pull policy
+      pullPolicy:
 
   # -- SETTINGS service.
   # @default -- see detailed service configuration options below
@@ -1227,6 +1437,16 @@ services:
     affinity: {}
     # -- Per-service custom labels
     extraLabels: {}
+    # -- Per-service image configuration. Overrides the default setting from `image` if set.
+    image:
+      # -- Image repository
+      repository: ""
+      # -- Image tag.
+      tag: ""
+      # -- Image sha / digest (optional).
+      sha: ""
+      # -- Image pull policy
+      pullPolicy:
 
   # -- SHARING service.
   # @default -- see detailed service configuration options below
@@ -1245,6 +1465,16 @@ services:
     affinity: {}
     # -- Per-service custom labels
     extraLabels: {}
+    # -- Per-service image configuration. Overrides the default setting from `image` if set.
+    image:
+      # -- Image repository
+      repository: ""
+      # -- Image tag.
+      tag: ""
+      # -- Image sha / digest (optional).
+      sha: ""
+      # -- Image pull policy
+      pullPolicy:
 
   # -- STORAGE-PUBLICLINK service.
   # @default -- see detailed service configuration options below
@@ -1263,6 +1493,16 @@ services:
     affinity: {}
     # -- Per-service custom labels
     extraLabels: {}
+    # -- Per-service image configuration. Overrides the default setting from `image` if set.
+    image:
+      # -- Image repository
+      repository: ""
+      # -- Image tag.
+      tag: ""
+      # -- Image sha / digest (optional).
+      sha: ""
+      # -- Image pull policy
+      pullPolicy:
 
   # -- STORAGE-SHARES service.
   # @default -- see detailed service configuration options below
@@ -1281,6 +1521,16 @@ services:
     affinity: {}
     # -- Per-service custom labels
     extraLabels: {}
+    # -- Per-service image configuration. Overrides the default setting from `image` if set.
+    image:
+      # -- Image repository
+      repository: ""
+      # -- Image tag.
+      tag: ""
+      # -- Image sha / digest (optional).
+      sha: ""
+      # -- Image pull policy
+      pullPolicy:
 
   # -- STORAGE-SYSTEM service.
   # @default -- see detailed service configuration options below
@@ -1331,6 +1581,16 @@ services:
     affinity: {}
     # -- Per-service custom labels
     extraLabels: {}
+    # -- Per-service image configuration. Overrides the default setting from `image` if set.
+    image:
+      # -- Image repository
+      repository: ""
+      # -- Image tag.
+      tag: ""
+      # -- Image sha / digest (optional).
+      sha: ""
+      # -- Image pull policy
+      pullPolicy:
 
   # -- STORAGE-USERS service.
   # @default -- see detailed service configuration options below
@@ -1465,6 +1725,16 @@ services:
     affinity: {}
     # -- Per-service custom labels
     extraLabels: {}
+    # -- Per-service image configuration. Overrides the default setting from `image` if set.
+    image:
+      # -- Image repository
+      repository: ""
+      # -- Image tag.
+      tag: ""
+      # -- Image sha / digest (optional).
+      sha: ""
+      # -- Image pull policy
+      pullPolicy:
 
   # -- STORE service.
   # @default -- see detailed service configuration options below
@@ -1511,6 +1781,16 @@ services:
     affinity: {}
     # -- Per-service custom labels
     extraLabels: {}
+    # -- Per-service image configuration. Overrides the default setting from `image` if set.
+    image:
+      # -- Image repository
+      repository: ""
+      # -- Image tag.
+      tag: ""
+      # -- Image sha / digest (optional).
+      sha: ""
+      # -- Image pull policy
+      pullPolicy:
 
   # -- THUMBNAILS service.
   # @default -- see detailed service configuration options below
@@ -1587,6 +1867,16 @@ services:
     affinity: {}
     # -- Per-service custom labels
     extraLabels: {}
+    # -- Per-service image configuration. Overrides the default setting from `image` if set.
+    image:
+      # -- Image repository
+      repository: ""
+      # -- Image tag.
+      tag: ""
+      # -- Image sha / digest (optional).
+      sha: ""
+      # -- Image pull policy
+      pullPolicy:
 
   # -- USERLOG service.
   # @default -- see detailed service configuration options below
@@ -1615,6 +1905,16 @@ services:
     affinity: {}
     # -- Per-service custom labels
     extraLabels: {}
+    # -- Per-service image configuration. Overrides the default setting from `image` if set.
+    image:
+      # -- Image repository
+      repository: ""
+      # -- Image tag.
+      tag: ""
+      # -- Image sha / digest (optional).
+      sha: ""
+      # -- Image pull policy
+      pullPolicy:
 
   # -- USERS service.
   # @default -- see detailed service configuration options below
@@ -1633,6 +1933,16 @@ services:
     affinity: {}
     # -- Per-service custom labels
     extraLabels: {}
+    # -- Per-service image configuration. Overrides the default setting from `image` if set.
+    image:
+      # -- Image repository
+      repository: ""
+      # -- Image tag.
+      tag: ""
+      # -- Image sha / digest (optional).
+      sha: ""
+      # -- Image pull policy
+      pullPolicy:
 
   # -- ownCloud WEB service.
   # @default -- see detailed service configuration options below
@@ -1771,6 +2081,16 @@ services:
     affinity: {}
     # -- Per-service custom labels
     extraLabels: {}
+    # -- Per-service image configuration. Overrides the default setting from `image` if set.
+    image:
+      # -- Image repository
+      repository: ""
+      # -- Image tag.
+      tag: ""
+      # -- Image sha / digest (optional).
+      sha: ""
+      # -- Image pull policy
+      pullPolicy:
 
   # -- WEBDAV service.
   # @default -- see detailed service configuration options below
@@ -1789,6 +2109,16 @@ services:
     affinity: {}
     # -- Per-service custom labels
     extraLabels: {}
+    # -- Per-service image configuration. Overrides the default setting from `image` if set.
+    image:
+      # -- Image repository
+      repository: ""
+      # -- Image tag.
+      tag: ""
+      # -- Image sha / digest (optional).
+      sha: ""
+      # -- Image pull policy
+      pullPolicy:
 
   # -- WEBFINGER service.
   # @default -- see detailed service configuration options below
@@ -1807,6 +2137,16 @@ services:
     affinity: {}
     # -- Per-service custom labels
     extraLabels: {}
+    # -- Per-service image configuration. Overrides the default setting from `image` if set.
+    image:
+      # -- Image repository
+      repository: ""
+      # -- Image tag.
+      tag: ""
+      # -- Image sha / digest (optional).
+      sha: ""
+      # -- Image pull policy
+      pullPolicy:
 
 # -- Service monitoring configuration. Requires the monitoring.coreos.com/v1 CRDs to be installed.
 monitoring:


### PR DESCRIPTION
## Description
add a per service image override setting section, forward port of #484

## Related Issue
- Fixes #475

## Motivation and Context

## How Has This Been Tested?

deploy ocis with the development example, afterwards configuring some image overrides

for 
```diff
diff --git a/deployments/development-install/helmfile.yaml b/deployments/development-install/helmfile.yaml
index dbc5009..e04982b 100644
--- a/deployments/development-install/helmfile.yaml
+++ b/deployments/development-install/helmfile.yaml
@@ -53,3 +53,6 @@ releases:
           web:
             persistence:
               enabled: true
+          proxy:
+            image:
+              tag: "4.0.7"
```

`helmfile diff` yields:

```diff
        containers:
          - name: proxy
-           image: "owncloud/ocis:4.0.6"
+           image: "owncloud/ocis:4.0.7"
            imagePullPolicy: IfNotPresent
            command: ["ocis"]
```


## Screenshots (if appropriate):

## Types of changes
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Technical debt
- [ ] Tests only (no source changes)

## Checklist:
- [x] Code changes
- [ ] Unit tests added
- [ ] Acceptance tests added
- [x] Documentation generated (`make docs`) and committed
- [ ] Documentation ticket raised: <link>
- [ ] Documentation PR created: <link>
