### PR TITLE
add max height and width constrains for thumbnails

### DIFF
--- a/charts/ocis/docs/values-desc-table.adoc
+++ b/charts/ocis/docs/values-desc-table.adoc
@@ -4284,6 +4284,18 @@ a| [subs=-attributes]
 a| [subs=-attributes]
 `"50MB"`
 | Sets a maximum file size of an input image which is being processed. Usable common abbreviations: [KB, KiB, MB, MiB, GB, GiB, TB, TiB, PB, PiB, EB, EiB], example: 2GB.
+| services.thumbnails.quota.maxInputHeight
+a| [subs=-attributes]
++int+
+a| [subs=-attributes]
+`7680`
+| Sets a maximium height of an imput image which is being processed.
+| services.thumbnails.quota.maxInputWitdth
+a| [subs=-attributes]
++int+
+a| [subs=-attributes]
+`7680`
+| Sets a maximium width of an imput image which is being processed.
 | services.thumbnails.resources
 a| [subs=-attributes]
 +object+

--- a/charts/ocis/docs/values.adoc.yaml
+++ b/charts/ocis/docs/values.adoc.yaml
@@ -2038,6 +2038,10 @@ services:
       maxConcurrencyRequests: 0
       # -- Sets a maximum file size of an input image which is being processed. Usable common abbreviations: [KB, KiB, MB, MiB, GB, GiB, TB, TiB, PB, PiB, EB, EiB], example: 2GB.
       maxFileSize: 50MB
+      # -- Sets a maximium width of an imput image which is being processed.
+      maxInputWitdth: 7680
+      # -- Sets a maximium height of an imput image which is being processed.
+      maxInputHeight: 7680
     # -- Persistence settings.
     # @default -- see detailed persistence configuration options below
     persistence:

--- a/charts/ocis/templates/thumbnails/deployment.yaml
+++ b/charts/ocis/templates/thumbnails/deployment.yaml
@@ -70,6 +70,10 @@ spec:
               value: {{ .Values.services.thumbnails.quota.maxConcurrencyRequests | quote }}
             - name: THUMBNAILS_MAX_INPUT_IMAGE_FILE_SIZE
               value: {{ .Values.services.thumbnails.quota.maxFileSize | quote }}
+            - name: THUMBNAILS_MAX_INPUT_WIDTH
+              value: {{ .Values.services.thumbnails.quota.maxInputWitdth | quote }}
+            - name: THUMBNAILS_MAX_INPUT_HEIGHT
+              value: {{ .Values.services.thumbnails.quota.maxInputHeight | quote }}
 
             - name: THUMBNAILS_WEBDAVSOURCE_INSECURE
               value: {{ .Values.insecure.ocisHttpApiInsecure | quote }}

--- a/charts/ocis/values.yaml
+++ b/charts/ocis/values.yaml
@@ -2037,6 +2037,10 @@ services:
       maxConcurrencyRequests: 0
       # -- Sets a maximum file size of an input image which is being processed. Usable common abbreviations: [KB, KiB, MB, MiB, GB, GiB, TB, TiB, PB, PiB, EB, EiB], example: 2GB.
       maxFileSize: 50MB
+      # -- Sets a maximium width of an imput image which is being processed.
+      maxInputWitdth: 7680
+      # -- Sets a maximium height of an imput image which is being processed.
+      maxInputHeight: 7680
     # -- Persistence settings.
     # @default -- see detailed persistence configuration options below
     persistence:


### PR DESCRIPTION
## Description
expose configuration options for the maximum height and width of image for thumbnails to be processed

## Related Issue
- Fixes https://github.com/owncloud/ocis-charts/issues/723

## Motivation and Context

## How Has This Been Tested?
- not tested

## Screenshots (if appropriate):

## Types of changes
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Technical debt
- [ ] Tests only (no source changes)

## Checklist:
- [x] Code changes
- [ ] Unit tests added
- [ ] Acceptance tests added
- [x] Documentation generated (`make docs`) and committed
- [ ] Documentation ticket raised: <link>
- [ ] Documentation PR created: <link>
