### PR TITLE
fix command to be invoked by storage-users-clean-expired-uploads

### DIFF
--- a/charts/ocis/templates/storageusers/jobs.yaml
+++ b/charts/ocis/templates/storageusers/jobs.yaml
@@ -34,7 +34,7 @@ spec:
             - name: storage-users-clean-expired-uploads
               {{- include "ocis.jobContainerImageOcis" . | nindent 14 }}
               command: ["ocis"]
-              args: ["storage-users", "uploads", "clean"]
+              args: ["storage-users", "uploads", "sessions", "--clean"]
               securityContext:
                 runAsNonRoot: true
                 runAsUser: {{ .Values.securityContext.runAsUser }}


### PR DESCRIPTION
## Description

Replaces the depreciated command by the one to be used for oCIS 6.3.0

## Related Issue

## Motivation and Context


## How Has This Been Tested?
- deployed the development install example in minikube and waited for the job exectution

## Screenshots (if appropriate):

## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Technical debt
- [ ] Tests only (no source changes)

## Checklist:
- [x] Code changes
- [ ] Unit tests added
- [ ] Acceptance tests added
- [ ] Documentation generated (`make docs`) and committed
- [ ] Documentation ticket raised: <link>
- [ ] Documentation PR created: <link>
