### PR TITLE
Add STORAGE_USERS_GATEWAY_GRPC_ADDR for CLI tool

### DIFF
--- a/charts/ocis/templates/storageusers/deployment.yaml
+++ b/charts/ocis/templates/storageusers/deployment.yaml
@@ -39,6 +39,9 @@ spec:
             {{- include "ocis.events" . | nindent 12 }}
             {{- include "ocis.cacheStore" . | nindent 12 }}
 
+            # set the gateway for the CLI tools
+            - name: STORAGE_USERS_GATEWAY_GRPC_ADDR
+              value: {{ .appNameGateway }}:9142
             # logging
             - name: STORAGE_USERS_LOG_COLOR
               value: {{ .Values.logging.color | quote }}


### PR DESCRIPTION
## Description
This PR adds STORAGE_USERS_GATEWAY_GRPC_ADDR so that the CLI tools can be used

## Related Issue
- None

## Motivation and Context
Currently the CLI tools don't work as they can't connect to the gateway

## How Has This Been Tested?
- Tested via `helm template`:

```
            - name: STORAGE_USERS_GATEWAY_GRPC_ADDR
              value: gateway:9142
```

## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Technical debt
- [ ] Tests only (no source changes)

## Checklist:
- [ ] Code changes
- [ ] Unit tests added
- [ ] Acceptance tests added
- [ ] Documentation generated (`make docs`) and committed
- [ ] Documentation ticket raised: <link>
- [ ] Documentation PR created: <link>
