### PR TITLE
include autoprovisioning variables only if used

### DIFF
--- a/charts/ocis/templates/proxy/deployment.yaml
+++ b/charts/ocis/templates/proxy/deployment.yaml
@@ -114,6 +114,7 @@ spec:
 
             - name: PROXY_AUTOPROVISION_ACCOUNTS
               value: {{ .Values.features.externalUserManagement.autoprovisionAccounts.enabled | default "false" | quote }}
+            {{- if .Values.features.externalUserManagement.autoprovisionAccounts.enabled }}
             - name: PROXY_AUTOPROVISION_CLAIM_EMAIL
               value: {{ .Values.features.externalUserManagement.autoprovisionAccounts.claimEmail | quote }}
             - name: PROXY_AUTOPROVISION_CLAIM_DISPLAYNAME
@@ -122,6 +123,7 @@ spec:
               value: {{ .Values.features.externalUserManagement.autoprovisionAccounts.claimGroups | quote }}
             - name: PROXY_AUTOPROVISION_CLAIM_USERNAME
               value: {{ .Values.features.externalUserManagement.autoprovisionAccounts.claimUserName | quote }}
+            {{- end }}
 
           {{- include "ocis.livenessProbe" . | nindent 10 }}
 


### PR DESCRIPTION
## Description
render PROXY_AUTOPROVISION_xx variables only when PROXY_AUTOPROVISION_ACCOUNTS is enabled

## Related Issue

## Motivation and Context
I personally prefer to skip options that have no effect

## How Has This Been Tested?
- tested by rendering (helmfile template) with autoprovisionAccounts.enabled set to true and false
- 
## Screenshots (if appropriate):

## Types of changes
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [x] Technical debt
- [ ] Tests only (no source changes)

## Checklist:
- [x] Code changes
- [ ] Unit tests added
- [ ] Acceptance tests added
- [ ] Documentation generated (`make docs`) and committed
- [ ] Documentation ticket raised: <link>
- [ ] Documentation PR created: <link>
