### PR TITLE
remove drawio csp policy because drawio is no longer shipped with oC Web

### DIFF
--- a/charts/ocis/docs/values-desc-table.adoc
+++ b/charts/ocis/docs/values-desc-table.adoc
@@ -958,7 +958,7 @@ a| [subs=-attributes]
 a| [subs=-attributes]
 +list+
 a| [subs=-attributes]
-`["'self'","blob:","https://embed.diagrams.net/"]`
+`["'self'","blob:"]`
 | frame-src directive, see https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/Content-Security-Policy/frame-src
 | http.csp.directives.imgSrc
 a| [subs=-attributes]

--- a/charts/ocis/docs/values.adoc.yaml
+++ b/charts/ocis/docs/values.adoc.yaml
@@ -85,9 +85,6 @@ http:
       frameSrc:
         - "'self'"
         - "blob:"
-        # Needed for the draw-io integration that is enabled by default.
-        # Can be removed when "draw-io" is removed from services.web.config.apps
-        - "https://embed.diagrams.net/"
       # -- img-src directive, see https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/Content-Security-Policy/img-src
       imgSrc:
         - "'self'"

--- a/charts/ocis/values.yaml
+++ b/charts/ocis/values.yaml
@@ -84,9 +84,6 @@ http:
       frameSrc:
         - "'self'"
         - "blob:"
-        # Needed for the draw-io integration that is enabled by default.
-        # Can be removed when "draw-io" is removed from services.web.config.apps
-        - "https://embed.diagrams.net/"
       # -- img-src directive, see https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/Content-Security-Policy/img-src
       imgSrc:
         - "'self'"


### PR DESCRIPTION
## Description
remove drawio csp policy because drawio is no longer shipped with oC Web

## Related Issue

## Motivation and Context

## How Has This Been Tested?

## Screenshots (if appropriate):

## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Technical debt
- [ ] Tests only (no source changes)

## Checklist:
- [x] Code changes
- [ ] Unit tests added
- [ ] Acceptance tests added
- [x] Documentation generated (`make docs`) and committed
- [ ] Documentation ticket raised: <link>
- [ ] Documentation PR created: <link>
