### PR TITLE
add activitylog

### DIFF
--- a/charts/ocis/docs/values-desc-table.adoc
+++ b/charts/ocis/docs/values-desc-table.adoc
@@ -1374,6 +1374,84 @@ a| [subs=-attributes]
 a| [subs=-attributes]
 `"tcp"`
 | appProtocol to be used for service ports that use the nats wire protocol. Not used if `messagingSystem.external.enabled` equals `true`.
+| services.activitylog
+a| [subs=-attributes]
++object+
+a| [subs=-attributes]
+see detailed service configuration options below
+| ACTIVITYLOG service.
+| services.activitylog.affinity
+a| [subs=-attributes]
++object+
+a| [subs=-attributes]
+`{}`
+| Affinity settings for the activitylog service. See the documentation of this setting in approvider for examples.
+| services.activitylog.autoscaling
+a| [subs=-attributes]
++object+
+a| [subs=-attributes]
+`{}`
+| Per-service autoscaling. Overrides the default setting from `autoscaling` if set.
+| services.activitylog.extraLabels
+a| [subs=-attributes]
++object+
+a| [subs=-attributes]
+`{}`
+| Per-service custom labels
+| services.activitylog.image.pullPolicy
+a| [subs=-attributes]
++string+
+a| [subs=-attributes]
+`nil`
+| Image pull policy
+| services.activitylog.image.repository
+a| [subs=-attributes]
++string+
+a| [subs=-attributes]
+`""`
+| Image repository
+| services.activitylog.image.sha
+a| [subs=-attributes]
++string+
+a| [subs=-attributes]
+`""`
+| Image sha / digest (optional).
+| services.activitylog.image.tag
+a| [subs=-attributes]
++string+
+a| [subs=-attributes]
+`""`
+| Image tag.
+| services.activitylog.nodeSelector
+a| [subs=-attributes]
++object+
+a| [subs=-attributes]
+`{}`
+| Per-service nodeSelector configuration. Overrides the default setting from `nodeSelector` if set.
+| services.activitylog.podDisruptionBudget
+a| [subs=-attributes]
++object+
+a| [subs=-attributes]
+`{}`
+| Per-service PodDisruptionBudget. Overrides the default setting from `podDisruptionBudget` if set.
+| services.activitylog.priorityClassName
+a| [subs=-attributes]
++string+
+a| [subs=-attributes]
+`""`
+| Per-service priorityClassName configuration. Overrides the default setting from `priorityClassName` if set.
+| services.activitylog.resources
+a| [subs=-attributes]
++object+
+a| [subs=-attributes]
+`{}`
+| Per-service resources configuration. Overrides the default setting from `resources` if set.
+| services.activitylog.store
+a| [subs=-attributes]
++object+
+a| [subs=-attributes]
+`{}`
+| Per-service store configuration for the activitylog service. Overrides the default setting from `store` if set.
 | services.antivirus
 a| [subs=-attributes]
 +object+

--- a/charts/ocis/docs/values.adoc.yaml
+++ b/charts/ocis/docs/values.adoc.yaml
@@ -865,6 +865,43 @@ extraResources: []
 
 # per-service configuration.
 services:
+  # -- ACTIVITYLOG service.
+  # @default -- see detailed service configuration options below
+  activitylog:
+    # -- Per-service resources configuration. Overrides the default setting from `resources` if set.
+    resources: {}
+    # -- Per-service nodeSelector configuration. Overrides the default setting from `nodeSelector` if set.
+    nodeSelector: {}
+    # -- Per-service priorityClassName configuration. Overrides the default setting from `priorityClassName` if set.
+    priorityClassName: ""
+    # -- Per-service store configuration for the activitylog service. Overrides the default setting from `store` if set.
+    store:
+      {}
+      # -- Configure the store type for the activitylog service. Might be `memory` (only for testing), `redis-sentinel`, `nats-js-kv`
+      # type:
+      # -- Provide a list of comma-separated addresses of `redis-sentinel` or `nats-js` servers here
+      # if the proper store is selected
+      # addresses:
+      # - "{{ .appNameNats }}:9233"
+    # -- Per-service PodDisruptionBudget. Overrides the default setting from `podDisruptionBudget` if set.
+    podDisruptionBudget: {}
+    # -- Per-service autoscaling. Overrides the default setting from `autoscaling` if set.
+    autoscaling: {}
+    # -- Affinity settings for the activitylog service. See the documentation of this setting in approvider for examples.
+    affinity: {}
+    # -- Per-service custom labels
+    extraLabels: {}
+    # Per-service image configuration. Overrides the default setting from `image` if set.
+    image:
+      # -- Image repository
+      repository: ""
+      # -- Image tag.
+      tag: ""
+      # -- Image sha / digest (optional).
+      sha: ""
+      # -- Image pull policy
+      pullPolicy:
+
   # -- COLLABORATION service. Not used if `features.appsIntegration.enabled` equals `false`.
   # @default -- see detailed service configuration options below
   collaboration:

--- a/charts/ocis/templates/_common/_tplvalues.tpl
+++ b/charts/ocis/templates/_common/_tplvalues.tpl
@@ -33,6 +33,7 @@ Adds the app names to the scope and set the name of the app based on the input p
 @param .appNameSuffix  The suffix to be added to the appName (if needed)
 */}}
 {{- define "ocis.basicServiceTemplates" -}}
+  {{- $_ := set .scope "appNameActivitylog" "activitylog" -}}
   {{- $_ := set .scope "appNameAppRegistry" "appregistry" -}}
   {{- $_ := set .scope "appNameAudit" "audit" -}}
   {{- $_ := set .scope "appNameAuthBasic" "authbasic" -}}

--- a/charts/ocis/templates/activitylog/deployment.yaml
+++ b/charts/ocis/templates/activitylog/deployment.yaml
@@ -1,0 +1,99 @@
+{{- include "ocis.basicServiceTemplates" (dict "scope" . "appName" "appNameActivitylog" "appNameSuffix" "") -}}
+apiVersion: apps/v1
+kind: Deployment
+{{ include "ocis.metadata" . }}
+spec:
+  {{- include "ocis.selector" . | nindent 2 }}
+  {{- if and (not .Values.autoscaling.enabled) (.Values.replicas) }}
+  replicas: {{ .Values.replicas }}
+  {{- end }}
+  {{- include "ocis.deploymentStrategy" . | nindent 2 }}
+  template:
+    {{- include "ocis.templateMetadata" (dict "scope" $ "configCheck" false) | nindent 4 }}
+    spec:
+      {{- include "ocis.affinity" $ | nindent 6 }}
+      {{- include "ocis.securityContextAndtopologySpreadConstraints" . | nindent 6 }}
+      {{- include "ocis.priorityClassName" $.priorityClassName | nindent 6 }}
+      {{- include "ocis.hostAliases" $ | nindent 6 }}
+      nodeSelector: {{ toYaml $.nodeSelector | nindent 8 }}
+      containers:
+        - name: {{ .appName }}
+          {{- include "ocis.image" $ | nindent 10 }}
+          command: ["ocis"]
+          args: ["activitylog", "server"]
+          {{- include "ocis.containerSecurityContext" . | nindent 10 }}
+          env:
+            {{- include "ocis.serviceRegistry" . | nindent 12 }}
+            {{- include "ocis.events" . | nindent 12 }}
+            {{- include "ocis.cors" . | nindent 12 }}
+            {{- include "ocis.persistentStore" . | nindent 12 }}
+
+            - name: ACTIVITYLOG_LOG_COLOR
+              value: {{ .Values.logging.color | quote }}
+            - name: ACTIVITYLOG_LOG_LEVEL
+              value: {{ .Values.logging.level | quote }}
+            - name: ACTIVITYLOG_LOG_PRETTY
+              value: {{ .Values.logging.pretty | quote }}
+
+            - name: ACTIVITYLOG_TRACING_ENABLED
+              value: "{{ .Values.tracing.enabled }}"
+            - name: ACTIVITYLOG_TRACING_TYPE
+              value: {{ .Values.tracing.type | quote }}
+            - name: ACTIVITYLOG_TRACING_ENDPOINT
+              value: {{ .Values.tracing.endpoint | quote }}
+            - name: ACTIVITYLOG_TRACING_COLLECTOR
+              value: {{ .Values.tracing.collector | quote }}
+
+            - name: ACTIVITYLOG_DEBUG_PPROF
+              value: {{ .Values.debug.profiling | quote }}
+
+            - name: ACTIVITYLOG_HTTP_ADDR
+              value: 0.0.0.0:9195
+            - name: ACTIVITYLOG_DEBUG_ADDR
+              value: 0.0.0.0:9197
+
+            - name: ACTIVITYLOG_SERVICE_ACCOUNT_ID
+              valueFrom:
+                configMapKeyRef:
+                  name: {{ include "config.authService" . }}
+                  key: service-account-id
+            - name: ACTIVITYOG_SERVICE_ACCOUNT_SECRET #TODO: https://github.com/owncloud/ocis/issues/10013
+              valueFrom:
+                secretKeyRef:
+                  name: {{ include "secrets.serviceAccountSecret" . }}
+                  key: service-account-secret
+
+            - name: ACTIVITYLOG_JWT_SECRET
+              valueFrom:
+                secretKeyRef:
+                  name: {{ include "secrets.jwtSecret" . }}
+                  key: jwt-secret
+
+          {{- include "ocis.livenessProbe" . | nindent 10 }}
+
+          resources: {{ toYaml .resources | nindent 12 }}
+
+          ports:
+            - name: http
+              containerPort: 9195
+            - name: metrics-debug
+              containerPort: 9260
+
+          volumeMounts:
+            - name: ocis-config-tmp
+              mountPath: /etc/ocis # we mount that volume only to apply fsGroup to that path
+            - name: messaging-system-ca
+              mountPath: /etc/ocis/messaging-system-ca
+              readOnly: true
+
+      {{- include "ocis.imagePullSecrets" $ | nindent 6 }}
+      volumes:
+        - name: ocis-config-tmp
+          emptyDir: {}
+        - name: messaging-system-ca
+          {{ if and (.Values.messagingSystem.external.enabled) (not .Values.messagingSystem.external.tls.certTrusted) }}
+          secret:
+            secretName: {{ include "secrets.messagingSystemCASecret" . }}
+          {{ else }}
+          emptyDir: {}
+          {{ end }}

--- a/charts/ocis/templates/activitylog/deployment.yaml
+++ b/charts/ocis/templates/activitylog/deployment.yaml
@@ -77,7 +77,7 @@ spec:
             - name: http
               containerPort: 9195
             - name: metrics-debug
-              containerPort: 9260
+              containerPort: 9197
 
           volumeMounts:
             - name: messaging-system-ca

--- a/charts/ocis/templates/activitylog/deployment.yaml
+++ b/charts/ocis/templates/activitylog/deployment.yaml
@@ -80,16 +80,12 @@ spec:
               containerPort: 9260
 
           volumeMounts:
-            - name: ocis-config-tmp
-              mountPath: /etc/ocis # we mount that volume only to apply fsGroup to that path
             - name: messaging-system-ca
               mountPath: /etc/ocis/messaging-system-ca
               readOnly: true
 
       {{- include "ocis.imagePullSecrets" $ | nindent 6 }}
       volumes:
-        - name: ocis-config-tmp
-          emptyDir: {}
         - name: messaging-system-ca
           {{ if and (.Values.messagingSystem.external.enabled) (not .Values.messagingSystem.external.tls.certTrusted) }}
           secret:

--- a/charts/ocis/templates/activitylog/hpa.yaml
+++ b/charts/ocis/templates/activitylog/hpa.yaml
@@ -1,0 +1,3 @@
+{{- include "ocis.basicServiceTemplates" (dict "scope" . "appName" "appNameActivitylog" "appNameSuffix" "") -}}
+{{- $_ := set . "autoscaling" (default (default (dict) .Values.autoscaling) .Values.services.activitylog.autoscaling) -}}
+{{ include "ocis.hpa" . }}

--- a/charts/ocis/templates/activitylog/pdb.yaml
+++ b/charts/ocis/templates/activitylog/pdb.yaml
@@ -1,0 +1,2 @@
+{{- include "ocis.basicServiceTemplates" (dict "scope" . "appName" "appNameActivitylog" "appNameSuffix" "") -}}
+{{ include "ocis.pdb" . }}

--- a/charts/ocis/templates/activitylog/service.yaml
+++ b/charts/ocis/templates/activitylog/service.yaml
@@ -1,0 +1,22 @@
+{{- include "ocis.basicServiceTemplates" (dict "scope" . "appName" "appNameActivitylog" "appNameSuffix" "") -}}
+apiVersion: v1
+kind: Service
+metadata:
+  name: {{ .appName }}
+  namespace: {{ template "ocis.namespace" . }}
+  labels:
+    app: {{ .appName }}
+    ocis-metrics: enabled
+    {{- include "ocis.labels" . | nindent 4 }}
+spec:
+  selector:
+    app: {{ .appName }}
+  ports:
+    - name: http
+      port: 9195
+      protocol: TCP
+      appProtocol: {{ .Values.service.appProtocol.http | quote}}
+    - name: metrics-debug
+      port: 9197
+      protocol: TCP
+      appProtocol: {{ .Values.service.appProtocol.http | quote}}

--- a/charts/ocis/values.yaml
+++ b/charts/ocis/values.yaml
@@ -864,6 +864,43 @@ extraResources: []
 
 # per-service configuration.
 services:
+  # -- ACTIVITYLOG service.
+  # @default -- see detailed service configuration options below
+  activitylog:
+    # -- Per-service resources configuration. Overrides the default setting from `resources` if set.
+    resources: {}
+    # -- Per-service nodeSelector configuration. Overrides the default setting from `nodeSelector` if set.
+    nodeSelector: {}
+    # -- Per-service priorityClassName configuration. Overrides the default setting from `priorityClassName` if set.
+    priorityClassName: ""
+    # -- Per-service store configuration for the activitylog service. Overrides the default setting from `store` if set.
+    store:
+      {}
+      # -- Configure the store type for the activitylog service. Might be `memory` (only for testing), `redis-sentinel`, `nats-js-kv`
+      # type:
+      # -- Provide a list of comma-separated addresses of `redis-sentinel` or `nats-js` servers here
+      # if the proper store is selected
+      # addresses:
+      # - "{{ .appNameNats }}:9233"
+    # -- Per-service PodDisruptionBudget. Overrides the default setting from `podDisruptionBudget` if set.
+    podDisruptionBudget: {}
+    # -- Per-service autoscaling. Overrides the default setting from `autoscaling` if set.
+    autoscaling: {}
+    # -- Affinity settings for the activitylog service. See the documentation of this setting in approvider for examples.
+    affinity: {}
+    # -- Per-service custom labels
+    extraLabels: {}
+    # Per-service image configuration. Overrides the default setting from `image` if set.
+    image:
+      # -- Image repository
+      repository: ""
+      # -- Image tag.
+      tag: ""
+      # -- Image sha / digest (optional).
+      sha: ""
+      # -- Image pull policy
+      pullPolicy:
+
   # -- COLLABORATION service. Not used if `features.appsIntegration.enabled` equals `false`.
   # @default -- see detailed service configuration options below
   collaboration:

--- a/deployments/ocis-nats/streams/ocis.yaml
+++ b/deployments/ocis-nats/streams/ocis.yaml
@@ -97,6 +97,35 @@ spec:
 apiVersion: jetstream.nats.io/v1beta2
 kind: Stream
 metadata:
+  name: kv-activitylog
+spec:
+  account: ocis-nats
+  allowRollup: true
+  description: oCIS activitylog store
+  denyDelete: true
+  discard: new
+  duplicateWindow: "2m0s"
+  maxAge: "336h"
+  maxBytes: -1
+  maxConsumers: -1
+  maxMsgs: -1
+  maxMsgSize: -1
+  maxMsgsPerSubject: 1
+  name: KV_activitylog
+  noAck: false
+  allowDirect: true
+  preventDelete: false
+  preventUpdate: false
+  replicas: 3
+  retention: limits
+  storage: file
+  subjects:
+    - $KV.activitylog.>
+
+---
+apiVersion: jetstream.nats.io/v1beta2
+kind: Stream
+metadata:
   name: kv-postprocessing
 spec:
   account: ocis-nats


### PR DESCRIPTION
## Description
adds the activitylog service

## Related Issue
- Fixes https://github.com/owncloud/ocis-charts/issues/709

## Motivation and Context

## How Has This Been Tested?
- was run in minikube:
![image](https://github.com/user-attachments/assets/c706d230-263c-4252-8589-d07d34703860)

- default stream settings (oCIS product):
```
~ # nats stream info --all KV_activitylog 
Information for Stream KV_activitylog created 2024-09-09 13:26:21

           Description: KeyValue storage administered by go-micro store plugin
              Subjects: $KV.activitylog.>
              Replicas: 1
               Storage: File

Options:

             Retention: Limits
       Acknowledgments: true
        Discard Policy: New
      Duplicate Window: 2m0s
            Direct Get: true
     Allows Msg Delete: false
          Allows Purge: true
        Allows Rollups: true

Limits:

      Maximum Messages: unlimited
   Maximum Per Subject: 1
         Maximum Bytes: unlimited
           Maximum Age: unlimited
  Maximum Message Size: unlimited
     Maximum Consumers: unlimited

Cluster Information:

                  Name: nats
                Leader: nats-2

State:

              Messages: 2
                 Bytes: 2.1 KiB
        First Sequence: 9 @ 2024-09-09 13:26:31
         Last Sequence: 10 @ 2024-09-09 13:26:31
      Active Consumers: 0
    Number of Subjects: 2
```

- stream settings applied with NACK:
```
~ # nats stream info --all KV_activitylog
Information for Stream KV_activitylog created 2024-09-09 13:33:25

           Description: oCIS activitylog store
              Subjects: $KV.activitylog.>
              Replicas: 3
               Storage: File

Options:

             Retention: Limits
       Acknowledgments: true
        Discard Policy: New
      Duplicate Window: 2m0s
            Direct Get: true
     Allows Msg Delete: false
          Allows Purge: true
        Allows Rollups: true

Limits:

      Maximum Messages: unlimited
   Maximum Per Subject: 1
         Maximum Bytes: unlimited
           Maximum Age: 14d0h0m0s
  Maximum Message Size: unlimited
     Maximum Consumers: unlimited

Cluster Information:

                  Name: nats
                Leader: nats-1
               Replica: nats-0, current, seen 698ms ago
               Replica: nats-2, current, seen 698ms ago

State:

              Messages: 0
                 Bytes: 0 B
        First Sequence: 0
         Last Sequence: 0
      Active Consumers: 0
```

## Screenshots (if appropriate):

## Types of changes
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Technical debt
- [ ] Tests only (no source changes)

## Checklist:
- [x] Code changes
- [ ] Unit tests added
- [ ] Acceptance tests added
- [ ] Documentation generated (`make docs`) and committed
- [ ] Documentation ticket raised: <link>
- [ ] Documentation PR created: <link>
