### PR TITLE
configure serviceaccounts on storageusers cronjobs

### DIFF
--- a/charts/ocis/templates/storageusers/jobs.yaml
+++ b/charts/ocis/templates/storageusers/jobs.yaml
@@ -96,6 +96,17 @@ spec:
                       name: {{ include "config.storageUsers" . }}
                       key: storage-uuid
 
+                - name: STORAGE_USERS_SERVICE_ACCOUNT_ID
+                  valueFrom:
+                    configMapKeyRef:
+                      name: {{ include "config.authService" . }}
+                      key: service-account-id
+                - name: STORAGE_USERS_SERVICE_ACCOUNT_SECRET
+                  valueFrom:
+                    secretKeyRef:
+                      name: {{ include "secrets.serviceAccountSecret" . }}
+                      key: service-account-secret
+
               resources: {{ toYaml .jobResources | nindent 16 }}
 
               volumeMounts:
@@ -179,6 +190,17 @@ spec:
                     configMapKeyRef:
                       name: {{ include "config.storageUsers" . }}
                       key: storage-uuid
+
+                - name: STORAGE_USERS_SERVICE_ACCOUNT_ID
+                  valueFrom:
+                    configMapKeyRef:
+                      name: {{ include "config.authService" . }}
+                      key: service-account-id
+                - name: STORAGE_USERS_SERVICE_ACCOUNT_SECRET
+                  valueFrom:
+                    secretKeyRef:
+                      name: {{ include "secrets.serviceAccountSecret" . }}
+                      key: service-account-secret
 
               resources: {{ toYaml .jobResources | nindent 16 }}
 

--- a/deployments/development-install/helmfile.yaml
+++ b/deployments/development-install/helmfile.yaml
@@ -34,6 +34,15 @@ releases:
             persistence:
               enabled: true
 
+          postprocessing:
+            maintenance:
+              restartPostprocessingFinished:
+                enabled: true
+                schedule: "* * * * *"
+              restartPostprocessingVirusscan:
+                enabled: true
+                schedule: "* * * * *"
+
           search:
             persistence:
               enabled: true
@@ -45,10 +54,21 @@ releases:
           storageusers:
             persistence:
               enabled: true
+            maintenance:
+              cleanUpExpiredUploads:
+                enabled: true
+                schedule: "* * * * *"
+              purgeExpiredTrashBinItems:
+                enabled: true
+                schedule: "* * * * *"
 
           thumbnails:
             persistence:
               enabled: true
+            maintenance:
+              cleanUpOldThumbnails:
+                enabled: true
+                schedule: "* * * * *"
 
           web:
             persistence:


### PR DESCRIPTION
## Description
Configure serviceaccounts on storageusers cronjobs and enable cronjobs for development deployment.

Those cronjobs had failed before with this message:

```
The service account id has not been configured for storage-users.
Make sure your /etc/ocis config contains the proper values
(e.g. by running ocis init or setting it manually in the config/corresponding environment variable).
```

## Related Issue
- Fixes failing cronjobs

## Motivation and Context

## How Has This Been Tested?
- install the development-install deployment and observe the job run output / status

## Screenshots (if appropriate):

## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Technical debt
- [ ] Tests only (no source changes)

## Checklist:
- [x] Code changes
- [ ] Unit tests added
- [ ] Acceptance tests added
- [ ] Documentation generated (`make docs`) and committed
- [ ] Documentation ticket raised: <link>
- [ ] Documentation PR created: <link>
