### PR TITLE
proxy needs to be aware of events

### DIFF
--- a/charts/ocis/templates/proxy/deployment.yaml
+++ b/charts/ocis/templates/proxy/deployment.yaml
@@ -25,6 +25,7 @@ spec:
           env:
             {{- include "ocis.serviceRegistry" . | nindent 12 }}
             {{- include "ocis.cacheStore" . | nindent 12 }}
+            {{- include "ocis.events" . | nindent 12 }}
 
             - name: PROXY_LOG_COLOR
               value: {{ .Values.logging.color | quote }}


### PR DESCRIPTION
when testing latest ocis with the next branch the proxy would fail to start because it now tries to connect to nats to read events