### PR TITLE
Frontend service wasn't created without `appsIntegration`s

### DIFF
--- a/charts/ocis/templates/frontend/deployment.yaml
+++ b/charts/ocis/templates/frontend/deployment.yaml
@@ -11,6 +11,7 @@
 {{- end }}
 {{- end }}
 {{- end }}
+{{ end }}
 ---
 apiVersion: apps/v1
 kind: Deployment
@@ -196,4 +197,4 @@ spec:
         - name: configs
           configMap:
             name: sharing-banned-passwords-{{ .appName }}
-{{ end }}
+


### PR DESCRIPTION
## Description
Frontend service wasn't created without `appsIntegration`s as regression of https://github.com/owncloud/ocis-charts/pull/690

## Related Issue
- Fixes none

## Motivation and Context
Bugfix

## How Has This Been Tested?
Tested via `helmfile template` in `ocis-charts/deployments/development-install`

## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Technical debt
- [ ] Tests only (no source changes)

## Checklist:
- [ ] Code changes
- [ ] Unit tests added
- [ ] Acceptance tests added
- [ ] Documentation generated (`make docs`) and committed
- [ ] Documentation ticket raised: <link>
- [ ] Documentation PR created: <link>
