### PR TITLE
generate initial admin passwort for builtin idp with 30 characters

### DIFF
--- a/charts/ocis/templates/idp/secret.yaml
+++ b/charts/ocis/templates/idp/secret.yaml
@@ -14,6 +14,6 @@
 {{ if and (not .Values.features.externalUserManagement.enabled) (not .Values.secretRefs.adminUserSecretRef) }}
 {{- $params := (dict)}}
 {{- $_ := set $params "user-id" uuidv4 }}
-{{- $_ := set $params "password" (randAlphaNum 10) }}
+{{- $_ := set $params "password" (randAlphaNum 30) }}
 {{- include "ocis.secret" (dict "scope" . "name" "admin-user" "params" $params)}}
 {{- end }}


### PR DESCRIPTION
## Description
I wondered since some time if we generate secrets that are "only" 10 characters.
Turns out it was only the bultin idp's initial admin user password.
This password probably also deserves 30 characters by default.


## Related Issue

## Motivation and Context

## How Has This Been Tested?
- run dev deployment, I got:
```
kubectl -n ocis get secrets/admin-user --template='{{.data.password | base64decode | printf "%s\n" }}'
V99YVkphujWZpa2nQnU2N2uK0dRL2i
```

## Screenshots (if appropriate):

## Types of changes
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Technical debt
- [ ] Tests only (no source changes)

## Checklist:
- [x] Code changes
- [ ] Unit tests added
- [ ] Acceptance tests added
- [ ] Documentation generated (`make docs`) and committed
- [ ] Documentation ticket raised: <link>
- [ ] Documentation PR created: <link>
