### PR TITLE
Add cors to storage-users

### DIFF
--- a/charts/ocis/templates/storageusers/deployment.yaml
+++ b/charts/ocis/templates/storageusers/deployment.yaml
@@ -38,6 +38,7 @@ spec:
             {{- include "ocis.serviceRegistry" . | nindent 12 }}
             {{- include "ocis.events" . | nindent 12 }}
             {{- include "ocis.cacheStore" . | nindent 12 }}
+            {{- include "ocis.cors" . |nindent 12 }}
 
             # set the gateway for the CLI tools
             - name: STORAGE_USERS_GATEWAY_GRPC_ADDR


### PR DESCRIPTION
The storage-users service also need cors configuration for tus chunked uploads.