### PR TITLE
remove option to disable sse

### DIFF
--- a/charts/ocis/docs/values-desc-table.adoc
+++ b/charts/ocis/docs/values-desc-table.adoc
@@ -858,12 +858,6 @@ a| [subs=-attributes]
 a| [subs=-attributes]
 `true`
 | Show user email when searching for other users to share with.
-| features.sse.disabled
-a| [subs=-attributes]
-+bool+
-a| [subs=-attributes]
-`false`
-| Disables SSE. When disabled, clients will no longer receive sse notifications.
 | features.virusscan.enabled
 a| [subs=-attributes]
 +bool+

--- a/charts/ocis/docs/values.adoc.yaml
+++ b/charts/ocis/docs/values.adoc.yaml
@@ -238,11 +238,6 @@ features:
       # This ConfigMap is optional and can be omitted when images are not used.
       htmlMailImagesConfigRef: "html-mail-images"
 
-  # SSE (server-sent events) settings.
-  sse:
-    # -- Disables SSE. When disabled, clients will no longer receive sse notifications.
-    disabled: false
-
   # Sharing related settings
   sharing:
     # Sharing with users related settings

--- a/charts/ocis/templates/frontend/deployment.yaml
+++ b/charts/ocis/templates/frontend/deployment.yaml
@@ -114,9 +114,6 @@ spec:
             - name: FRONTEND_SHOW_USER_EMAIL_IN_RESULTS
               value: {{ .Values.features.sharing.users.search.showUserEmail | quote }}
 
-            - name: OCIS_DISABLE_SSE
-              value: {{ .Values.features.sse.disabled | quote }}
-
             # cache
             # the stat cache is disabled for now for performance reasons, see https://github.com/owncloud/ocis-charts/issues/214
             - name: FRONTEND_OCS_STAT_CACHE_STORE
@@ -193,4 +190,3 @@ spec:
         - name: configs
           configMap:
             name: sharing-banned-passwords-{{ .appName }}
-

--- a/charts/ocis/templates/sse/deployment.yaml
+++ b/charts/ocis/templates/sse/deployment.yaml
@@ -1,4 +1,3 @@
-{{ if not .Values.features.sse.disabled }}
 {{- include "ocis.basicServiceTemplates" (dict "scope" . "appName" "appNameSSE" "appNameSuffix" "") -}}
 apiVersion: apps/v1
 kind: Deployment
@@ -88,4 +87,3 @@ spec:
           {{ else }}
           emptyDir: {}
           {{ end }}
-{{ end }}

--- a/charts/ocis/templates/sse/hpa.yaml
+++ b/charts/ocis/templates/sse/hpa.yaml
@@ -1,5 +1,3 @@
-{{ if not .Values.features.sse.disabled }}
 {{- include "ocis.basicServiceTemplates" (dict "scope" . "appName" "appNameSSE" "appNameSuffix" "") -}}
 {{- $_ := set . "autoscaling" (default (default (dict) .Values.autoscaling) .Values.services.sse.autoscaling) -}}
 {{ include "ocis.hpa" . }}
-{{ end }}

--- a/charts/ocis/templates/sse/pdb.yaml
+++ b/charts/ocis/templates/sse/pdb.yaml
@@ -1,4 +1,2 @@
-{{ if not .Values.features.sse.disabled }}
 {{- include "ocis.basicServiceTemplates" (dict "scope" . "appName" "appNameSSE" "appNameSuffix" "") -}}
 {{ include "ocis.pdb" . }}
-{{ end }}

--- a/charts/ocis/templates/sse/service.yaml
+++ b/charts/ocis/templates/sse/service.yaml
@@ -1,4 +1,3 @@
-{{ if not .Values.features.sse.disabled }}
 {{- include "ocis.basicServiceTemplates" (dict "scope" . "appName" "appNameSSE" "appNameSuffix" "") -}}
 apiVersion: v1
 kind: Service
@@ -21,4 +20,3 @@ spec:
       port: 9135
       protocol: TCP
       appProtocol: {{ .Values.service.appProtocol.http | quote}}
-{{ end }}

--- a/charts/ocis/templates/userlog/deployment.yaml
+++ b/charts/ocis/templates/userlog/deployment.yaml
@@ -91,9 +91,6 @@ spec:
                   name: {{ include "secrets.jwtSecret" . }}
                   key: jwt-secret
 
-            - name: OCIS_DISABLE_SSE
-              value: {{ .Values.features.sse.disabled | quote }}
-
           {{- include "ocis.livenessProbe" . | nindent 10 }}
 
           resources: {{ toYaml .resources | nindent 12 }}

--- a/charts/ocis/values.yaml
+++ b/charts/ocis/values.yaml
@@ -237,11 +237,6 @@ features:
       # This ConfigMap is optional and can be omitted when images are not used.
       htmlMailImagesConfigRef: "html-mail-images"
 
-  # SSE (server-sent events) settings.
-  sse:
-    # -- Disables SSE. When disabled, clients will no longer receive sse notifications.
-    disabled: false
-
   # Sharing related settings
   sharing:
     # Sharing with users related settings


### PR DESCRIPTION
## Description
remove option to disable SSE (features.sse.disabled)

## Related Issue

## Motivation and Context
Removes complexity. I'm not sure how well the UX is without SSE these days anyways. So far we had zero problems with SSE that we know of...

## How Has This Been Tested?
- templated and rendered manifests didn't change (assuming features.sse.disabled was not set to true)

## Screenshots (if appropriate):

## Types of changes
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [x] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Technical debt
- [ ] Tests only (no source changes)

## Checklist:
- [x] Code changes
- [ ] Unit tests added
- [ ] Acceptance tests added
- [x] Documentation generated (`make docs`) and committed
- [ ] Documentation ticket raised: <link>
- [ ] Documentation PR created: <link>
