### PR TITLE
add appProtocol to services

### DIFF
--- a/charts/ocis/templates/antivirus/service.yaml
+++ b/charts/ocis/templates/antivirus/service.yaml
@@ -16,4 +16,5 @@ spec:
     - name: metrics-debug
       port: 9277
       protocol: TCP
+      appProtocol: http
 {{ end }}

--- a/charts/ocis/templates/appprovider/service.yaml
+++ b/charts/ocis/templates/appprovider/service.yaml
@@ -19,9 +19,11 @@ spec:
     - name: grpc
       port: 9164
       protocol: TCP
+      appProtocol: grpc
     - name: metrics-debug
       port: 9165
       protocol: TCP
+      appProtocol: http
 {{ end }}
 {{ end }}
 {{ end }}

--- a/charts/ocis/templates/appregistry/service.yaml
+++ b/charts/ocis/templates/appregistry/service.yaml
@@ -15,6 +15,8 @@ spec:
     - name: grpc
       port: 9242
       protocol: TCP
+      appProtocol: grpc
     - name: metrics-debug
       port: 9243
       protocol: TCP
+      appProtocol: http

--- a/charts/ocis/templates/audit/service.yaml
+++ b/charts/ocis/templates/audit/service.yaml
@@ -15,3 +15,4 @@ spec:
     - name: metrics-debug
       port: 9229
       protocol: TCP
+      appProtocol: http

--- a/charts/ocis/templates/authbasic/service.yaml
+++ b/charts/ocis/templates/authbasic/service.yaml
@@ -16,7 +16,9 @@ spec:
     - name: grpc
       port: 9146
       protocol: TCP
+      appProtocol: grpc
     - name: metrics-debug
       port: 9147
       protocol: TCP
+      appProtocol: http
 {{ end }}

--- a/charts/ocis/templates/authmachine/service.yaml
+++ b/charts/ocis/templates/authmachine/service.yaml
@@ -15,6 +15,8 @@ spec:
     - name: grpc
       port: 9166
       protocol: TCP
+      appProtocol: grpc
     - name: metrics-debug
       port: 9167
       protocol: TCP
+      appProtocol: http

--- a/charts/ocis/templates/authservice/service.yaml
+++ b/charts/ocis/templates/authservice/service.yaml
@@ -15,6 +15,8 @@ spec:
     - name: grpc
       port: 9616
       protocol: TCP
+      appProtocol: grpc
     - name: metrics-debug
       port: 9617
       protocol: TCP
+      appProtocol: http

--- a/charts/ocis/templates/clientlog/service.yaml
+++ b/charts/ocis/templates/clientlog/service.yaml
@@ -15,3 +15,4 @@ spec:
     - name: metrics-debug
       port: 9260
       protocol: TCP
+      appProtocol: http

--- a/charts/ocis/templates/eventhistory/service.yaml
+++ b/charts/ocis/templates/eventhistory/service.yaml
@@ -15,6 +15,8 @@ spec:
     - name: grpc
       port: 8080
       protocol: TCP
+      appProtocol: grpc
     - name: metrics-debug
       port: 9270
       protocol: TCP
+      appProtocol: http

--- a/charts/ocis/templates/frontend/service.yaml
+++ b/charts/ocis/templates/frontend/service.yaml
@@ -15,6 +15,8 @@ spec:
     - name: http
       port: 9140
       protocol: TCP
+      appProtocol: http
     - name: metrics-debug
       port: 9141
       protocol: TCP
+      appProtocol: http

--- a/charts/ocis/templates/gateway/service.yaml
+++ b/charts/ocis/templates/gateway/service.yaml
@@ -15,6 +15,8 @@ spec:
     - name: grpc
       port: 9142
       protocol: TCP
+      appProtocol: grpc
     - name: metrics-debug
       port: 9143
       protocol: TCP
+      appProtocol: http

--- a/charts/ocis/templates/graph/service.yaml
+++ b/charts/ocis/templates/graph/service.yaml
@@ -15,6 +15,8 @@ spec:
     - name: http
       port: 9120
       protocol: TCP
+      appProtocol: http
     - name: metrics-debug
       port: 9124
       protocol: TCP
+      appProtocol: http

--- a/charts/ocis/templates/groups/service.yaml
+++ b/charts/ocis/templates/groups/service.yaml
@@ -15,6 +15,8 @@ spec:
     - name: grpc
       port: 9160
       protocol: TCP
+      appProtocol: grpc
     - name: metrics-debug
       port: 9161
       protocol: TCP
+      appProtocol: http

--- a/charts/ocis/templates/idm/service.yaml
+++ b/charts/ocis/templates/idm/service.yaml
@@ -16,7 +16,9 @@ spec:
     - name: ldaps
       port: 9235
       protocol: TCP
+      appProtocol: tcp
     - name: metrics-debug
       port: 9239
       protocol: TCP
+      appProtocol: http
 {{- end }}

--- a/charts/ocis/templates/idp/service.yaml
+++ b/charts/ocis/templates/idp/service.yaml
@@ -16,7 +16,9 @@ spec:
     - name: http
       port: 9130
       protocol: TCP
+      appProtocol: http
     - name: metrics-debug
       port: 9134
       protocol: TCP
+      appProtocol: http
 {{- end }}

--- a/charts/ocis/templates/nats/service.yaml
+++ b/charts/ocis/templates/nats/service.yaml
@@ -16,7 +16,9 @@ spec:
     - name: nats
       port: 9233
       protocol: TCP
+      appProtocol: tcp
     - name: metrics-debug
       port: 9234
       protocol: TCP
+      appProtocol: http
 {{- end }}

--- a/charts/ocis/templates/notifications/service.yaml
+++ b/charts/ocis/templates/notifications/service.yaml
@@ -16,4 +16,5 @@ spec:
     - name: metrics-debug
       port: 9174
       protocol: TCP
+      appProtocol: http
 {{- end }}

--- a/charts/ocis/templates/ocdav/service.yaml
+++ b/charts/ocis/templates/ocdav/service.yaml
@@ -15,6 +15,8 @@ spec:
     - name: http
       port: 8080
       protocol: TCP
+      appProtocol: http
     - name: metrics-debug
       port: 9163
       protocol: TCP
+      appProtocol: http

--- a/charts/ocis/templates/ocs/service.yaml
+++ b/charts/ocis/templates/ocs/service.yaml
@@ -15,6 +15,8 @@ spec:
     - name: http
       port: 9110
       protocol: TCP
+      appProtocol: http
     - name: metrics-debug
       port: 9114
       protocol: TCP
+      appProtocol: http

--- a/charts/ocis/templates/policies/service.yaml
+++ b/charts/ocis/templates/policies/service.yaml
@@ -16,7 +16,9 @@ spec:
     - name: grpc
       port: 9125
       protocol: TCP
+      appProtocol: grpc
     - name: metrics-debug
       port: 9129
       protocol: TCP
+      appProtocol: http
 {{ end }}

--- a/charts/ocis/templates/postprocessing/service.yaml
+++ b/charts/ocis/templates/postprocessing/service.yaml
@@ -15,3 +15,4 @@ spec:
     - name: metrics-debug
       port: 9255
       protocol: TCP
+      appProtocol: http

--- a/charts/ocis/templates/proxy/service.yaml
+++ b/charts/ocis/templates/proxy/service.yaml
@@ -14,8 +14,9 @@ spec:
   ports:
     - name: http
       protocol: TCP
+      appProtocol: http
       port: 9200
-      targetPort: 9200
     - name: metrics-debug
       port: 9205
       protocol: TCP
+      appProtocol: http

--- a/charts/ocis/templates/search/service.yaml
+++ b/charts/ocis/templates/search/service.yaml
@@ -15,6 +15,8 @@ spec:
     - name: grpc
       port: 9220
       protocol: TCP
+      appProtocol: grpc
     - name: metrics-debug
       port: 9224
       protocol: TCP
+      appProtocol: http

--- a/charts/ocis/templates/settings/service.yaml
+++ b/charts/ocis/templates/settings/service.yaml
@@ -15,9 +15,12 @@ spec:
     - name: grpc
       port: 9191
       protocol: TCP
+      appProtocol: grpc
     - name: http
       port: 9190
       protocol: TCP
+      appProtocol: http
     - name: metrics-debug
       port: 9194
       protocol: TCP
+      appProtocol: http

--- a/charts/ocis/templates/sharing/service.yaml
+++ b/charts/ocis/templates/sharing/service.yaml
@@ -15,6 +15,8 @@ spec:
     - name: grpc
       port: 9150
       protocol: TCP
+      appProtocol: grpc
     - name: metrics-debug
       port: 9151
       protocol: TCP
+      appProtocol: http

--- a/charts/ocis/templates/sse/service.yaml
+++ b/charts/ocis/templates/sse/service.yaml
@@ -15,6 +15,8 @@ spec:
     - name: http
       port: 9939
       protocol: TCP
+      appProtocol: http
     - name: metrics-debug
       port: 9135
       protocol: TCP
+      appProtocol: http

--- a/charts/ocis/templates/storagepubliclink/service.yaml
+++ b/charts/ocis/templates/storagepubliclink/service.yaml
@@ -15,6 +15,8 @@ spec:
     - name: grpc
       port: 9178
       protocol: TCP
+      appProtocol: grpc
     - name: metrics-debug
       port: 9179
       protocol: TCP
+      appProtocol: http

--- a/charts/ocis/templates/storageshares/service.yaml
+++ b/charts/ocis/templates/storageshares/service.yaml
@@ -15,6 +15,8 @@ spec:
     - name: grpc
       port: 9154
       protocol: TCP
+      appProtocol: grpc
     - name: metrics-debug
       port: 9156
       protocol: TCP
+      appProtocol: http

--- a/charts/ocis/templates/storagesystem/service.yaml
+++ b/charts/ocis/templates/storagesystem/service.yaml
@@ -15,9 +15,12 @@ spec:
     - name: grpc
       port: 9215
       protocol: TCP
+      appProtocol: grpc
     - name: http
       port: 9216
       protocol: TCP
+      appProtocol: http
     - name: metrics-debug
       port: 9217
       protocol: TCP
+      appProtocol: http

--- a/charts/ocis/templates/storageusers/service.yaml
+++ b/charts/ocis/templates/storageusers/service.yaml
@@ -15,9 +15,12 @@ spec:
     - name: grpc
       port: 9157
       protocol: TCP
+      appProtocol: grpc
     - name: http
       port: 9158
       protocol: TCP
+      appProtocol: http
     - name: metrics-debug
       port: 9159
       protocol: TCP
+      appProtocol: http

--- a/charts/ocis/templates/thumbnails/service.yaml
+++ b/charts/ocis/templates/thumbnails/service.yaml
@@ -15,9 +15,12 @@ spec:
     - name: grpc
       port: 9185
       protocol: TCP
+      appProtocol: grpc
     - name: http
       port: 9186
       protocol: TCP
+      appProtocol: http
     - name: metrics-debug
       port: 9189
       protocol: TCP
+      appProtocol: http

--- a/charts/ocis/templates/userlog/service.yaml
+++ b/charts/ocis/templates/userlog/service.yaml
@@ -15,6 +15,8 @@ spec:
     - name: http
       port: 8080
       protocol: TCP
+      appProtocol: http
     - name: metrics-debug
       port: 9210
       protocol: TCP
+      appProtocol: http

--- a/charts/ocis/templates/users/service.yaml
+++ b/charts/ocis/templates/users/service.yaml
@@ -15,6 +15,8 @@ spec:
     - name: grpc
       port: 9144
       protocol: TCP
+      appProtocol: grpc
     - name: metrics-debug
       port: 9145
       protocol: TCP
+      appProtocol: http

--- a/charts/ocis/templates/web/service.yaml
+++ b/charts/ocis/templates/web/service.yaml
@@ -15,6 +15,8 @@ spec:
     - name: http
       port: 9100
       protocol: TCP
+      appProtocol: http
     - name: metrics-debug
       port: 9104
       protocol: TCP
+      appProtocol: http

--- a/charts/ocis/templates/webdav/service.yaml
+++ b/charts/ocis/templates/webdav/service.yaml
@@ -15,6 +15,8 @@ spec:
     - name: http
       port: 9115
       protocol: TCP
+      appProtocol: http
     - name: metrics-debug
       port: 9119
       protocol: TCP
+      appProtocol: http

--- a/charts/ocis/templates/webfinger/service.yaml
+++ b/charts/ocis/templates/webfinger/service.yaml
@@ -15,6 +15,8 @@ spec:
     - name: http
       port: 8080
       protocol: TCP
+      appProtocol: http
     - name: metrics-debug
       port: 8081
       protocol: TCP
+      appProtocol: http


### PR DESCRIPTION
## Description
adds the appProtocol field to all service

## Related Issue
- Documentation:
  - https://kubernetes.io/docs/concepts/services-networking/service/#application-protocol
  - https://istio.io/latest/docs/ops/configuration/traffic-management/protocol-selection/#explicit-protocol-selection
- fixes #471

## Motivation and Context
have the correct appProtocol set so that service meshes don't need to guesstimate the protocol.

## How Has This Been Tested?
- by the linter only

## Screenshots (if appropriate):

## Types of changes

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Technical debt
- [ ] Tests only (no source changes)

## Checklist:
- [x] Code changes
- [ ] Unit tests added
- [ ] Acceptance tests added
- [ ] Documentation generated (`make docs`) and committed
- [ ] Documentation ticket raised: <link>
- [ ] Documentation PR created: <link>
