### PR TITLE
Disable `sse` service if `sse` is disabled

### DIFF
--- a/charts/ocis/templates/sse/service.yaml
+++ b/charts/ocis/templates/sse/service.yaml
@@ -1,3 +1,4 @@
+{{ if not .Values.features.sse.disabled }}
 {{- include "ocis.basicServiceTemplates" (dict "scope" . "appName" "appNameSSE" "appNameSuffix" "") -}}
 apiVersion: v1
 kind: Service
@@ -20,3 +21,4 @@ spec:
       port: 9135
       protocol: TCP
       appProtocol: {{ .Values.service.appProtocol.http | quote}}
+{{ end }}


### PR DESCRIPTION
## Description
Right now all parts of `sse` are disabled if `features.sse.disabled` is set to `true` except the service which was missing. This PR changes this glitch.

## Related Issue
- Fixes none

## Motivation and Context
Bugfix and alignment

## How Has This Been Tested?
- tested with `helm template`

## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Technical debt
- [ ] Tests only (no source changes)

## Checklist:
- [x] Code changes
- [ ] Unit tests added
- [ ] Acceptance tests added
- [ ] Documentation generated (`make docs`) and committed
- [ ] Documentation ticket raised: <link>
- [ ] Documentation PR created: <link>
