### PR TITLE
include smtp credentials except for authentication mode `none`

### DIFF
--- a/charts/ocis/templates/notifications/deployment.yaml
+++ b/charts/ocis/templates/notifications/deployment.yaml
@@ -64,7 +64,7 @@ spec:
             - name: NOTIFICATIONS_SMTP_ENCRYPTION
               value: {{ .Values.features.emailNotifications.smtp.encryption | quote }}
 
-            {{- if ne .Values.features.emailNotifications.smtp.authentication "auto" }}
+            {{- if ne .Values.features.emailNotifications.smtp.authentication "none" }}
             - name: NOTIFICATIONS_SMTP_USERNAME
               valueFrom:
                 secretKeyRef:


### PR DESCRIPTION
## Description
actually provide smtp credentials when they are needed, compare to the actual secret reference description:

https://github.com/owncloud/ocis-charts/blob/f4280747eb43935d07103ed585ffcc58c537b952/charts/ocis/values.yaml#L596-L599

## Related Issue
- Fixes https://github.com/owncloud/ocis-charts/issues/585

## Motivation and Context


## How Has This Been Tested?
- not yet

## Screenshots (if appropriate):

## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Technical debt
- [ ] Tests only (no source changes)

## Checklist:
- [x] Code changes
- [ ] Unit tests added
- [ ] Acceptance tests added
- [ ] Documentation generated (`make docs`) and committed
- [ ] Documentation ticket raised: <link>
- [ ] Documentation PR created: <link>
