### PR TITLE
remove resharing option

### DIFF
--- a/charts/ocis/docs/values-desc-table.adoc
+++ b/charts/ocis/docs/values-desc-table.adoc
@@ -840,12 +840,6 @@ a| [subs=-attributes]
 a| [subs=-attributes]
 `false`
 | Enforce a password only on writable public link shares. Is already enforced if `features.sharing.publiclink.shareMustHavePassword` option is set to `true``.
-| features.sharing.users.resharing
-a| [subs=-attributes]
-+bool+
-a| [subs=-attributes]
-`true`
-| Allow a share receiver to share the share with a 3rd person.
 | features.sharing.users.search.minLengthLimit
 a| [subs=-attributes]
 +int+

--- a/charts/ocis/docs/values.adoc.yaml
+++ b/charts/ocis/docs/values.adoc.yaml
@@ -247,8 +247,6 @@ features:
   sharing:
     # Sharing with users related settings
     users:
-      # -- Allow a share receiver to share the share with a 3rd person.
-      resharing: true
       # Search settings for finding users to share with.
       search:
         # -- Minimum number of characters to enter before a client should start a search for Share receivers.

--- a/charts/ocis/templates/frontend/deployment.yaml
+++ b/charts/ocis/templates/frontend/deployment.yaml
@@ -99,9 +99,6 @@ spec:
             - name: FRONTEND_SEARCH_MIN_LENGTH
               value: {{ .Values.features.sharing.users.search.minLengthLimit | quote }}
 
-            - name: FRONTEND_ENABLE_RESHARING
-              value: {{ .Values.features.sharing.users.resharing | quote }}
-
             - name: FRONTEND_ARCHIVER_MAX_SIZE
               value: {{ int64 .Values.features.archiver.maxSize | quote }}
 
@@ -193,4 +190,3 @@ spec:
         - name: configs
           configMap:
             name: sharing-banned-passwords-{{ .appName }}
-

--- a/charts/ocis/values.yaml
+++ b/charts/ocis/values.yaml
@@ -246,8 +246,6 @@ features:
   sharing:
     # Sharing with users related settings
     users:
-      # -- Allow a share receiver to share the share with a 3rd person.
-      resharing: true
       # Search settings for finding users to share with.
       search:
         # -- Minimum number of characters to enter before a client should start a search for Share receivers.


### PR DESCRIPTION
## Description
remove resharing option

## Related Issue
- Follow up of https://github.com/owncloud/ocis/pull/8762

## Motivation and Context
Resharing no longer exists

## How Has This Been Tested?
- not at all

## Screenshots (if appropriate):

## Types of changes
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [x] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Technical debt
- [ ] Tests only (no source changes)

## Checklist:
- [x] Code changes
- [ ] Unit tests added
- [ ] Acceptance tests added
- [x] Documentation generated (`make docs`) and committed
- [ ] Documentation ticket raised: <link>
- [ ] Documentation PR created: <link>
