### PR TITLE
add default language setting to graph service

### DIFF
--- a/charts/ocis/templates/graph/deployment.yaml
+++ b/charts/ocis/templates/graph/deployment.yaml
@@ -111,7 +111,7 @@ spec:
 
             - name: GRAPH_USERNAME_MATCH
               value: {{ .Values.features.externalUserManagement.ldap.user.userNameMatch | quote }}
-              
+
             - name: GRAPH_LDAP_USER_FILTER
               value: {{ .Values.features.externalUserManagement.ldap.user.filter | quote }}
             - name: GRAPH_LDAP_GROUP_FILTER
@@ -164,6 +164,9 @@ spec:
                 secretKeyRef:
                   name: {{ include "secrets.jwtSecret" . }}
                   key: jwt-secret
+
+            - name: OCIS_DEFAULT_LANGUAGE
+              value: {{ default "en" .Values.features.language.default | quote }}
 
             {{- if .Values.features.quotas.default }}
             - name: GRAPH_SPACES_DEFAULT_QUOTA


### PR DESCRIPTION
## Description
configure default language on the the graph service

## Related Issue
- Fixes https://github.com/owncloud/ocis-charts/issues/716

## Motivation and Context

## How Has This Been Tested?
- not tested

## Screenshots (if appropriate):

## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Technical debt
- [ ] Tests only (no source changes)

## Checklist:
- [x] Code changes
- [ ] Unit tests added
- [ ] Acceptance tests added
- [ ] Documentation generated (`make docs`) and committed
- [ ] Documentation ticket raised: <link>
- [ ] Documentation PR created: <link>
