### PR TITLE
fix(ocis-office): disable scaling in collabora

### DIFF
--- a/deployments/ocis-office/helmfile.yaml
+++ b/deployments/ocis-office/helmfile.yaml
@@ -94,7 +94,9 @@ releases:
     chart: collabora/collabora-online
     version: 1.1.20
     values:
-      - collabora:
+      - autoscaling:
+          enabled: false
+        collabora:
           aliasgroups:
             - host: "wopi-collabora.kube.owncloud.test" # needed because we connect via the ingress to the collaboration service
             # - host: "collaboration-collabora.ocis.svc.cluster.local" # needed if we would use the cluster internal Service to connect to the collaboration service


### PR DESCRIPTION
## Description
This disables the autoscaling in the collabora online chart.
c.f. https://github.com/CollaboraOnline/online/blob/eb2526d8151edb8f481b3ddbc7ffcd17e5efa291/kubernetes/helm/collabora-online/values.yaml#L232C3-L232C10

## Related Issue
<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->
- Fixes <issue_link>

## Motivation and Context
I had a lot of issues with locking/not correctly unlocking of files, all went away when I disabled the autoscaling.
As we don't enable scaling for our own services in the examples, I'd argue we can disable it here too.

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
- test environment:
- test case 1:
- test case 2:
- ...

## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Technical debt
- [ ] Tests only (no source changes)

## Checklist:
<!-- Tick the checkboxes when done. -->
<!-- Raise documentation ticket in https://github.com/owncloud/docs-ocis/issues -->
<!-- or create documentation PR in https://github.com/owncloud/docs-ocis/tree/master/modules/ROOT/pages/deployment/container>
- [ ] Code changes
- [ ] Unit tests added
- [ ] Acceptance tests added
- [ ] Documentation generated (`make docs`) and committed
- [ ] Documentation ticket raised: <link>
- [ ] Documentation PR created: <link>
