### PR TITLE
make theme configmap mountpath configurable

### DIFF
--- a/charts/ocis/docs/values-desc-table.adoc
+++ b/charts/ocis/docs/values-desc-table.adoc
@@ -4300,7 +4300,7 @@ a| [subs=-attributes]
 a| [subs=-attributes]
 +string+
 a| [subs=-attributes]
-`""`
+`"/themes/owncloud/theme.json"`
 | URL path to load themes from. The theme server will be prepended. Defaults to the ownCloud Web default theme.
 | services.web.config.theme.server
 a| [subs=-attributes]
@@ -4308,6 +4308,12 @@ a| [subs=-attributes]
 a| [subs=-attributes]
 `""`
 | URL to load themes from. Will be prepended to the theme path. Defaults to the value of "externalDomain".
+| services.web.config.theme.themeNameConfigRefs
+a| [subs=-attributes]
++string+
+a| [subs=-attributes]
+`"owncloud"`
+| Name of the theme you provide via `configRefs.webThemeConfigRef` and `configRefs.webThemeAssetsConfigRef`. If you change this when providing a custom theme, you must also change `theme.path`.
 | services.web.extraLabels
 a| [subs=-attributes]
 +object+

--- a/charts/ocis/docs/values.adoc.yaml
+++ b/charts/ocis/docs/values.adoc.yaml
@@ -2142,7 +2142,10 @@ services:
         # -- URL to load themes from. Will be prepended to the theme path. Defaults to the value of "externalDomain".
         server: ""
         # -- URL path to load themes from. The theme server will be prepended. Defaults to the ownCloud Web default theme.
-        path: ""
+        path: "/themes/owncloud/theme.json"
+        # -- Name of the theme you provide via `configRefs.webThemeConfigRef` and `configRefs.webThemeAssetsConfigRef`.
+        # If you change this when providing a custom theme, you must also change `theme.path`.
+        themeNameConfigRefs: "owncloud"
       # URI where to redirect the user after a logout was performed. Defaults to the URI of the login page.
       postLogoutRedirectURI: ""
       # Specifies the target url valid for the logged out / access denied page.

--- a/charts/ocis/templates/web/deployment.yaml
+++ b/charts/ocis/templates/web/deployment.yaml
@@ -168,11 +168,11 @@ spec:
               mountPath: /etc/ocis
             {{- if .Values.configRefs.webThemeConfigRef }}
             - name: theme
-              mountPath: /var/lib/ocis/web/assets/themes/owncloud
+              mountPath: "/var/lib/ocis/web/assets/themes/{{ .Values.services.web.config.theme.themeNameConfigRefs }}"
             {{- end }}
             {{- if .Values.configRefs.webThemeAssetsConfigRef }}
             - name: theme-assets
-              mountPath: /var/lib/ocis/web/assets/themes/owncloud/assets
+              mountPath: "/var/lib/ocis/web/assets/themes/{{ .Values.services.web.config.theme.themeNameConfigRefs }}/assets"
             {{- end }}
             - name: {{ include "ocis.persistence.dataVolumeName" . }}
               mountPath: /var/lib/ocis

--- a/charts/ocis/values.yaml
+++ b/charts/ocis/values.yaml
@@ -2141,7 +2141,10 @@ services:
         # -- URL to load themes from. Will be prepended to the theme path. Defaults to the value of "externalDomain".
         server: ""
         # -- URL path to load themes from. The theme server will be prepended. Defaults to the ownCloud Web default theme.
-        path: ""
+        path: "/themes/owncloud/theme.json"
+        # -- Name of the theme you provide via `configRefs.webThemeConfigRef` and `configRefs.webThemeAssetsConfigRef`.
+        # If you change this when providing a custom theme, you must also change `theme.path`.
+        themeNameConfigRefs: "owncloud"
       # URI where to redirect the user after a logout was performed. Defaults to the URI of the login page.
       postLogoutRedirectURI: ""
       # Specifies the target url valid for the logged out / access denied page.


### PR DESCRIPTION
## Description
make the theme config map mount path configurable

## Related Issue

## Motivation and Context

## How Has This Been Tested?

## Screenshots (if appropriate):

## Types of changes
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Technical debt
- [ ] Tests only (no source changes)

## Checklist:
- [x] Code changes
- [ ] Unit tests added
- [ ] Acceptance tests added
- [ ] Documentation generated (`make docs`) and committed
- [ ] Documentation ticket raised: <link>
- [ ] Documentation PR created: <link>
