### PR TITLE
Implemented deployment of suspended CronJobs

### DIFF
--- a/charts/ocis/templates/postprocessing/jobs.yaml
+++ b/charts/ocis/templates/postprocessing/jobs.yaml
@@ -1,4 +1,3 @@
-{{- if .Values.services.postprocessing.maintenance.restartPostprocessingFinished.enabled }}
 {{- include "ocis.basicServiceTemplates" (dict "scope" . "appName" "appNamePostprocessing" "appNameSuffix" "") -}}
 ---
 apiVersion: batch/v1
@@ -13,6 +12,8 @@ spec:
   successfulJobsHistoryLimit: 3
   failedJobsHistoryLimit: 3
   concurrencyPolicy: Forbid
+  startingDeadlineSeconds: {{ .Values.services.postprocessing.maintenance.restartPostprocessingFinished.startingDeadlineSeconds }}
+  suspend: {{ not .Values.services.postprocessing.maintenance.restartPostprocessingFinished.enabled }}
   jobTemplate:
     spec:
       parallelism: 1
@@ -50,9 +51,8 @@ spec:
               resources: {{ toYaml .jobResources | nindent 16 }}
 
           {{- include "ocis.imagePullSecrets" $ | nindent 10 }}
-{{ end }}
 
-{{- if and .Values.services.postprocessing.maintenance.restartPostprocessingVirusscan.enabled .Values.features.virusscan.enabled }}
+{{- if .Values.features.virusscan.enabled }}
 {{- include "ocis.basicServiceTemplates" (dict "scope" . "appName" "appNamePostprocessing" "appNameSuffix" "") -}}
 ---
 apiVersion: batch/v1
@@ -67,6 +67,8 @@ spec:
   successfulJobsHistoryLimit: 3
   failedJobsHistoryLimit: 3
   concurrencyPolicy: Forbid
+  startingDeadlineSeconds: {{ .Values.services.postprocessing.maintenance.restartPostprocessingVirusscan.startingDeadlineSeconds }}
+  suspend: {{ not .Values.services.postprocessing.maintenance.restartPostprocessingVirusscan.enabled }}
   jobTemplate:
     spec:
       parallelism: 1

--- a/charts/ocis/templates/storageusers/jobs.yaml
+++ b/charts/ocis/templates/storageusers/jobs.yaml
@@ -1,4 +1,4 @@
-{{- if and .Values.services.storageusers.persistence.enabled .Values.services.storageusers.maintenance.cleanUpExpiredUploads.enabled }}
+{{- if .Values.services.storageusers.persistence.enabled }}
 {{- include "ocis.basicServiceTemplates" (dict "scope" . "appName" "appNameStorageUsers" "appNameSuffix" "") -}}
 ---
 apiVersion: batch/v1
@@ -13,6 +13,8 @@ spec:
   successfulJobsHistoryLimit: 3
   failedJobsHistoryLimit: 3
   concurrencyPolicy: Forbid
+  startingDeadlineSeconds: {{ .Values.services.storageusers.maintenance.cleanUpExpiredUploads.startingDeadlineSeconds }}
+  suspend: {{ not .Values.services.storageusers.maintenance.cleanUpExpiredUploads.enabled }}
   jobTemplate:
     spec:
       parallelism: 1
@@ -108,7 +110,7 @@ spec:
               emptyDir: {}
             {{- include "ocis.persistence.dataVolume" . | nindent 12 }}
 {{ end }}
-{{- if and .Values.services.storageusers.persistence.enabled .Values.services.storageusers.maintenance.purgeExpiredTrashBinItems.enabled }}
+{{- if .Values.services.storageusers.persistence.enabled }}
 {{- include "ocis.basicServiceTemplates" (dict "scope" . "appName" "appNameStorageUsers" "appNameSuffix" "") -}}
 ---
 apiVersion: batch/v1
@@ -123,6 +125,8 @@ spec:
   successfulJobsHistoryLimit: 3
   failedJobsHistoryLimit: 3
   concurrencyPolicy: Forbid
+  startingDeadlineSeconds: {{ .Values.services.storageusers.maintenance.purgeExpiredTrashBinItems.startingDeadlineSeconds }}
+  suspend: {{ not .Values.services.storageusers.maintenance.purgeExpiredTrashBinItems.enabled }}
   jobTemplate:
     spec:
       parallelism: 1

--- a/charts/ocis/templates/thumbnails/jobs.yaml
+++ b/charts/ocis/templates/thumbnails/jobs.yaml
@@ -1,4 +1,4 @@
-{{- if and .Values.services.thumbnails.persistence.enabled .Values.services.thumbnails.maintenance.cleanUpOldThumbnails.enabled }}
+{{- if .Values.services.thumbnails.persistence.enabled }}
 {{- include "ocis.basicServiceTemplates" (dict "scope" . "appName" "appNameThumbnails" "appNameSuffix" "") -}}
 ---
 apiVersion: batch/v1
@@ -15,6 +15,8 @@ spec:
   successfulJobsHistoryLimit: 3
   failedJobsHistoryLimit: 3
   concurrencyPolicy: Forbid
+  startingDeadlineSeconds: {{ .Values.services.thumbnails.maintenance.cleanUpOldThumbnails.startingDeadlineSeconds }}
+  suspend: {{ not .Values.services.thumbnails.maintenance.cleanUpOldThumbnails.enabled }}
   jobTemplate:
     spec:
       parallelism: 1

--- a/charts/ocis/values.yaml
+++ b/charts/ocis/values.yaml
@@ -1417,14 +1417,18 @@ services:
         # -- Enables a job, that cleans up expired uploads. Requires persistence to be enabled and RWX storage.
         enabled: false
         # -- Cron pattern for the job to be run. Defaults to every minute.
-        schedule: "* * * * *"
+        schedule: "60 * * * *"
+        # Defines the a deadline (in whole seconds) for starting the Job, if that Job misses its scheduled time for any reason.
+        startingDeadlineSeconds: 600
       # -- Restart postprocessing for uploads hwich are currenlty in the virusscan step.
       # Only applicable when `.Values.features.virusscan.enabled` is set to `true`.
       restartPostprocessingVirusscan:
         # -- Enables a job, that purges expired trash bin items. Requires persistence to be enabled.
         enabled: false
         # -- Cron pattern for the job to be run. Defaults to every minute.
-        schedule: "* * * * *"
+        schedule: "60 * * * *"
+        # Defines the a deadline (in whole seconds) for starting the Job, if that Job misses its scheduled time for any reason.
+        startingDeadlineSeconds: 600
       # -- Image for the storageusers service maintenance jobs
       # Defaults to the same values as `image`
       image:
@@ -1807,7 +1811,9 @@ services:
         # -- Enables a job, that cleans up expired uploads. Requires persistence to be enabled and RWX storage.
         enabled: false
         # -- Cron pattern for the job to be run. Defaults to every minute.
-        schedule: "* * * * *"
+        schedule: "60 * * * *"
+        # Defines the a deadline (in whole seconds) for starting the Job, if that Job misses its scheduled time for any reason.
+        startingDeadlineSeconds: 600
         # -- Duration in seconds after which uploads will expire.
         #    WARNING: Setting this to a low number will lead to uploads being cancelled before they are finished and returning a 403 to the user.
         uploadExpiration: 86400
@@ -1816,7 +1822,9 @@ services:
         # -- Enables a job, that purges expired trash bin items. Requires persistence to be enabled.
         enabled: false
         # -- Cron pattern for the job to be run. Defaults to every minute.
-        schedule: "* * * * *"
+        schedule: "60 * * * *"
+        # Defines the a deadline (in whole seconds) for starting the Job, if that Job misses its scheduled time for any reason.
+        startingDeadlineSeconds: 600
         # -- Setting that makes the command delete all trashed personal files older than the value. The value is a number and a unit "d", "h", "m", "s".
         personalDeleteBefore: 30d
         # -- Setting that makes the command delete all trashed project files older than the value. The value is a number and a unit "d", "h", "m", "s".
@@ -2006,7 +2014,9 @@ services:
         # -- Enables a job, that cleans up old thumbnails. Requires persistence to be enabled.
         enabled: false
         # -- Cron pattern for the job to be run. Defaults to every minute.
-        schedule: "* * * * *"
+        schedule: "60 * * * *"
+        # Defines the a deadline (in whole seconds) for starting the Job, if that Job misses its scheduled time for any reason.
+        startingDeadlineSeconds: 600
         # -- Setting that makes the command delete all thumbnails older than the value. The value is a number in days.
         deleteBefore: 30
         # -- Method to use with BusyBox "find" for finding old thumbnails. Can be mtime, atime or ctime.


### PR DESCRIPTION
## Description
This PR implements issue 497. So CronJob will now be deployed all the time (if the corresponding service is enabled at all). Enabling the job in the values file will just switch if the `CronJob` is `suspend`ed or not.

## Related Issue
- Fixes https://github.com/owncloud/ocis-charts/issues/497

## Motivation and Context
Fixed issue 497

## How Has This Been Tested?
Tested with `helm template` via

```
helm template --debug --set features.virusscan.enabled=true,services.storageusers.persistence.enabled=true,services.thumbnails.persistence.enabled=true,services.thumbnails.maintenance.cleanUpOldThumbnails.enabled=true,services.storageusers.maintenance.purgeExpiredTrashBinItems.enabled=true,services.storageusers.maintenance.cleanUpExpiredUploads.enabled=true,services.postprocessing.maintenance.restartPostprocessingVirusscan.enabled=true,services.postprocessing.maintenance.restartPostprocessingFinished.enabled=true myowncloud charts/ocis/.
```

## Types of changes
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Technical debt
- [ ] Tests only (no source changes)

## Checklist:
- [x] Code changes
- [ ] Unit tests added
- [ ] Acceptance tests added
- [ ] Documentation generated (`make docs`) and committed
- [ ] Documentation ticket raised: <link>
- [ ] Documentation PR created: <link>
