### PR TITLE
expose storageusers event concurrency setting

### DIFF
--- a/charts/ocis/docs/values-desc-table.adoc
+++ b/charts/ocis/docs/values-desc-table.adoc
@@ -3498,6 +3498,12 @@ a| [subs=-attributes]
 a| [subs=-attributes]
 `{}`
 | Per-service autoscaling. Overrides the default setting from `autoscaling` if set.
+| services.storageusers.events.consumer.concurrency
+a| [subs=-attributes]
++int+
+a| [subs=-attributes]
+`10`
+| Number of event consumers to be started that concurrently consume events (eg. postprocessing related events)
 | services.storageusers.extraLabels
 a| [subs=-attributes]
 +object+

--- a/charts/ocis/docs/values.adoc.yaml
+++ b/charts/ocis/docs/values.adoc.yaml
@@ -1723,6 +1723,11 @@ services:
   # -- STORAGE-USERS service.
   # @default -- see detailed service configuration options below
   storageusers:
+    events:
+      consumer:
+        # -- Number of event consumers to be started that concurrently consume events (eg. postprocessing related events)
+        concurrency: 10
+
     storageBackend:
       # -- Configures the storage driver. Possible values are "ocis" and "s3ng".
       # The oCIS driver stores all data in the persistent volume if persistence is enabled.

--- a/charts/ocis/templates/storageusers/deployment.yaml
+++ b/charts/ocis/templates/storageusers/deployment.yaml
@@ -173,6 +173,8 @@ spec:
 
             - name: OCIS_ASYNC_UPLOADS
               value: "true"
+            - name: STORAGE_USERS_EVENTS_NUM_CONSUMERS
+              value: {{ .Values.services.storageusers.events.consumer.concurrency | quote }}
 
             - name: STORAGE_USERS_DATA_GATEWAY_URL
               value: "http://{{ .appNameFrontend }}:9140/data/"

--- a/charts/ocis/values.yaml
+++ b/charts/ocis/values.yaml
@@ -1722,6 +1722,11 @@ services:
   # -- STORAGE-USERS service.
   # @default -- see detailed service configuration options below
   storageusers:
+    events:
+      consumer:
+        # -- Number of event consumers to be started that concurrently consume events (eg. postprocessing related events)
+        concurrency: 10
+
     storageBackend:
       # -- Configures the storage driver. Possible values are "ocis" and "s3ng".
       # The oCIS driver stores all data in the persistent volume if persistence is enabled.


### PR DESCRIPTION
## Description
expose the `STORAGE_USERS_EVENTS_NUM_CONSUMERS` setting to work faster to the postprocessing queue.

## Related Issue


## Motivation and Context

## How Has This Been Tested?
using the NATS deployment example:

- make all files stuck in postprocessing: `kubectl exec -n ocis-nats deployments/nats-box -- sh -c 'nats consumer rm -f main-queue antivirus; nats consumer rm -f main-queue audit; nats consumer rm -f main-queue clientlog; nats consumer rm -f main-queue dcfs; nats consumer rm -f main-queue evhistory; nats consumer rm -f main-queue frontend; nats consumer rm -f main-queue notifications; nats consumer rm -f main-queue policies; nats consumer rm -f main-queue postprocessing; nats consumer rm -f main-queue search; nats consumer rm -f main-queue storage-users; nats consumer rm -f main-queue userlog'`
- upload a lot of files, I used ~6000 files
- recreate oCIS NATS clients: `kubectl rollout restart -n ocis deployment`
- restart the postprocessing: `kubectl -n ocis exec deployment/storageusers -it -- ocis storage-users uploads sessions --restart`
- look at `kubectl exec -n ocis-nats deployments/nats-box -- nats consumer report main-queue` and stop the time until "unprocessed" for the "dcfs" client equals zero

With the product default:

```diff
diff --git a/deployments/ocis-nats/helmfile.yaml b/deployments/ocis-nats/helmfile.yaml
index 7948ca1..fbed3de 100644
--- a/deployments/ocis-nats/helmfile.yaml
+++ b/deployments/ocis-nats/helmfile.yaml
@@ -130,6 +130,9 @@ releases:
           storageusers:
             persistence:
               enabled: true
+            events:
+              consumer:
+                concurrency: 1
 
           thumbnails:
             persistence:
```

the postprocessing took more than 10 minutes

While with

```diff
diff --git a/deployments/ocis-nats/helmfile.yaml b/deployments/ocis-nats/helmfile.yaml
index 7948ca1..fbed3de 100644
--- a/deployments/ocis-nats/helmfile.yaml
+++ b/deployments/ocis-nats/helmfile.yaml
@@ -130,6 +130,9 @@ releases:
           storageusers:
             persistence:
               enabled: true
+            events:
+              consumer:
+                concurrency: 100
 
           thumbnails:
             persistence:
```

it took about 3 minutes.

## Screenshots (if appropriate):

## Types of changes
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Technical debt
- [ ] Tests only (no source changes)

## Checklist:
- [x] Code changes
- [ ] Unit tests added
- [ ] Acceptance tests added
- [x] Documentation generated (`make docs`) and committed
- [ ] Documentation ticket raised: <link>
- [ ] Documentation PR created: <link>
