### PR TITLE
allow to disable chat in office suite

### DIFF
--- a/charts/ocis/docs/values-desc-table.adoc
+++ b/charts/ocis/docs/values-desc-table.adoc
@@ -132,6 +132,12 @@ a| [subs=-attributes]
 a| [subs=-attributes]
 default configuration of oCIS, see https://doc.owncloud.com/ocis/next/deployment/services/s-list/app-registry.html#yaml-example[doc.owncloud.com]
 | Mimetype configuration. Let's you configure a mimetypes' default application, if it is allowed to create a new file and more.
+| features.appsIntegration.wopiIntegration.officeSuites[0].disableChat
+a| [subs=-attributes]
++bool+
+a| [subs=-attributes]
+`false`
+| Disables the chat in the office suite. Note: This currently only applies to OnlyOffice
 | features.appsIntegration.wopiIntegration.officeSuites[0].enabled
 a| [subs=-attributes]
 +bool+
@@ -204,6 +210,12 @@ a| [subs=-attributes]
 a| [subs=-attributes]
 `""`
 | URI of the office suite.
+| features.appsIntegration.wopiIntegration.officeSuites[1].disableChat
+a| [subs=-attributes]
++bool+
+a| [subs=-attributes]
+`false`
+| Disables the chat in the office suite. Note: This currently only applies to OnlyOffice
 | features.appsIntegration.wopiIntegration.officeSuites[1].enabled
 a| [subs=-attributes]
 +bool+

--- a/charts/ocis/docs/values.adoc.yaml
+++ b/charts/ocis/docs/values.adoc.yaml
@@ -311,6 +311,8 @@ features:
           insecure: false
           # -- Enable secure view for this office suite
           secureViewEnabled: false
+          # -- Disables the chat in the office suite. Note: This currently only applies to OnlyOffice
+          disableChat: false
           # Ingress for collaboration service.
           ingress:
             # -- Enables the Ingress. Only needed if the office application is not running within the same cluster.
@@ -343,6 +345,8 @@ features:
           insecure: false
           # -- Enable secure view for this office suite. Note: OnlyOffice doesn't support secureView right now
           secureViewEnabled: false
+          # -- Disables the chat in the office suite. Note: This currently only applies to OnlyOffice
+          disableChat: false
           # Ingress for collaboration service.
           ingress:
             # -- Enables the Ingress. Only needed if the office application is not running within the same cluster.

--- a/charts/ocis/templates/collaboration/deployment.yaml
+++ b/charts/ocis/templates/collaboration/deployment.yaml
@@ -80,6 +80,9 @@ spec:
               value: http://{{ $.appName }}.{{ template "ocis.namespace" $ }}.svc.cluster.local:9300
               {{- end }}
 
+            - name: COLLABORATION_WOPI_DISABLE_CHAT
+              value: {{ default false $officeSuite.disableChat | quote }}
+
             - name: COLLABORATION_JWT_SECRET
               valueFrom:
                 secretKeyRef:

--- a/charts/ocis/values.yaml
+++ b/charts/ocis/values.yaml
@@ -310,6 +310,8 @@ features:
           insecure: false
           # -- Enable secure view for this office suite
           secureViewEnabled: false
+          # -- Disables the chat in the office suite. Note: This currently only applies to OnlyOffice
+          disableChat: false
           # Ingress for collaboration service.
           ingress:
             # -- Enables the Ingress. Only needed if the office application is not running within the same cluster.
@@ -342,6 +344,8 @@ features:
           insecure: false
           # -- Enable secure view for this office suite. Note: OnlyOffice doesn't support secureView right now
           secureViewEnabled: false
+          # -- Disables the chat in the office suite. Note: This currently only applies to OnlyOffice
+          disableChat: false
           # Ingress for collaboration service.
           ingress:
             # -- Enables the Ingress. Only needed if the office application is not running within the same cluster.


### PR DESCRIPTION
## Description
allow to disable chat in the office suites

## Related Issue
- Fixes https://github.com/owncloud/ocis-charts/issues/640

## Motivation and Context

reintroduce option that was existing for oCIS 5

## How Has This Been Tested?
- TODO: to be tested

## Screenshots (if appropriate):

## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Technical debt
- [ ] Tests only (no source changes)

## Checklist:
- [x] Code changes
- [ ] Unit tests added
- [ ] Acceptance tests added
- [ ] Documentation generated (`make docs`) and committed
- [ ] Documentation ticket raised: <link>
- [ ] Documentation PR created: <link>
