### PR TITLE
adapt user email in search results settings and change it to false by default to follow the ocis product

### DIFF
--- a/charts/ocis/docs/values-desc-table.adoc
+++ b/charts/ocis/docs/values-desc-table.adoc
@@ -856,7 +856,7 @@ a| [subs=-attributes]
 a| [subs=-attributes]
 +bool+
 a| [subs=-attributes]
-`true`
+`false`
 | Show user email when searching for other users to share with.
 | features.sse.disabled
 a| [subs=-attributes]

--- a/charts/ocis/docs/values.adoc.yaml
+++ b/charts/ocis/docs/values.adoc.yaml
@@ -255,7 +255,7 @@ features:
         # This setting can be used to customize the user experience if e.g too many results are displayed.
         minLengthLimit: 3
         # -- Show user email when searching for other users to share with.
-        showUserEmail: true
+        showUserEmail: false
     # Sharing per public link related setings
     publiclink:
       # -- Enforce a password on all public link shares.

--- a/charts/ocis/templates/frontend/deployment.yaml
+++ b/charts/ocis/templates/frontend/deployment.yaml
@@ -111,7 +111,7 @@ spec:
             - name: FRONTEND_FULL_TEXT_SEARCH_ENABLED
               value: {{ not (eq .Values.services.search.extractor.type "basic") | quote }}
 
-            - name: FRONTEND_SHOW_USER_EMAIL_IN_RESULTS
+            - name: OCIS_SHOW_USER_EMAIL_IN_RESULTS
               value: {{ .Values.features.sharing.users.search.showUserEmail | quote }}
 
             - name: OCIS_DISABLE_SSE
@@ -193,4 +193,3 @@ spec:
         - name: configs
           configMap:
             name: sharing-banned-passwords-{{ .appName }}
-

--- a/charts/ocis/templates/graph/deployment.yaml
+++ b/charts/ocis/templates/graph/deployment.yaml
@@ -111,7 +111,7 @@ spec:
 
             - name: GRAPH_USERNAME_MATCH
               value: {{ .Values.features.externalUserManagement.ldap.user.userNameMatch | quote }}
-              
+
             - name: GRAPH_LDAP_USER_FILTER
               value: {{ .Values.features.externalUserManagement.ldap.user.filter | quote }}
             - name: GRAPH_LDAP_GROUP_FILTER
@@ -152,6 +152,9 @@ spec:
               value: {{ .Values.features.externalUserManagement.ldap.disableUsers.disabledUsersGroupDN | quote }}
 
             {{ end }}
+
+            - name: OCIS_SHOW_USER_EMAIL_IN_RESULTS
+              value: {{ .Values.features.sharing.users.search.showUserEmail | quote }}
 
             - name: GRAPH_APPLICATION_ID
               valueFrom:

--- a/charts/ocis/values.yaml
+++ b/charts/ocis/values.yaml
@@ -254,7 +254,7 @@ features:
         # This setting can be used to customize the user experience if e.g too many results are displayed.
         minLengthLimit: 3
         # -- Show user email when searching for other users to share with.
-        showUserEmail: true
+        showUserEmail: false
     # Sharing per public link related setings
     publiclink:
       # -- Enforce a password on all public link shares.


### PR DESCRIPTION
## Description
- adapt the xx_SHOW_USER_EMAIL_IN_RESULTS settings to match what oCIS 6.3 has
- change the default for `features.sharing.users.search.showUserEmail` from `true` to `false` to match the oCIS product

## Related Issue
- Fixes https://github.com/owncloud/ocis-charts/issues/715

## Motivation and Context

## How Has This Been Tested?
- ...

## Screenshots (if appropriate):

## Types of changes
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [x] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Technical debt
- [ ] Tests only (no source changes)

## Checklist:
- [x] Code changes
- [ ] Unit tests added
- [ ] Acceptance tests added
- [x] Documentation generated (`make docs`) and committed
- [ ] Documentation ticket raised: <link>
- [ ] Documentation PR created: <link>
