### PR TITLE
autoprovisionAccounts

### DIFF
--- a/charts/ocis/docs/values-desc-table.adoc
+++ b/charts/ocis/docs/values-desc-table.adoc
@@ -380,9 +380,21 @@ a| [subs=-attributes]
 | UUID of the inital admin user. If the given value matches a user's value from `features.externalUserManagement.oidc.userIDClaim`, the admin role will be assigned. Consider that the UUID can be encoded in some LDAP deployment configurations like in .ldif files. These need to be decoded beforehand. Note: Enabling `roleAssignment` will disable `adminUUID`.
 | features.externalUserManagement.autoprovisionAccounts
 a| [subs=-attributes]
++object+
+a| [subs=-attributes]
+`{"clamUsenName":"email","enabled":true}`
+| Enables account auto provisioning. It will create missing users on the LDAP server from OIDC information. Needs `features.externalUserManagement.ldap.writeable` to be be set to `true`.
+| features.externalUserManagement.autoprovisionAccounts.clamUsenName
+a| [subs=-attributes]
++string+
+a| [subs=-attributes]
+`"email"`
+| Claim to take an unique user identifier from. It will be used to look up the user on the LDAP server.
+| features.externalUserManagement.autoprovisionAccounts.enabled
+a| [subs=-attributes]
 +bool+
 a| [subs=-attributes]
-`false`
+`true`
 | Enables account auto provisioning. It will create missing users on the LDAP server from OIDC information. Needs `features.externalUserManagement.ldap.writeable` to be be set to `true`.
 | features.externalUserManagement.enabled
 a| [subs=-attributes]

--- a/charts/ocis/docs/values-desc-table.adoc
+++ b/charts/ocis/docs/values-desc-table.adoc
@@ -382,13 +382,31 @@ a| [subs=-attributes]
 a| [subs=-attributes]
 +object+
 a| [subs=-attributes]
-`{"clamUsenName":"email","enabled":false}`
+`{"clamDisplayname":"name","clamEmail":"email","clamGroups":"groups","clamUserName":"sub","enabled":false}`
 | Enables account auto provisioning. It will create missing users on the LDAP server from OIDC information. Needs `features.externalUserManagement.ldap.writeable` to be be set to `true`.
-| features.externalUserManagement.autoprovisionAccounts.clamUsenName
+| features.externalUserManagement.autoprovisionAccounts.clamDisplayname
+a| [subs=-attributes]
++string+
+a| [subs=-attributes]
+`"name"`
+| The name of the OIDC claim that holds the display name.
+| features.externalUserManagement.autoprovisionAccounts.clamEmail
 a| [subs=-attributes]
 +string+
 a| [subs=-attributes]
 `"email"`
+| The name of the OIDC claim that holds the email.
+| features.externalUserManagement.autoprovisionAccounts.clamGroups
+a| [subs=-attributes]
++string+
+a| [subs=-attributes]
+`"groups"`
+| The name of the OIDC claim that holds the groups.
+| features.externalUserManagement.autoprovisionAccounts.clamUserName
+a| [subs=-attributes]
++string+
+a| [subs=-attributes]
+`"sub"`
 | The name of the OIDC claim that holds the username.
 | features.externalUserManagement.autoprovisionAccounts.enabled
 a| [subs=-attributes]

--- a/charts/ocis/docs/values-desc-table.adoc
+++ b/charts/ocis/docs/values-desc-table.adoc
@@ -382,19 +382,19 @@ a| [subs=-attributes]
 a| [subs=-attributes]
 +object+
 a| [subs=-attributes]
-`{"clamUsenName":"email","enabled":true}`
+`{"clamUsenName":"email","enabled":false}`
 | Enables account auto provisioning. It will create missing users on the LDAP server from OIDC information. Needs `features.externalUserManagement.ldap.writeable` to be be set to `true`.
 | features.externalUserManagement.autoprovisionAccounts.clamUsenName
 a| [subs=-attributes]
 +string+
 a| [subs=-attributes]
 `"email"`
-| Claim to take an unique user identifier from. It will be used to look up the user on the LDAP server.
+| The name of the OIDC claim that holds the username.
 | features.externalUserManagement.autoprovisionAccounts.enabled
 a| [subs=-attributes]
 +bool+
 a| [subs=-attributes]
-`true`
+`false`
 | Enables account auto provisioning. It will create missing users on the LDAP server from OIDC information. Needs `features.externalUserManagement.ldap.writeable` to be be set to `true`.
 | features.externalUserManagement.enabled
 a| [subs=-attributes]

--- a/charts/ocis/docs/values-desc-table.adoc
+++ b/charts/ocis/docs/values-desc-table.adoc
@@ -382,27 +382,27 @@ a| [subs=-attributes]
 a| [subs=-attributes]
 +object+
 a| [subs=-attributes]
-`{"clamDisplayname":"name","clamEmail":"email","clamGroups":"groups","clamUserName":"sub","enabled":false}`
+`{"claimDisplayname":"name","claimEmail":"email","claimGroups":"groups","claimUserName":"sub","enabled":false}`
 | Enables account auto provisioning. It will create missing users on the LDAP server from OIDC information. Needs `features.externalUserManagement.ldap.writeable` to be be set to `true`.
-| features.externalUserManagement.autoprovisionAccounts.clamDisplayname
+| features.externalUserManagement.autoprovisionAccounts.claimDisplayname
 a| [subs=-attributes]
 +string+
 a| [subs=-attributes]
 `"name"`
 | The name of the OIDC claim that holds the display name.
-| features.externalUserManagement.autoprovisionAccounts.clamEmail
+| features.externalUserManagement.autoprovisionAccounts.claimEmail
 a| [subs=-attributes]
 +string+
 a| [subs=-attributes]
 `"email"`
 | The name of the OIDC claim that holds the email.
-| features.externalUserManagement.autoprovisionAccounts.clamGroups
+| features.externalUserManagement.autoprovisionAccounts.claimGroups
 a| [subs=-attributes]
 +string+
 a| [subs=-attributes]
 `"groups"`
 | The name of the OIDC claim that holds the groups.
-| features.externalUserManagement.autoprovisionAccounts.clamUserName
+| features.externalUserManagement.autoprovisionAccounts.claimUserName
 a| [subs=-attributes]
 +string+
 a| [subs=-attributes]

--- a/charts/ocis/docs/values.adoc.yaml
+++ b/charts/ocis/docs/values.adoc.yaml
@@ -381,7 +381,13 @@ features:
     # -- Enables account auto provisioning.
     # It will create missing users on the LDAP server from OIDC information.
     # Needs `features.externalUserManagement.ldap.writeable` to be be set to `true`.
-    autoprovisionAccounts: false
+    autoprovisionAccounts:
+      # -- Enables account auto provisioning.
+      # It will create missing users on the LDAP server from OIDC information.
+      # Needs `features.externalUserManagement.ldap.writeable` to be be set to `true`.
+      enabled: true
+      # -- Claim to take an unique user identifier from. It will be used to look up the user on the LDAP server.
+      clamUsenName: email
     # OpenID Connect Identity provider related settings.
     oidc:
       # -- Issuer URI of the OpenID Connect Identity Provider.

--- a/charts/ocis/docs/values.adoc.yaml
+++ b/charts/ocis/docs/values.adoc.yaml
@@ -385,8 +385,8 @@ features:
       # -- Enables account auto provisioning.
       # It will create missing users on the LDAP server from OIDC information.
       # Needs `features.externalUserManagement.ldap.writeable` to be be set to `true`.
-      enabled: true
-      # -- Claim to take an unique user identifier from. It will be used to look up the user on the LDAP server.
+      enabled: false
+      # -- The name of the OIDC claim that holds the username.
       clamUsenName: email
     # OpenID Connect Identity provider related settings.
     oidc:

--- a/charts/ocis/docs/values.adoc.yaml
+++ b/charts/ocis/docs/values.adoc.yaml
@@ -387,13 +387,13 @@ features:
       # Needs `features.externalUserManagement.ldap.writeable` to be be set to `true`.
       enabled: false
       # -- The name of the OIDC claim that holds the email.
-      clamEmail: email
+      claimEmail: email
       # -- The name of the OIDC claim that holds the display name.
-      clamDisplayname: name
+      claimDisplayname: name
       # -- The name of the OIDC claim that holds the groups.
-      clamGroups: groups
+      claimGroups: groups
       # -- The name of the OIDC claim that holds the username.
-      clamUserName: sub
+      claimUserName: sub
     # OpenID Connect Identity provider related settings.
     oidc:
       # -- Issuer URI of the OpenID Connect Identity Provider.

--- a/charts/ocis/docs/values.adoc.yaml
+++ b/charts/ocis/docs/values.adoc.yaml
@@ -386,8 +386,14 @@ features:
       # It will create missing users on the LDAP server from OIDC information.
       # Needs `features.externalUserManagement.ldap.writeable` to be be set to `true`.
       enabled: false
+      # -- The name of the OIDC claim that holds the email.
+      clamEmail: email
+      # -- The name of the OIDC claim that holds the display name.
+      clamDisplayname: name
+      # -- The name of the OIDC claim that holds the groups.
+      clamGroups: groups
       # -- The name of the OIDC claim that holds the username.
-      clamUsenName: email
+      clamUserName: sub
     # OpenID Connect Identity provider related settings.
     oidc:
       # -- Issuer URI of the OpenID Connect Identity Provider.

--- a/charts/ocis/templates/proxy/deployment.yaml
+++ b/charts/ocis/templates/proxy/deployment.yaml
@@ -114,12 +114,17 @@ spec:
             - name: PROXY_POLICIES_QUERY
               value: data.proxy.granted
             {{- end }}
-            
-            - name: PROXY_AUTOPROVISION_CLAIM_USERNAME
-              value: {{ .Values.features.externalUserManagement.autoprovisionAccounts.clamUsenName | quote }}
 
             - name: PROXY_AUTOPROVISION_ACCOUNTS
               value: {{ .Values.features.externalUserManagement.autoprovisionAccounts | default "false" | quote }}
+            - name: PROXY_AUTOPROVISION_CLAIM_EMAIL
+              value: {{ .Values.features.externalUserManagement.autoprovisionAccounts.clamEmail | quote }}
+            - name: PROXY_AUTOPROVISION_CLAIM_DISPLAYNAME
+              value: {{ .Values.features.externalUserManagement.autoprovisionAccounts.clamDisplayname | quote }}
+            - name: PROXY_AUTOPROVISION_CLAIM_GROUPS
+              value: {{ .Values.features.externalUserManagement.autoprovisionAccounts.clamGroups | quote }}
+            - name: PROXY_AUTOPROVISION_CLAIM_USERNAME
+              value: {{ .Values.features.externalUserManagement.autoprovisionAccounts.clamUserName | quote }}
 
           {{- include "ocis.livenessProbe" . | nindent 10 }}
 

--- a/charts/ocis/templates/proxy/deployment.yaml
+++ b/charts/ocis/templates/proxy/deployment.yaml
@@ -114,6 +114,9 @@ spec:
             - name: PROXY_POLICIES_QUERY
               value: data.proxy.granted
             {{- end }}
+            
+            - name: PROXY_AUTOPROVISION_CLAIM_USERNAME
+              value: {{ .Values.features.externalUserManagement.autoprovisionAccounts.clamUsenName | quote }}
 
             - name: PROXY_AUTOPROVISION_ACCOUNTS
               value: {{ .Values.features.externalUserManagement.autoprovisionAccounts | default "false" | quote }}

--- a/charts/ocis/templates/proxy/deployment.yaml
+++ b/charts/ocis/templates/proxy/deployment.yaml
@@ -118,13 +118,13 @@ spec:
             - name: PROXY_AUTOPROVISION_ACCOUNTS
               value: {{ .Values.features.externalUserManagement.autoprovisionAccounts.enabled | default "false" | quote }}
             - name: PROXY_AUTOPROVISION_CLAIM_EMAIL
-              value: {{ .Values.features.externalUserManagement.autoprovisionAccounts.clamEmail | quote }}
+              value: {{ .Values.features.externalUserManagement.autoprovisionAccounts.claimEmail | quote }}
             - name: PROXY_AUTOPROVISION_CLAIM_DISPLAYNAME
-              value: {{ .Values.features.externalUserManagement.autoprovisionAccounts.clamDisplayname | quote }}
+              value: {{ .Values.features.externalUserManagement.autoprovisionAccounts.claimDisplayname | quote }}
             - name: PROXY_AUTOPROVISION_CLAIM_GROUPS
-              value: {{ .Values.features.externalUserManagement.autoprovisionAccounts.clamGroups | quote }}
+              value: {{ .Values.features.externalUserManagement.autoprovisionAccounts.claimGroups | quote }}
             - name: PROXY_AUTOPROVISION_CLAIM_USERNAME
-              value: {{ .Values.features.externalUserManagement.autoprovisionAccounts.clamUserName | quote }}
+              value: {{ .Values.features.externalUserManagement.autoprovisionAccounts.claimUserName | quote }}
 
           {{- include "ocis.livenessProbe" . | nindent 10 }}
 

--- a/charts/ocis/templates/proxy/deployment.yaml
+++ b/charts/ocis/templates/proxy/deployment.yaml
@@ -116,7 +116,7 @@ spec:
             {{- end }}
 
             - name: PROXY_AUTOPROVISION_ACCOUNTS
-              value: {{ .Values.features.externalUserManagement.autoprovisionAccounts | default "false" | quote }}
+              value: {{ .Values.features.externalUserManagement.autoprovisionAccounts.enabled | default "false" | quote }}
             - name: PROXY_AUTOPROVISION_CLAIM_EMAIL
               value: {{ .Values.features.externalUserManagement.autoprovisionAccounts.clamEmail | quote }}
             - name: PROXY_AUTOPROVISION_CLAIM_DISPLAYNAME

--- a/charts/ocis/values.yaml
+++ b/charts/ocis/values.yaml
@@ -385,8 +385,14 @@ features:
       # It will create missing users on the LDAP server from OIDC information.
       # Needs `features.externalUserManagement.ldap.writeable` to be be set to `true`.
       enabled: false
+      # -- The name of the OIDC claim that holds the email.
+      clamEmail: email
+      # -- The name of the OIDC claim that holds the display name.
+      clamDisplayname: name
+      # -- The name of the OIDC claim that holds the groups.
+      clamGroups: groups
       # -- The name of the OIDC claim that holds the username.
-      clamUsenName: email
+      clamUserName: sub
     # OpenID Connect Identity provider related settings.
     oidc:
       # -- Issuer URI of the OpenID Connect Identity Provider.

--- a/charts/ocis/values.yaml
+++ b/charts/ocis/values.yaml
@@ -380,7 +380,13 @@ features:
     # -- Enables account auto provisioning.
     # It will create missing users on the LDAP server from OIDC information.
     # Needs `features.externalUserManagement.ldap.writeable` to be be set to `true`.
-    autoprovisionAccounts: false
+    autoprovisionAccounts:
+      # -- Enables account auto provisioning.
+      # It will create missing users on the LDAP server from OIDC information.
+      # Needs `features.externalUserManagement.ldap.writeable` to be be set to `true`.
+      enabled: false
+      # -- Claim to take an unique user identifier from. It will be used to look up the user on the LDAP server.
+      clamUsenName: email
     # OpenID Connect Identity provider related settings.
     oidc:
       # -- Issuer URI of the OpenID Connect Identity Provider.

--- a/charts/ocis/values.yaml
+++ b/charts/ocis/values.yaml
@@ -385,7 +385,7 @@ features:
       # It will create missing users on the LDAP server from OIDC information.
       # Needs `features.externalUserManagement.ldap.writeable` to be be set to `true`.
       enabled: false
-      # -- Claim to take an unique user identifier from. It will be used to look up the user on the LDAP server.
+      # -- The name of the OIDC claim that holds the username.
       clamUsenName: email
     # OpenID Connect Identity provider related settings.
     oidc:

--- a/charts/ocis/values.yaml
+++ b/charts/ocis/values.yaml
@@ -386,13 +386,13 @@ features:
       # Needs `features.externalUserManagement.ldap.writeable` to be be set to `true`.
       enabled: false
       # -- The name of the OIDC claim that holds the email.
-      clamEmail: email
+      claimEmail: email
       # -- The name of the OIDC claim that holds the display name.
-      clamDisplayname: name
+      claimDisplayname: name
       # -- The name of the OIDC claim that holds the groups.
-      clamGroups: groups
+      claimGroups: groups
       # -- The name of the OIDC claim that holds the username.
-      clamUserName: sub
+      claimUserName: sub
     # OpenID Connect Identity provider related settings.
     oidc:
       # -- Issuer URI of the OpenID Connect Identity Provider.


### PR DESCRIPTION
## Description
Provide new values ​​for the proxy service
- [x] PROXY_AUTOPROVISION_CLAIM_USERNAME - The name of the OIDC claim that holds the username.
- [x] PROXY_AUTOPROVISION_CLAIM_EMAIL - The name of the OIDC claim that holds the email.
- [x] PROXY_AUTOPROVISION_CLAIM_DISPLAYNAME - The name of the OIDC claim that holds the display name.
- [x] PROXY_AUTOPROVISION_CLAIM_GROUPS - The name of the OIDC claim that holds the groups.

## How Has This Been Tested?
- test environment: k3s,k8s
- test case 1:

## Screenshots (if appropriate):

## Types of changes
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [x] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Technical debt
- [ ] Tests only (no source changes)

## Checklist:
- [x] Code changes
- [ ] Unit tests added
- [ ] Acceptance tests added
- [x] Documentation generated (`make docs`) and committed
- [ ] Documentation ticket raised: <link>
- [ ] Documentation PR created: <link>
