### PR TITLE
fix appVersion renovate tracking by switching to rolling

### DIFF
--- a/charts/ocis/Chart.yaml
+++ b/charts/ocis/Chart.yaml
@@ -10,7 +10,7 @@ maintainers:
     url: https://owncloud.com
 type: application
 version: 0.7.0
-# renovate: datasource=docker depName=owncloud/ocis
+# renovate: datasource=docker depName=owncloud/ocis-rolling
 appVersion: 6.1.0
 kubeVersion: "" # please see https://doc.owncloud.com/ocis/next/deployment/container/orchestration/orchestration.html#get-the-chart for compatible Kubernetes versions
 sources:


### PR DESCRIPTION
## Description
the renovate annotation on the appVersion was still tracking owncloud/ocis while it should track owncloud/ocis-rolling

## Related Issue
- Fixes automated version updates on main branch

## Motivation and Context

## How Has This Been Tested?
- not tested

## Screenshots (if appropriate):

## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Technical debt
- [ ] Tests only (no source changes)

## Checklist:
- [x] Code changes
- [ ] Unit tests added
- [ ] Acceptance tests added
- [ ] Documentation generated (`make docs`) and committed
- [ ] Documentation ticket raised: <link>
- [ ] Documentation PR created: <link>
