### PR TITLE
fix upload issues by providing OCIS_URL that is used in fallback for OCIS_CORS_ALLOW_ORIGINS

### DIFF
--- a/charts/ocis/templates/_common/_tplvalues.tpl
+++ b/charts/ocis/templates/_common/_tplvalues.tpl
@@ -235,6 +235,8 @@ oCIS deployment CORS template
 
 */}}
 {{- define "ocis.cors" -}}
+- name: OCIS_URL
+  value: "https://{{ .Values.externalDomain }}"
 {{- if .Values.http.cors.allow_origins }}
 - name: OCIS_CORS_ALLOW_ORIGINS
   value: {{ without .Values.http.cors.allow_origins "" | join "," | quote }}


### PR DESCRIPTION
## Description
fix uploads that are larger than 10MB

## Related Issue
- Fixes https://github.com/owncloud/ocis-charts/issues/643

## Motivation and Context

## How Has This Been Tested?
- development-install deployment example in minikube -> upload a file bigger than 10MB

## Screenshots (if appropriate):

## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Technical debt
- [ ] Tests only (no source changes)

## Checklist:
- [x] Code changes
- [ ] Unit tests added
- [ ] Acceptance tests added
- [ ] Documentation generated (`make docs`) and committed
- [ ] Documentation ticket raised: <link>
- [ ] Documentation PR created: <link>
