### PR TITLE
switch keycloak chart submodule to https protocol and shallow

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,3 +1,4 @@
 [submodule "deployments/external-user-management/charts/keycloak-k8s-resources"]
 	path = deployments/external-user-management/charts/keycloak-k8s-resources
-	url = git@github.com:keycloak/keycloak-k8s-resources.git
+	url = https://github.com/keycloak/keycloak-k8s-resources.git
+	shallow = true


### PR DESCRIPTION
## Description
Allows cloning the submodule in environments without ssh key.

## Related Issue
- Fixes #546

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->

## How Has This Been Tested?
- `git submodule deinit --all -f`
- doing the change
- `git submodule update --init --recursive`

## Screenshots (if appropriate):

## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Technical debt
- [ ] Tests only (no source changes)

## Checklist:
- [x] Code changes
- [ ] Unit tests added
- [ ] Acceptance tests added
- [ ] Documentation generated (`make docs`) and committed
- [ ] Documentation ticket raised: <link>
- [ ] Documentation PR created: <link>
