### PR TITLE
add Kubernetes 1.30 for testing and remove 1.26 because of EOL

### DIFF
--- a/.drone.star
+++ b/.drone.star
@@ -5,10 +5,10 @@ config = {
     # if this changes, also tested versions in need to be changed here:
     # - Makefile
     "kubernetesVersions": [
-        "1.26.0",
         "1.27.0",
         "1.28.0",
         "1.29.0",
+        "1.30.0",
     ],
 }
 

--- a/Makefile
+++ b/Makefile
@@ -23,18 +23,7 @@ lint: $(KUBE_LINTER)
 
 
 .PHONY: api
-api: api-1.26.0 api-1.27.0 api-1.28.0 api-1.29.0
-
-.PHONY: api-1.26.0
-api-1.26.0: api-1.26.0-template api-1.26.0-kubeconform
-
-.PHONY: api-1.26.0-template
-api-1.26.0-template:
-	helm template --kube-version 1.26.0 charts/ocis -f 'charts/ocis/ci/values.yaml' > charts/ocis/ci/templated.yaml
-
-.PHONY: api-1.26.0-kubeconform
-api-1.26.0-kubeconform: $(KUBECONFORM)
-	$(KUBECONFORM) -kubernetes-version 1.26.0 -summary -strict charts/ocis/ci/templated.yaml
+api: api-1.27.0 api-1.28.0 api-1.29.0 api-1.30.0
 
 .PHONY: api-1.27.0
 api-1.27.0: api-1.27.0-template api-1.27.0-kubeconform
@@ -68,6 +57,18 @@ api-1.29.0-template:
 .PHONY: api-1.29.0-kubeconform
 api-1.29.0-kubeconform: $(KUBECONFORM)
 	$(KUBECONFORM) -kubernetes-version 1.29.0 -summary -strict charts/ocis/ci/templated.yaml
+
+.PHONY: api-1.30.0
+api-1.30.0: api-1.30.0-template api-1.30.0-kubeconform
+
+.PHONY: api-1.30.0-template
+api-1.30.0-template:
+	helm template --kube-version 1.30.0 charts/ocis -f 'charts/ocis/ci/values.yaml' > charts/ocis/ci/templated.yaml
+
+.PHONY: api-1.30.0-kubeconform
+api-1.30.0-kubeconform: $(KUBECONFORM)
+	$(KUBECONFORM) -kubernetes-version 1.30.0 -summary -strict charts/ocis/ci/templated.yaml
+
 
 .PHONY: tools-update
 tools-update: $(BINGO)


### PR DESCRIPTION
## Description
add Kubernetes 1.30 to tests and remove 1.26 because of EOL

## Related Issue

## Motivation and Context

## How Has This Been Tested?
- `make all`
- CI

## Screenshots (if appropriate):

## Types of changes
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Technical debt
- [x] Tests only (no source changes)

## Checklist:
- [x] Code changes
- [ ] Unit tests added
- [ ] Acceptance tests added
- [ ] Documentation generated (`make docs`) and committed
- [ ] Documentation ticket raised: <link>
- [ ] Documentation PR created: <link>
