### PR TITLE
bump wopiserver image to 10.4.0

### DIFF
--- a/deployments/ocis-office/helmfile.yaml
+++ b/deployments/ocis-office/helmfile.yaml
@@ -108,6 +108,7 @@ releases:
     version: 0.9.2
     values:
       - image:
+          # renovate: datasource=docker depName=cs3org/wopiserver
           tag: v10.4.0
       - wopiserverUrl: http://wopiserver.wopiserver.svc.cluster.local:8880
       - config:

--- a/deployments/ocis-office/helmfile.yaml
+++ b/deployments/ocis-office/helmfile.yaml
@@ -107,6 +107,8 @@ releases:
     chart: cs3org/wopiserver
     version: 0.9.2
     values:
+      - image:
+          tag: v10.4.0
       - wopiserverUrl: http://wopiserver.wopiserver.svc.cluster.local:8880
       - config:
           cs3:


### PR DESCRIPTION
## Description
Use the latest wopi server release

## Related Issue
- see also https://github.com/owncloud/ocis/pull/9182

## Motivation and Context
keep the wopi server up to date

## How Has This Been Tested?
- deployed the ocis-office deployment example in minikube and used it to edit files

## Screenshots (if appropriate):

## Types of changes
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Technical debt
- [ ] Tests only (no source changes)

## Checklist:
- [x] Code changes
- [ ] Unit tests added
- [ ] Acceptance tests added
- [ ] Documentation generated (`make docs`) and committed
- [ ] Documentation ticket raised: <link>
- [ ] Documentation PR created: <link>
