### PR TITLE
enable submodule updates

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -1,13 +1,22 @@
 {
   "$schema": "https://docs.renovatebot.com/renovate-schema.json",
-  "extends": ["github>owncloud-ops/renovate-presets:docker"],
+  "extends": [
+    "github>owncloud-ops/renovate-presets:docker"
+  ],
   "kubernetes": {
-    "fileMatch": ["^ci/k3d-drone\\.ya?ml"]
+    "fileMatch": [
+      "^ci/k3d-drone\\.ya?ml"
+    ]
+  },
+  "git-submodules": {
+    "enabled": true
   },
   "customManagers": [
     {
       "customType": "regex",
-      "fileMatch": ["^charts/.+Chart\\.ya?ml$"],
+      "fileMatch": [
+        "^charts/.+Chart\\.ya?ml$"
+      ],
       "matchStrings": [
         "# renovate: datasource=(?<datasource>\\S+) depName=(?<depName>\\S+)( versioning=(?<versioning>.*?))?\\nappVersion:\\s?\\\"?(?<currentValue>.*?)\"?\\s"
       ]


### PR DESCRIPTION
## Description
enable renovate submodule updates according to https://docs.renovatebot.com/modules/manager/git-submodules/

## Related Issue
- Keycloak submodule is quite outdated

## Motivation and Context
keep deployment examples up to date

## How Has This Been Tested?
- will be tested after merging (I expect a Keycloak submodule bump to 25.0.0)

## Screenshots (if appropriate):

## Types of changes
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [x] Technical debt
- [ ] Tests only (no source changes)

## Checklist:
- [x] Code changes
- [ ] Unit tests added
- [ ] Acceptance tests added
- [ ] Documentation generated (`make docs`) and committed
- [ ] Documentation ticket raised: <link>
- [ ] Documentation PR created: <link>
