### PR TITLE
set ttlSecondsAfterFinished for all jobs to 1 day

### DIFF
--- a/charts/ocis/templates/storageusers/jobs.yaml
+++ b/charts/ocis/templates/storageusers/jobs.yaml
@@ -18,6 +18,7 @@ spec:
   jobTemplate:
     spec:
       parallelism: 1
+      ttlSecondsAfterFinished: 86400
       template:
         metadata:
           labels:
@@ -141,6 +142,7 @@ spec:
   jobTemplate:
     spec:
       parallelism: 1
+      ttlSecondsAfterFinished: 86400
       template:
         metadata:
           labels:
@@ -237,6 +239,7 @@ spec:
   jobTemplate:
     spec:
       parallelism: 1
+      ttlSecondsAfterFinished: 86400
       template:
         metadata:
           labels:

--- a/charts/ocis/templates/thumbnails/jobs.yaml
+++ b/charts/ocis/templates/thumbnails/jobs.yaml
@@ -20,6 +20,7 @@ spec:
   jobTemplate:
     spec:
       parallelism: 1
+      ttlSecondsAfterFinished: 86400
       template:
         metadata:
           labels:


### PR DESCRIPTION
## Description
sets ttlSecondsAfterFinished for all (cron)jobs to 1 day

## Related Issue
- Fixes #465

## Motivation and Context
https://kubernetes.io/docs/concepts/workloads/controllers/job/#ttl-mechanism-for-finished-jobs

```
It is recommended to set ttlSecondsAfterFinished field because unmanaged jobs
(Jobs that you created directly, and not indirectly through other workload APIs such as CronJob)
have a default deletion policy of orphanDependents causing Pods created by an unmanaged Job to
be left around after that Job is fully deleted. Even though the control plane eventually garbage
collects the Pods from a deleted Job after they either fail or complete, sometimes those
lingering pods may cause cluster performance degradation or in worst case cause the cluster
to go offline due to this degradation.
```

## How Has This Been Tested?
- linter in ci
- deployed development-install example to minikube

## Screenshots (if appropriate):

## Types of changes
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Technical debt
- [ ] Tests only (no source changes)

## Checklist:
- [x] Code changes
- [ ] Unit tests added
- [ ] Acceptance tests added
- [ ] Documentation generated (`make docs`) and committed
- [ ] Documentation ticket raised: <link>
- [ ] Documentation PR created: <link>
