### PR TITLE
remove proxy config option that no longer exists

### DIFF
--- a/charts/ocis/templates/proxy/deployment.yaml
+++ b/charts/ocis/templates/proxy/deployment.yaml
@@ -73,9 +73,6 @@ spec:
 
             - name: PROXY_OIDC_ACCESS_TOKEN_VERIFY_METHOD
               value: {{ .Values.features.externalUserManagement.oidc.accessTokenVerifyMethod | quote }}
-
-            - name: PROXY_OIDC_SKIP_CLIENT_ID_CHECK
-              value: "true"
             {{- end }}
 
             - name: PROXY_TLS


### PR DESCRIPTION
## Description

Remove configuration from the proxy that has been removed from the oCIS project.

## Related Issue
- The configuration option was originally removed in https://github.com/owncloud/ocis/pull/6156

## Motivation and Context
Don't configure something that doesn't exist (any longer)

## How Has This Been Tested?
- How to test something, that doesn't do anything!?

## Screenshots (if appropriate):

## Types of changes
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [x] Technical debt
- [ ] Tests only (no source changes)

## Checklist:
- [x] Code changes
- [ ] Unit tests added
- [ ] Acceptance tests added
- [ ] Documentation generated (`make docs`) and committed
- [ ] Documentation ticket raised: <link>
- [ ] Documentation PR created: <link>
