### PR TITLE
fix deprecated antivirus scan timout setting

### DIFF
--- a/charts/ocis/templates/antivirus/deployment.yaml
+++ b/charts/ocis/templates/antivirus/deployment.yaml
@@ -52,7 +52,7 @@ spec:
               value: {{ .Values.features.virusscan.infectedFileHandling | quote }}
             - name: ANTIVIRUS_SCANNER_TYPE
               value: "icap"
-            - name: ANTIVIRUS_ICAP_TIMEOUT
+            - name: ANTIVIRUS_ICAP_SCAN_TIMEOUT
               value: {{ .Values.features.virusscan.icap.timeout | quote }}
             - name: ANTIVIRUS_ICAP_URL
               value: {{ .Values.features.virusscan.icap.url | quote }}


### PR DESCRIPTION
## Description
fix a antivirus environment variable depreciation

## Related Issue
- fixes `ANTIVIRUS_ICAP_TIMEOUT is deprecated, use ANTIVIRUS_ICAP_SCAN_TIMEOUT instead`

## Motivation and Context

## How Has This Been Tested?
- not tested

## Screenshots (if appropriate):

## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Technical debt
- [ ] Tests only (no source changes)

## Checklist:
- [x] Code changes
- [ ] Unit tests added
- [ ] Acceptance tests added
- [ ] Documentation generated (`make docs`) and committed
- [ ] Documentation ticket raised: <link>
- [ ] Documentation PR created: <link>
