### PR TITLE
allow to hide email addresses in the sharing search dialog

### DIFF
--- a/charts/ocis/docs/values-desc-table.adoc
+++ b/charts/ocis/docs/values-desc-table.adoc
@@ -714,18 +714,18 @@ a| [subs=-attributes]
 a| [subs=-attributes]
 `true`
 | Allow a share receiver to share the share with a 3rd person.
-| features.sharing.users.search.maskEmailAddresses
-a| [subs=-attributes]
-+bool+
-a| [subs=-attributes]
-`false`
-| Mask user email addresses in responses.
 | features.sharing.users.search.minLengthLimit
 a| [subs=-attributes]
 +int+
 a| [subs=-attributes]
 `3`
 | Minimum number of characters to enter before a client should start a search for Share receivers. This setting can be used to customize the user experience if e.g too many results are displayed.
+| features.sharing.users.search.showUserEmail
+a| [subs=-attributes]
++bool+
+a| [subs=-attributes]
+`true`
+| Show user email when searching for other users to share with.
 | features.sse.disabled
 a| [subs=-attributes]
 +bool+

--- a/charts/ocis/docs/values-desc-table.adoc
+++ b/charts/ocis/docs/values-desc-table.adoc
@@ -714,6 +714,12 @@ a| [subs=-attributes]
 a| [subs=-attributes]
 `true`
 | Allow a share receiver to share the share with a 3rd person.
+| features.sharing.users.search.maskEmailAddresses
+a| [subs=-attributes]
++bool+
+a| [subs=-attributes]
+`false`
+| Mask user email addresses in responses.
 | features.sharing.users.search.minLengthLimit
 a| [subs=-attributes]
 +int+

--- a/charts/ocis/docs/values.adoc.yaml
+++ b/charts/ocis/docs/values.adoc.yaml
@@ -203,8 +203,8 @@ features:
         # -- Minimum number of characters to enter before a client should start a search for Share receivers.
         # This setting can be used to customize the user experience if e.g too many results are displayed.
         minLengthLimit: 3
-        # -- Mask user email addresses in responses.
-        maskEmailAddresses: false
+        # -- Show user email when searching for other users to share with.
+        showUserEmail: true
     # Sharing per public link related setings
     publiclink:
       # -- Enforce a password on all public link shares.

--- a/charts/ocis/docs/values.adoc.yaml
+++ b/charts/ocis/docs/values.adoc.yaml
@@ -203,6 +203,8 @@ features:
         # -- Minimum number of characters to enter before a client should start a search for Share receivers.
         # This setting can be used to customize the user experience if e.g too many results are displayed.
         minLengthLimit: 3
+        # -- Mask user email addresses in responses.
+        maskEmailAddresses: false
     # Sharing per public link related setings
     publiclink:
       # -- Enforce a password on all public link shares.

--- a/charts/ocis/templates/frontend/deployment.yaml
+++ b/charts/ocis/templates/frontend/deployment.yaml
@@ -101,6 +101,9 @@ spec:
             - name: OCIS_DISABLE_SSE
               value: {{ .Values.features.sse.disabled | quote }}
 
+            - name: OCIS_SHOW_USER_EMAIL_IN_RESULTS
+              value: {{ .Values.features.sharing.users.search.showUserEmail | quote }}
+
             # cache
             # the stat cache is disabled for now for performance reasons, see https://github.com/owncloud/ocis-charts/issues/214
             - name: FRONTEND_OCS_STAT_CACHE_STORE

--- a/charts/ocis/templates/frontend/deployment.yaml
+++ b/charts/ocis/templates/frontend/deployment.yaml
@@ -104,7 +104,6 @@ spec:
             - name: OCIS_DISABLE_SSE
               value: {{ .Values.features.sse.disabled | quote }}
 
-
             # cache
             # the stat cache is disabled for now for performance reasons, see https://github.com/owncloud/ocis-charts/issues/214
             - name: FRONTEND_OCS_STAT_CACHE_STORE

--- a/charts/ocis/templates/frontend/deployment.yaml
+++ b/charts/ocis/templates/frontend/deployment.yaml
@@ -98,11 +98,12 @@ spec:
             - name: FRONTEND_FULL_TEXT_SEARCH_ENABLED
               value: {{ not (eq .Values.services.search.extractor.type "basic") | quote }}
 
+            - name: FRONTEND_SHOW_USER_EMAIL_IN_RESULTS
+              value: {{ .Values.features.sharing.users.search.showUserEmail | quote }}
+
             - name: OCIS_DISABLE_SSE
               value: {{ .Values.features.sse.disabled | quote }}
 
-            - name: OCIS_SHOW_USER_EMAIL_IN_RESULTS
-              value: {{ .Values.features.sharing.users.search.showUserEmail | quote }}
 
             # cache
             # the stat cache is disabled for now for performance reasons, see https://github.com/owncloud/ocis-charts/issues/214

--- a/charts/ocis/templates/ocs/deployment.yaml
+++ b/charts/ocis/templates/ocs/deployment.yaml
@@ -51,9 +51,6 @@ spec:
             - name: OCS_DEBUG_ADDR
               value: 0.0.0.0:9114
 
-            - name: OCIS_SHOW_USER_EMAIL_IN_RESULTS
-              value: {{ not .Values.features.sharing.users.search.maskEmailAddresses | quote }}
-
             - name: OCS_IDM_ADDRESS
             {{ if not .Values.features.externalUserManagement.enabled }}
               value: "https://{{ .Values.externalDomain }}"

--- a/charts/ocis/templates/ocs/deployment.yaml
+++ b/charts/ocis/templates/ocs/deployment.yaml
@@ -51,6 +51,9 @@ spec:
             - name: OCS_DEBUG_ADDR
               value: 0.0.0.0:9114
 
+            - name: OCIS_SHOW_USER_EMAIL_IN_RESULTS
+              value: {{ not .Values.features.sharing.users.search.maskEmailAddresses | quote }}
+
             - name: OCS_IDM_ADDRESS
             {{ if not .Values.features.externalUserManagement.enabled }}
               value: "https://{{ .Values.externalDomain }}"

--- a/charts/ocis/values.yaml
+++ b/charts/ocis/values.yaml
@@ -202,8 +202,8 @@ features:
         # -- Minimum number of characters to enter before a client should start a search for Share receivers.
         # This setting can be used to customize the user experience if e.g too many results are displayed.
         minLengthLimit: 3
-        # -- Mask user email addresses in responses.
-        maskEmailAddresses: false
+        # -- Show user email when searching for other users to share with.
+        showUserEmail: true
     # Sharing per public link related setings
     publiclink:
       # -- Enforce a password on all public link shares.

--- a/charts/ocis/values.yaml
+++ b/charts/ocis/values.yaml
@@ -202,6 +202,8 @@ features:
         # -- Minimum number of characters to enter before a client should start a search for Share receivers.
         # This setting can be used to customize the user experience if e.g too many results are displayed.
         minLengthLimit: 3
+        # -- Mask user email addresses in responses.
+        maskEmailAddresses: false
     # Sharing per public link related setings
     publiclink:
       # -- Enforce a password on all public link shares.


### PR DESCRIPTION
## Description
mask emails by default

## Related Issue

- uses https://github.com/owncloud/ocis/pull/8781 and https://github.com/owncloud/ocis/pull/8825/commits/12c785e5846e66ec4643f5f1e0b4d942c0519427  from https://github.com/owncloud/ocis/pull/8825
- needs https://github.com/owncloud/ocis-charts/pull/524 first for chart and application version bump

## Motivation and Context

## How Has This Been Tested?
- use the development example with this modification:

```diff
diff --git a/deployments/development-install/helmfile.yaml b/deployments/development-install/helmfile.yaml
index 762c62d..a38d76c 100644
--- a/deployments/development-install/helmfile.yaml
+++ b/deployments/development-install/helmfile.yaml
@@ -25,6 +25,16 @@ releases:
           demoUsers: true
           basicAuthentication: true
 
+      - image:
+          repository: wkloucek/ocis
+          tag: release-5.0.1-8d1ba0244c3203c9bd2ac05b683d01afe885fc8d
+
+      - features:
+          sharing:
+            users:
+              search:
+                showUserEmail: false # you can also use true = the chart default to show them
+
       - services:
           idm:
             persistence:
```

then create another user and share a file with this user. In the sharing dialog, you should see 

- if showUserEmail is set to true:

![image](https://github.com/owncloud/ocis-charts/assets/34452982/da90c26a-f037-4664-a4e3-02513eef50d3)


- if showUserEmail is set to false:

![image](https://github.com/owncloud/ocis-charts/assets/34452982/f4c2a3e2-bc83-4f29-af8b-198806de71e0)


## Screenshots (if appropriate):

## Types of changes
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Technical debt
- [ ] Tests only (no source changes)

## Checklist:
- [x] Code changes
- [ ] Unit tests added
- [ ] Acceptance tests added
- [x] Documentation generated (`make docs`) and committed
- [ ] Documentation ticket raised: <link>
- [ ] Documentation PR created: <link>
