### PR TITLE
update mail settings

### DIFF
--- a/charts/ocis/docs/values-desc-table.adoc
+++ b/charts/ocis/docs/values-desc-table.adoc
@@ -364,8 +364,8 @@ a| [subs=-attributes]
 a| [subs=-attributes]
 +string+
 a| [subs=-attributes]
-`"none"`
-| Values 'ssl' and 'tls' are deprecated and will be removed in oCIS release 6.0.0. Use 'starttls' instead of 'tls' and 'ssltls' instead of 'ssl'.
+`"ssltls"`
+| Encryption method for the SMTP communication. Possible values are `starttls`, `ssl`, `ssltls`, `tls` and `none`
 | features.emailNotifications.smtp.host
 a| [subs=-attributes]
 +string+

--- a/charts/ocis/docs/values.adoc.yaml
+++ b/charts/ocis/docs/values.adoc.yaml
@@ -219,9 +219,8 @@ features:
       # -- Authentication method for the SMTP communication. Possible values are ‘login’, ‘plain’, ‘crammd5’, ‘none’, 'auto'
       # If set to another value than `none`, a secret referenced by `notificationsSmtpSecretRef` needs to be present.
       authentication: auto
-      # -- Encryption method for the SMTP communication. Possible values are ‘starttls’, ‘ssltls’ and ‘none’.
-      # -- Values 'ssl' and 'tls' are deprecated and will be removed in oCIS release 6.0.0. Use 'starttls' instead of 'tls' and 'ssltls' instead of 'ssl'.
-      encryption: none
+      # -- Encryption method for the SMTP communication. Possible values are `starttls`, `ssl`, `ssltls`, `tls` and `none`
+      encryption: ssltls
     branding:
       # -- Enables mail branding. If enabled, you need to provide the text and html template ConfigMap.
       # The image ConfigMap is optional.

--- a/charts/ocis/values.yaml
+++ b/charts/ocis/values.yaml
@@ -219,7 +219,7 @@ features:
       # If set to another value than `none`, a secret referenced by `notificationsSmtpSecretRef` needs to be present.
       authentication: auto
       # -- Encryption method for the SMTP communication. Possible values are `starttls`, `ssl`, `ssltls`, `tls` and `none`
-      encryption: none #TODO: have a more sane default?
+      encryption: ssltls
     branding:
       # -- Enables mail branding. If enabled, you need to provide the text and html template ConfigMap.
       # The image ConfigMap is optional.

--- a/charts/ocis/values.yaml
+++ b/charts/ocis/values.yaml
@@ -218,9 +218,8 @@ features:
       # -- Authentication method for the SMTP communication. Possible values are ‘login’, ‘plain’, ‘crammd5’, ‘none’, 'auto'
       # If set to another value than `none`, a secret referenced by `notificationsSmtpSecretRef` needs to be present.
       authentication: auto
-      # -- Encryption method for the SMTP communication. Possible values are ‘starttls’, ‘ssltls’ and ‘none’.
-      # -- Values 'ssl' and 'tls' are deprecated and will be removed in oCIS release 6.0.0. Use 'starttls' instead of 'tls' and 'ssltls' instead of 'ssl'.
-      encryption: none
+      # -- Encryption method for the SMTP communication. Possible values are `starttls`, `ssl`, `ssltls`, `tls` and `none`
+      encryption: none #TODO: have a more sane default?
     branding:
       # -- Enables mail branding. If enabled, you need to provide the text and html template ConfigMap.
       # The image ConfigMap is optional.

--- a/deployments/ocis-mail/helmfile.yaml
+++ b/deployments/ocis-mail/helmfile.yaml
@@ -2,7 +2,6 @@ repositories:
   - name: inbucket
     url: https://inbucket.github.io/inbucket-community
 
-
 releases:
   - name: inbucket
     chart: inbucket/inbucket
@@ -42,6 +41,7 @@ releases:
               host: inbucket.inbucket.svc.cluster.local
               port: 2500
               sender: "ownCloud <noreply@ocis.kube.owncloud.test>"
+              encryption: none
             branding:
               enabled: false # you can set this to true if you first run `kubectl -n ocis apply -f mail-templates.yaml`
 

--- a/deployments/ocis-mail/helmfile.yaml
+++ b/deployments/ocis-mail/helmfile.yaml
@@ -41,6 +41,7 @@ releases:
               host: inbucket.inbucket.svc.cluster.local
               port: 2500
               sender: "ownCloud <noreply@ocis.kube.owncloud.test>"
+              authentication: none
               encryption: none
             branding:
               enabled: false # you can set this to true if you first run `kubectl -n ocis apply -f mail-templates.yaml`


### PR DESCRIPTION
## Description
updates the list of available mail encryption settings and switches to a more secure default.

## Related Issue

## Motivation and Context


## How Has This Been Tested?
- using the ocis-mail deployment example

## Screenshots (if appropriate):

## Types of changes
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [x] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Technical debt
- [ ] Tests only (no source changes)

## Checklist:
- [x] Code changes
- [ ] Unit tests added
- [ ] Acceptance tests added
- [x] Documentation generated (`make docs`) and committed
- [ ] Documentation ticket raised: <link>
- [ ] Documentation PR created: <link>
