### PR TITLE
remove frontend cors workaround since it's fixed in https://github.com/owncloud/ocis/pull/8651

### DIFF
--- a/charts/ocis/templates/frontend/deployment.yaml
+++ b/charts/ocis/templates/frontend/deployment.yaml
@@ -40,10 +40,6 @@ spec:
             {{- include "ocis.cors" . |nindent 12 }}
             {{- include "ocis.events" . | nindent 12 }}
 
-            # TODO: this is a workaround, remove it after https://github.com/owncloud/ocis/issues/8380 is closed
-            - name: OCIS_CORS_ALLOW_METHODS
-              value: "OPTIONS,HEAD,GET,PUT,POST,PATCH,DELETE,MKCOL,PROPFIND,PROPPATCH,MOVE,COPY,REPORT,SEARCH"
-
             - name: FRONTEND_LOG_COLOR
               value: {{ .Values.logging.color | quote }}
             - name: FRONTEND_LOG_LEVEL


### PR DESCRIPTION
## Description
removes a workaround that was fixed in upstream ocis code meanwhile

## Related Issue
- fix in https://github.com/owncloud/ocis/pull/8651
- original issue https://github.com/owncloud/ocis/issues/8380
- introduction of workaround https://github.com/owncloud/ocis-charts/pull/504

## Motivation and Context
see https://github.com/owncloud/ocis/issues/8380

## How Has This Been Tested?
- not tested

## Screenshots (if appropriate):

## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [x] Technical debt
- [ ] Tests only (no source changes)

## Checklist:
- [x] Code changes
- [ ] Unit tests added
- [ ] Acceptance tests added
- [ ] Documentation generated (`make docs`) and committed
- [ ] Documentation ticket raised: <link>
- [ ] Documentation PR created: <link>
