### PR TITLE
stable-5: thumbnails hardening

### DIFF
--- a/charts/ocis/docs/values-desc-table.adoc
+++ b/charts/ocis/docs/values-desc-table.adoc
@@ -4068,6 +4068,12 @@ a| [subs=-attributes]
 a| [subs=-attributes]
 `""`
 | Per-service priorityClassName configuration. Overrides the default setting from `priorityClassName` if set.
+| services.thumbnails.quota.maxConcurrencyRequests
+a| [subs=-attributes]
++int+
+a| [subs=-attributes]
+`0`
+| Number of maximum concurrent thumbnail requests. Default is 0 which is unlimited.
 | services.thumbnails.resources
 a| [subs=-attributes]
 +object+

--- a/charts/ocis/docs/values.adoc.yaml
+++ b/charts/ocis/docs/values.adoc.yaml
@@ -1913,6 +1913,9 @@ services:
   # -- THUMBNAILS service.
   # @default -- see detailed service configuration options below
   thumbnails:
+    quota:
+      # -- Number of maximum concurrent thumbnail requests. Default is 0 which is unlimited.
+      maxConcurrencyRequests: 0
     # -- Persistence settings.
     # @default -- see detailed persistence configuration options below
     persistence:

--- a/charts/ocis/templates/thumbnails/deployment.yaml
+++ b/charts/ocis/templates/thumbnails/deployment.yaml
@@ -66,6 +66,9 @@ spec:
             - name: THUMBNAILS_DATA_ENDPOINT
               value: http://{{ .appName }}:9186/thumbnails/data
 
+            - name: THUMBNAILS_MAX_CONCURRENT_REQUESTS
+              value: {{ .Values.services.thumbnails.quota.maxConcurrencyRequests | quote }}
+              
             - name: THUMBNAILS_WEBDAVSOURCE_INSECURE
               value: {{ .Values.insecure.ocisHttpApiInsecure | quote }}
 

--- a/charts/ocis/values.yaml
+++ b/charts/ocis/values.yaml
@@ -1912,6 +1912,9 @@ services:
   # -- THUMBNAILS service.
   # @default -- see detailed service configuration options below
   thumbnails:
+    quota:
+      # -- Number of maximum concurrent thumbnail requests. Default is 0 which is unlimited.
+      maxConcurrencyRequests: 0
     # -- Persistence settings.
     # @default -- see detailed persistence configuration options below
     persistence:


### PR DESCRIPTION
## Description
port of #642, adapted for oCIS 5.0.6

## Related Issue
- Fixes #570

## Motivation and Context
- prevent thumbnails service OOM kills when configured

## How Has This Been Tested?
- set  up concurrency in the development-install example:
```diff
diff --git a/deployments/development-install/helmfile.yaml b/deployments/development-install/helmfile.yaml
index 6edf79a..f5d0e80 100644
--- a/deployments/development-install/helmfile.yaml
+++ b/deployments/development-install/helmfile.yaml
@@ -63,6 +63,8 @@ releases:
               cleanUpOldThumbnails:
                 enabled: true
                 schedule: "* * * * *"
+            quota:
+              maxConcurrencyRequests: 1
 
           web:
             persistence:
```

Then I uploaded images and watched the thumbnail behavior:

![image](https://github.com/user-attachments/assets/2b0182e3-f043-43d5-afc5-81188fce06a7)


## Screenshots (if appropriate):

## Types of changes
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Technical debt
- [ ] Tests only (no source changes)

## Checklist:
- [x] Code changes
- [ ] Unit tests added
- [ ] Acceptance tests added
- [ ] Documentation generated (`make docs`) and committed
- [ ] Documentation ticket raised: <link>
- [ ] Documentation PR created: <link>
