### PR TITLE
Revert "refactor names of autogenerated configmaps and secrets"

### DIFF
--- a/charts/ocis/templates/authmachine/secret.yaml
+++ b/charts/ocis/templates/authmachine/secret.yaml
@@ -1,5 +1,5 @@
 {{- if or (not .Values.secretRefs.machineAuthApiKeySecretRef) }}
 {{- $params := (dict)}}
 {{- $_ := set $params "machine-auth-api-key" (randAlphaNum 30) }}
-{{- include "ocis.secret" (dict "scope" . "name" (include "secrets.machineAuthAPIKeySecret" .) "params" $params)}}
+{{- include "ocis.secret" (dict "scope" . "name" "machine-auth-api-key" "params" $params)}}
 {{- end }}

--- a/charts/ocis/templates/authservice/configmap.yaml
+++ b/charts/ocis/templates/authservice/configmap.yaml
@@ -1,5 +1,5 @@
 {{- if not .Values.configRefs.authServiceConfigRef }}
 {{- $params := (dict)}}
 {{- $_ := set $params "service-account-id" (uuidv4) }}
-{{- include "ocis.configMap" (dict "scope" . "name" (include "config.authService" .) "params" $params)}}
+{{- include "ocis.configMap" (dict "scope" . "name" "auth-service" "params" $params)}}
 {{- end }}

--- a/charts/ocis/templates/authservice/secret.yaml
+++ b/charts/ocis/templates/authservice/secret.yaml
@@ -1,5 +1,5 @@
 {{- if not .Values.secretRefs.serviceAccountSecretRef }}
 {{- $params := (dict)}}
 {{- $_ := set $params "service-account-secret" (randAlphaNum 30) }}
-{{- include "ocis.secret" (dict "scope" . "name" (include "secrets.serviceAccountSecret" .) "params" $params)}}
+{{- include "ocis.secret" (dict "scope" . "name" "service-account-secret" "params" $params)}}
 {{- end }}

--- a/charts/ocis/templates/graph/configmap.yaml
+++ b/charts/ocis/templates/graph/configmap.yaml
@@ -1,5 +1,5 @@
 {{- if not .Values.configRefs.graphConfigRef }}
 {{- $params := (dict)}}
 {{- $_ := set $params "application-id" (uuidv4) }}
-{{- include "ocis.configMap" (dict "scope" . "name" (include "config.graph" .) "params" $params)}}
+{{- include "ocis.configMap" (dict "scope" . "name" "graph" "params" $params)}}
 {{- end }}

--- a/charts/ocis/templates/idm/secret.yaml
+++ b/charts/ocis/templates/idm/secret.yaml
@@ -2,7 +2,7 @@
 {{ if and (not .Values.secretRefs.ldapCaRef) (not .Values.features.externalUserManagement.enabled)  }}
 {{- $params := (dict)}}
 {{- $_ := set $params "ldap-ca.crt" .ldapCA.Cert }}
-{{- include "ocis.secret" (dict "scope" . "name" (include "secrets.ldapCASecret" .) "params" $params)}}
+{{- include "ocis.secret" (dict "scope" . "name" "ldap-ca" "params" $params)}}
 {{- end }}
 ---
 {{ if and (not .Values.secretRefs.ldapCertRef) (not .Values.features.externalUserManagement.enabled)  }}
@@ -10,7 +10,7 @@
 {{- $ldapCert := genSignedCert "idm" nil (list "idm") 365  .ldapCA }}
 {{- $_ := set $params "ldap.key" $ldapCert.Key }}
 {{- $_ := set $params "ldap.crt" $ldapCert.Cert }}
-{{- include "ocis.secret" (dict "scope" . "name" (include "secrets.ldapCertSecret" .) "params" $params)}}
+{{- include "ocis.secret" (dict "scope" . "name" "ldap-cert" "params" $params)}}
 {{- end }}
 ---
 {{ if not .Values.secretRefs.ldapSecretRef }}
@@ -18,5 +18,5 @@
 {{- $_ := set $params "reva-ldap-bind-password" (randAlphaNum 30) }}
 {{- $_ := set $params "idp-ldap-bind-password" (randAlphaNum 30) }}
 {{- $_ := set $params "graph-ldap-bind-password" (randAlphaNum 30) }}
-{{- include "ocis.secret" (dict "scope" . "name" (include "secrets.ldapBindSecret" .) "labels" .Values.backup.secretLabels "params" $params)}}
+{{- include "ocis.secret" (dict "scope" . "name" "ldap-bind-secrets" "labels" .Values.backup.secretLabels "params" $params)}}
 {{- end }}

--- a/charts/ocis/templates/idp/secret.yaml
+++ b/charts/ocis/templates/idp/secret.yaml
@@ -2,12 +2,18 @@
 {{- $params := (dict)}}
 {{- $_ := set $params "encryption.key" (randAscii 32) }}
 {{- $_ := set $params "private-key.pem" (genPrivateKey "rsa") }}
-{{- include "ocis.secret" (dict "scope" . "name" (include "secrets.idpSecret" .) "labels" .Values.backup.secretLabels "params" $params)}}
+{{- include "ocis.secret" (dict "scope" . "name" "idp-secrets" "labels" .Values.backup.secretLabels "params" $params)}}
+{{- end }}
+---
+{{ if not .Values.secretRefs.jwtSecretRef }}
+{{- $params := (dict)}}
+{{- $_ := set $params "jwt-secret" (randAlphaNum 30) }}
+{{- include "ocis.secret" (dict "scope" . "name" "jwt-secret" "params" $params)}}
 {{- end }}
 ---
 {{ if and (not .Values.features.externalUserManagement.enabled) (not .Values.secretRefs.adminUserSecretRef) }}
 {{- $params := (dict)}}
 {{- $_ := set $params "user-id" uuidv4 }}
 {{- $_ := set $params "password" (randAlphaNum 30) }}
-{{- include "ocis.secret" (dict "scope" . "name" (include "secrets.adminUser" .) "params" $params)}}
+{{- include "ocis.secret" (dict "scope" . "name" "admin-user" "params" $params)}}
 {{- end }}

--- a/charts/ocis/templates/proxy/secret.yaml
+++ b/charts/ocis/templates/proxy/secret.yaml
@@ -1,6 +1,0 @@
----
-{{ if not .Values.secretRefs.jwtSecretRef }}
-{{- $params := (dict)}}
-{{- $_ := set $params "jwt-secret" (randAlphaNum 30) }}
-{{- include "ocis.secret" (dict "scope" . "name" (include "secrets.jwtSecret" .) "params" $params)}}
-{{- end }}

--- a/charts/ocis/templates/storagesystem/secret.yaml
+++ b/charts/ocis/templates/storagesystem/secret.yaml
@@ -1,18 +1,18 @@
 {{ if not .Values.secretRefs.storagesystemJwtSecretRef }}
 {{- $params := (dict)}}
 {{- $_ := set $params "storage-system-jwt-secret" (randAlphaNum 30) }}
-{{- include "ocis.secret" (dict "scope" . "name" (include "secrets.storageSystemJWTSecret" .) "params" $params)}}
+{{- include "ocis.secret" (dict "scope" . "name" "storage-system-jwt-secret" "params" $params)}}
 {{- end }}
 ---
 {{ if not .Values.secretRefs.storagesystemSecretRef }}
 {{- $params := (dict)}}
 {{- $_ := set $params "api-key" (randAlphaNum 30) }}
 {{- $_ := set $params "user-id" uuidv4 }}
-{{- include "ocis.secret" (dict "scope" . "name"  (include "secrets.storageSystemSecret" .) "labels" .Values.backup.secretLabels "params" $params)}}
+{{- include "ocis.secret" (dict "scope" . "name" "storage-system" "labels" .Values.backup.secretLabels "params" $params)}}
 {{- end }}
 ---
 {{ if not .Values.secretRefs.transferSecretSecretRef }}
 {{- $params := (dict)}}
 {{- $_ := set $params "transfer-secret" (randAlphaNum 30) }}
-{{- include "ocis.secret" (dict "scope" . "name"  (include "secrets.transferSecret" .) "params" $params)}}
+{{- include "ocis.secret" (dict "scope" . "name" "transfer-secret" "params" $params)}}
 {{- end }}

--- a/charts/ocis/templates/storageusers/configmap.yaml
+++ b/charts/ocis/templates/storageusers/configmap.yaml
@@ -1,5 +1,5 @@
 {{- if not .Values.configRefs.storageusersConfigRef }}
 {{- $params := (dict)}}
 {{- $_ := set $params "storage-uuid" (uuidv4) }}
-{{- include "ocis.configMap" (dict "scope" . "name" (include "config.storageUsers" .) "labels" .Values.backup.configMapLabels "params" $params)}}
+{{- include "ocis.configMap" (dict "scope" . "name" "storage-users" "labels" .Values.backup.configMapLabels "params" $params)}}
 {{- end }}

--- a/charts/ocis/templates/thumbnails/secret.yaml
+++ b/charts/ocis/templates/thumbnails/secret.yaml
@@ -1,5 +1,5 @@
 {{- if not .Values.secretRefs.thumbnailsSecretRef }}
 {{- $params := (dict)}}
 {{- $_ := set $params "thumbnails-transfer-secret" (randAlphaNum 30) }}
-{{- include "ocis.secret" (dict "scope" . "name" (include "secrets.thumbnailsSecret" .) "params" $params)}}
+{{- include "ocis.secret" (dict "scope" . "name" "thumbnails-transfer-secret" "params" $params)}}
 {{- end }}


### PR DESCRIPTION
Reverts owncloud/ocis-charts#618 because it actually causes the autogenerated secrets' and configmaps' data to be recreated every time.
