### PR TITLE
add demo users issuer url to IDM setup

### DIFF
--- a/charts/ocis/templates/idm/deployment.yaml
+++ b/charts/ocis/templates/idm/deployment.yaml
@@ -71,6 +71,8 @@ spec:
 
             - name: IDM_CREATE_DEMO_USERS
               value: {{ .Values.features.demoUsers | quote }}
+            - name: OCIS_OIDC_ISSUER
+              value: "https://{{ .Values.externalDomain }}"
 
             - name: IDM_ADMIN_PASSWORD
               valueFrom:


### PR DESCRIPTION
## Description
add correct issuer url to demo users in IDM setup

## Related Issue
- Follow up of https://github.com/owncloud/ocis/pull/9819

## Motivation and Context

## How Has This Been Tested?
- tested with the development-install deployment example
![image](https://github.com/user-attachments/assets/53e29908-aceb-4709-908d-1a66275ecb01)


## Screenshots (if appropriate):

## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Technical debt
- [ ] Tests only (no source changes)

## Checklist:
- [x] Code changes
- [ ] Unit tests added
- [ ] Acceptance tests added
- [ ] Documentation generated (`make docs`) and committed
- [ ] Documentation ticket raised: <link>
- [ ] Documentation PR created: <link>
