### PR TITLE
add option to not use wopi proof keys

### DIFF
--- a/charts/ocis/docs/values-desc-table.adoc
+++ b/charts/ocis/docs/values-desc-table.adoc
@@ -132,6 +132,12 @@ a| [subs=-attributes]
 a| [subs=-attributes]
 default configuration of oCIS, see https://doc.owncloud.com/ocis/next/deployment/services/s-list/app-registry.html#yaml-example[doc.owncloud.com]
 | Mimetype configuration. Let's you configure a mimetypes' default application, if it is allowed to create a new file and more.
+| features.appsIntegration.wopiIntegration.officeSuites[0].disableProof
+a| [subs=-attributes]
++bool+
+a| [subs=-attributes]
+`false`
+| Disables verifying requests via WOPI proof keys. Not recommended to be disabled for production installations.
 | features.appsIntegration.wopiIntegration.officeSuites[0].enabled
 a| [subs=-attributes]
 +bool+
@@ -204,6 +210,12 @@ a| [subs=-attributes]
 a| [subs=-attributes]
 `""`
 | URI of the office suite.
+| features.appsIntegration.wopiIntegration.officeSuites[1].disableProof
+a| [subs=-attributes]
++bool+
+a| [subs=-attributes]
+`false`
+| Disables verifying requests via WOPI proof keys. Not recommended to be disabled for production installations.
 | features.appsIntegration.wopiIntegration.officeSuites[1].enabled
 a| [subs=-attributes]
 +bool+

--- a/charts/ocis/docs/values.adoc.yaml
+++ b/charts/ocis/docs/values.adoc.yaml
@@ -309,6 +309,9 @@ features:
           # -- Disables SSL certificate checking for connections to the office suites http api.
           # Not recommended for production installations.
           insecure: false
+          # -- Disables verifying requests via WOPI proof keys.
+          # Not recommended to be disabled for production installations.
+          disableProof: false
           # -- Enable secure view for this office suite
           secureViewEnabled: false
           # Ingress for collaboration service.
@@ -341,6 +344,9 @@ features:
           # -- Disables SSL certificate checking for connections to the office suites http api.
           # Not recommended for production installations.
           insecure: false
+          # -- Disables verifying requests via WOPI proof keys.
+          # Not recommended to be disabled for production installations.
+          disableProof: false
           # -- Enable secure view for this office suite. Note: OnlyOffice doesn't support secureView right now
           secureViewEnabled: false
           # Ingress for collaboration service.

--- a/charts/ocis/templates/collaboration/deployment.yaml
+++ b/charts/ocis/templates/collaboration/deployment.yaml
@@ -80,6 +80,9 @@ spec:
               value: http://{{ $.appName }}.{{ template "ocis.namespace" $ }}.svc.cluster.local:9300
               {{- end }}
 
+            - name: COLLABORATION_APP_PROOF_DISABLE
+              value: {{ default false $officeSuite.disableProof | quote }}
+
             - name: COLLABORATION_JWT_SECRET
               valueFrom:
                 secretKeyRef:

--- a/charts/ocis/values.yaml
+++ b/charts/ocis/values.yaml
@@ -308,6 +308,9 @@ features:
           # -- Disables SSL certificate checking for connections to the office suites http api.
           # Not recommended for production installations.
           insecure: false
+          # -- Disables verifying requests via WOPI proof keys.
+          # Not recommended to be disabled for production installations.
+          disableProof: false
           # -- Enable secure view for this office suite
           secureViewEnabled: false
           # Ingress for collaboration service.
@@ -340,6 +343,9 @@ features:
           # -- Disables SSL certificate checking for connections to the office suites http api.
           # Not recommended for production installations.
           insecure: false
+          # -- Disables verifying requests via WOPI proof keys.
+          # Not recommended to be disabled for production installations.
+          disableProof: false
           # -- Enable secure view for this office suite. Note: OnlyOffice doesn't support secureView right now
           secureViewEnabled: false
           # Ingress for collaboration service.

--- a/deployments/ocis-office/helmfile.yaml
+++ b/deployments/ocis-office/helmfile.yaml
@@ -161,7 +161,7 @@ releases:
                   enabled: true
                   uri: "https://onlyoffice.kube.owncloud.test"
                   insecure: true
-                  disableProof: true # until we can set up working proof keys, https://api1.onlyoffice.com/editors/wopi/proofkeys
+                  disableProof: true # to be resolved in https://github.com/owncloud/ocis/issues/10022
                   iconURI: https://onlyoffice.kube.owncloud.test/web-apps/apps/documenteditor/main/resources/img/favicon.ico
                   ingress:
                     # OnlyOffice connects to the collaboration service via the cluster internal Service in this case

--- a/deployments/ocis-office/helmfile.yaml
+++ b/deployments/ocis-office/helmfile.yaml
@@ -161,6 +161,7 @@ releases:
                   enabled: true
                   uri: "https://onlyoffice.kube.owncloud.test"
                   insecure: true
+                  disableProof: true # until we can set up working proof keys, https://api1.onlyoffice.com/editors/wopi/proofkeys
                   iconURI: https://onlyoffice.kube.owncloud.test/web-apps/apps/documenteditor/main/resources/img/favicon.ico
                   ingress:
                     # OnlyOffice connects to the collaboration service via the cluster internal Service in this case


### PR DESCRIPTION
## Description
add an option to not use wopi proof keys

## Related Issue
- Fixes https://github.com/owncloud/ocis-charts/issues/711

## Motivation and Context


## How Has This Been Tested?
- see ocis-office deployment example

## Screenshots (if appropriate):

## Types of changes
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Technical debt
- [ ] Tests only (no source changes)

## Checklist:
- [x] Code changes
- [ ] Unit tests added
- [ ] Acceptance tests added
- [x] Documentation generated (`make docs`) and committed
- [ ] Documentation ticket raised: <link>
- [ ] Documentation PR created: <link>
