### PR TITLE
improve roles_quota identation

### DIFF
--- a/charts/ocis/templates/proxy/config.yaml
+++ b/charts/ocis/templates/proxy/config.yaml
@@ -14,7 +14,7 @@ data:
         policy: ocis
     {{- with $.Values.features.quotas.roles }}
     role_quotas:
-      {{- toYaml . | nindent 8 }}
+      {{- toYaml . | nindent 6 }}
     {{- end }}
     {{- if $.Values.features.externalUserManagement.oidc.roleAssignment.enabled }}
     role_assignment:


### PR DESCRIPTION
## Description
we found a identation that is off by 2 in https://github.com/owncloud/ocis-charts/pull/636#discussion_r1675563450

it's still working, so this can only be consider as a cosmetic change

## Related Issue

## Motivation and Context

## How Has This Been Tested?
- looking at the generated yaml:

before:

```yaml
    role_quotas:
        xxx: yyy
```

after:

```yaml
    role_quotas:
      xxx: yyy
```

## Screenshots (if appropriate):

## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Technical debt
- [ ] Tests only (no source changes)

## Checklist:
- [x] Code changes
- [ ] Unit tests added
- [ ] Acceptance tests added
- [ ] Documentation generated (`make docs`) and committed
- [ ] Documentation ticket raised: <link>
- [ ] Documentation PR created: <link>
