### PR TITLE
restart only postprocessings that were not classified as virus

### DIFF
--- a/charts/ocis/templates/storageusers/jobs.yaml
+++ b/charts/ocis/templates/storageusers/jobs.yaml
@@ -251,7 +251,7 @@ spec:
             - name: storage-users-restart-postprocessing
               {{- include "ocis.jobContainerImageOcis" . | nindent 14 }}
               command: ["ocis"]
-              args: ["storage-users", "uploads", "sessions", "--restart"]
+              args: ["storage-users", "uploads", "sessions", "--restart", "--processing=true"]
               securityContext:
                 runAsNonRoot: true
                 runAsUser: {{ .Values.securityContext.runAsUser }}


### PR DESCRIPTION
## Description
only restart postprocessings that haven't been classified as virus files yet

## Related Issue

## Motivation and Context

## How Has This Been Tested?
in a setup that has a virus scanner

## Screenshots (if appropriate):

## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Technical debt
- [ ] Tests only (no source changes)

## Checklist:
- [x] Code changes
- [ ] Unit tests added
- [ ] Acceptance tests added
- [ ] Documentation generated (`make docs`) and committed
- [ ] Documentation ticket raised: <link>
- [ ] Documentation PR created: <link>
