### PR TITLE
refactor names of autogenerated configmaps and secrets

### DIFF
--- a/charts/ocis/templates/authmachine/secret.yaml
+++ b/charts/ocis/templates/authmachine/secret.yaml
@@ -1,5 +1,5 @@
 {{- if or (not .Values.secretRefs.machineAuthApiKeySecretRef) }}
 {{- $params := (dict)}}
 {{- $_ := set $params "machine-auth-api-key" (randAlphaNum 30) }}
-{{- include "ocis.secret" (dict "scope" . "name" "machine-auth-api-key" "params" $params)}}
+{{- include "ocis.secret" (dict "scope" . "name" (include "secrets.machineAuthAPIKeySecret" .) "params" $params)}}
 {{- end }}

--- a/charts/ocis/templates/authservice/configmap.yaml
+++ b/charts/ocis/templates/authservice/configmap.yaml
@@ -1,5 +1,5 @@
 {{- if not .Values.configRefs.authServiceConfigRef }}
 {{- $params := (dict)}}
 {{- $_ := set $params "service-account-id" (uuidv4) }}
-{{- include "ocis.configMap" (dict "scope" . "name" "auth-service" "params" $params)}}
+{{- include "ocis.configMap" (dict "scope" . "name" (include "config.authService" .) "params" $params)}}
 {{- end }}

--- a/charts/ocis/templates/authservice/secret.yaml
+++ b/charts/ocis/templates/authservice/secret.yaml
@@ -1,5 +1,5 @@
 {{- if or (not .Values.secretRefs.serviceAccountSecretRef) }}
 {{- $params := (dict)}}
 {{- $_ := set $params "service-account-secret" (randAlphaNum 30) }}
-{{- include "ocis.secret" (dict "scope" . "name" "service-account-secret" "params" $params)}}
+{{- include "ocis.secret" (dict "scope" . "name" (include "secrets.serviceAccountSecret" .) "params" $params)}}
 {{- end }}

--- a/charts/ocis/templates/graph/configmap.yaml
+++ b/charts/ocis/templates/graph/configmap.yaml
@@ -1,5 +1,5 @@
 {{- if not .Values.configRefs.graphConfigRef }}
 {{- $params := (dict)}}
 {{- $_ := set $params "application-id" (uuidv4) }}
-{{- include "ocis.configMap" (dict "scope" . "name" "graph" "params" $params)}}
+{{- include "ocis.configMap" (dict "scope" . "name" (include "config.graph" .) "params" $params)}}
 {{- end }}

--- a/charts/ocis/templates/idm/secret.yaml
+++ b/charts/ocis/templates/idm/secret.yaml
@@ -2,7 +2,7 @@
 {{ if and (not .Values.secretRefs.ldapCaRef) (not .Values.features.externalUserManagement.enabled)  }}
 {{- $params := (dict)}}
 {{- $_ := set $params "ldap-ca.crt" .ldapCA.Cert }}
-{{- include "ocis.secret" (dict "scope" . "name" "ldap-ca" "params" $params)}}
+{{- include "ocis.secret" (dict "scope" . "name" (include "secrets.ldapCASecret" .) "params" $params)}}
 {{- end }}
 ---
 {{ if and (not .Values.secretRefs.ldapCertRef) (not .Values.features.externalUserManagement.enabled)  }}
@@ -10,7 +10,7 @@
 {{- $ldapCert := genSignedCert "idm" nil (list "idm") 365  .ldapCA }}
 {{- $_ := set $params "ldap.key" $ldapCert.Key }}
 {{- $_ := set $params "ldap.crt" $ldapCert.Cert }}
-{{- include "ocis.secret" (dict "scope" . "name" "ldap-cert" "params" $params)}}
+{{- include "ocis.secret" (dict "scope" . "name" (include "secrets.ldapCertSecret" .) "params" $params)}}
 {{- end }}
 ---
 {{ if not .Values.secretRefs.ldapSecretRef }}
@@ -18,5 +18,5 @@
 {{- $_ := set $params "reva-ldap-bind-password" (randAlphaNum 30) }}
 {{- $_ := set $params "idp-ldap-bind-password" (randAlphaNum 30) }}
 {{- $_ := set $params "graph-ldap-bind-password" (randAlphaNum 30) }}
-{{- include "ocis.secret" (dict "scope" . "name" "ldap-bind-secrets" "labels" .Values.backup.secretLabels "params" $params)}}
+{{- include "ocis.secret" (dict "scope" . "name" (include "secrets.ldapBindSecret" .) "labels" .Values.backup.secretLabels "params" $params)}}
 {{- end }}

--- a/charts/ocis/templates/idp/secret.yaml
+++ b/charts/ocis/templates/idp/secret.yaml
@@ -2,18 +2,12 @@
 {{- $params := (dict)}}
 {{- $_ := set $params "encryption.key" (randAscii 32) }}
 {{- $_ := set $params "private-key.pem" (genPrivateKey "rsa") }}
-{{- include "ocis.secret" (dict "scope" . "name" "idp-secrets" "labels" .Values.backup.secretLabels "params" $params)}}
-{{- end }}
----
-{{ if not .Values.secretRefs.jwtSecretRef }}
-{{- $params := (dict)}}
-{{- $_ := set $params "jwt-secret" (randAlphaNum 30) }}
-{{- include "ocis.secret" (dict "scope" . "name" "jwt-secret" "params" $params)}}
+{{- include "ocis.secret" (dict "scope" . "name" (include "secrets.idpSecret" .) "labels" .Values.backup.secretLabels "params" $params)}}
 {{- end }}
 ---
 {{ if and (not .Values.features.externalUserManagement.enabled) (not .Values.secretRefs.adminUserSecretRef) }}
 {{- $params := (dict)}}
 {{- $_ := set $params "user-id" uuidv4 }}
 {{- $_ := set $params "password" (randAlphaNum 30) }}
-{{- include "ocis.secret" (dict "scope" . "name" "admin-user" "params" $params)}}
+{{- include "ocis.secret" (dict "scope" . "name" (include "secrets.adminUser" .) "params" $params)}}
 {{- end }}

--- a/charts/ocis/templates/proxy/secret.yaml
+++ b/charts/ocis/templates/proxy/secret.yaml
@@ -1,0 +1,6 @@
+---
+{{ if not .Values.secretRefs.jwtSecretRef }}
+{{- $params := (dict)}}
+{{- $_ := set $params "jwt-secret" (randAlphaNum 30) }}
+{{- include "ocis.secret" (dict "scope" . "name" (include "secrets.jwtSecret" .) "params" $params)}}
+{{- end }}

--- a/charts/ocis/templates/storagesystem/secret.yaml
+++ b/charts/ocis/templates/storagesystem/secret.yaml
@@ -1,18 +1,18 @@
 {{ if not .Values.secretRefs.storagesystemJwtSecretRef }}
 {{- $params := (dict)}}
 {{- $_ := set $params "storage-system-jwt-secret" (randAlphaNum 30) }}
-{{- include "ocis.secret" (dict "scope" . "name" "storage-system-jwt-secret" "params" $params)}}
+{{- include "ocis.secret" (dict "scope" . "name" (include "secrets.storageSystemJWTSecret" .) "params" $params)}}
 {{- end }}
 ---
 {{ if not .Values.secretRefs.storagesystemSecretRef }}
 {{- $params := (dict)}}
 {{- $_ := set $params "api-key" (randAlphaNum 30) }}
 {{- $_ := set $params "user-id" uuidv4 }}
-{{- include "ocis.secret" (dict "scope" . "name" "storage-system" "labels" .Values.backup.secretLabels "params" $params)}}
+{{- include "ocis.secret" (dict "scope" . "name"  (include "secrets.storageSystemSecret" .) "labels" .Values.backup.secretLabels "params" $params)}}
 {{- end }}
 ---
 {{ if not .Values.secretRefs.transferSecretSecretRef }}
 {{- $params := (dict)}}
 {{- $_ := set $params "transfer-secret" (randAlphaNum 30) }}
-{{- include "ocis.secret" (dict "scope" . "name" "transfer-secret" "params" $params)}}
+{{- include "ocis.secret" (dict "scope" . "name"  (include "secrets.transferSecret" .) "params" $params)}}
 {{- end }}

--- a/charts/ocis/templates/storageusers/configmap.yaml
+++ b/charts/ocis/templates/storageusers/configmap.yaml
@@ -1,5 +1,5 @@
 {{- if not .Values.configRefs.storageusersConfigRef }}
 {{- $params := (dict)}}
 {{- $_ := set $params "storage-uuid" (uuidv4) }}
-{{- include "ocis.configMap" (dict "scope" . "name" "storage-users" "labels" .Values.backup.configMapLabels "params" $params)}}
+{{- include "ocis.configMap" (dict "scope" . "name" (include "config.storageUsers" .) "labels" .Values.backup.configMapLabels "params" $params)}}
 {{- end }}

--- a/charts/ocis/templates/thumbnails/secret.yaml
+++ b/charts/ocis/templates/thumbnails/secret.yaml
@@ -1,5 +1,5 @@
 {{- if not .Values.secretRefs.thumbnailsSecretRef }}
 {{- $params := (dict)}}
 {{- $_ := set $params "thumbnails-transfer-secret" (randAlphaNum 30) }}
-{{- include "ocis.secret" (dict "scope" . "name" "thumbnails-transfer-secret" "params" $params)}}
+{{- include "ocis.secret" (dict "scope" . "name" (include "secrets.thumbnailsSecret" .) "params" $params)}}
 {{- end }}


### PR DESCRIPTION
## Description
Refactors autogenerated secrets and configmaps to use the name template to reduce 
duplication.

Also moves the jwt secret to the proxy service, since this is currently the service who is minting JWT tokens. The IDP service doesn't have anything to do with the jwt secret.

This reverts commit 2c0b6ca16fecf3f2974ca44d29d8b66c5c289a27.

## Related Issue

## Motivation and Context
remove duplicate string constants

## How Has This Been Tested?
- install the development example

## Screenshots (if appropriate):

## Types of changes
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [x] Technical debt
- [ ] Tests only (no source changes)

## Checklist:
- [x] Code changes
- [ ] Unit tests added
- [ ] Acceptance tests added
- [ ] Documentation generated (`make docs`) and committed
- [ ] Documentation ticket raised: <link>
- [ ] Documentation PR created: <link>
