### PR TITLE
remove nats persistence settings from external nats deployment example

### DIFF
--- a/deployments/ocis-nats/helmfile.yaml
+++ b/deployments/ocis-nats/helmfile.yaml
@@ -115,10 +115,6 @@ releases:
             persistence:
               enabled: true
 
-          nats:
-            persistence:
-              enabled: true
-
           search:
             persistence:
               enabled: true


### PR DESCRIPTION
## Description

We don't have a oCIS NATS volume in that deployment example, therefore we can just remove the config.

## Related Issue

## Motivation and Context

Avoid confusing configuration examples

## How Has This Been Tested?

I ran the deployment in Minikube, the installation didn't complain about a missing persistence:

```
...

Release "ocis" has been upgraded. Happy Helming!
NAME: ocis
LAST DEPLOYED: Thu Sep 12 13:05:37 2024
NAMESPACE: ocis
STATUS: deployed
REVISION: 5
TEST SUITE: None
NOTES:
You're now running
                 ,----..      ,---,   .--.--.
                /   /   \  ,`--.' |  /  /    '.
       ,---.   |   :     : |   :  : |  :  /`. /
      '   ,'\  .   |  ;. / :   |  ' ;  |  |--`
     /   /   | .   ; /--`  |   :  | |  :  ;_
    .   ; ,. : ;   | ;     '   '  ;  \  \    `.
    '   | |: : |   : |     |   |  |   `----.   \
    '   | .; : .   | '___  '   :  ;   __ \  \  |
    |   :    | '   ; : .'| |   |  '  /  /`--'  /
     \   \  /  '   | '/  : '   :  | '--'.     /
      `----'   |   :    /  ;   |.'    `--'---'
                \   \ .'   '---'
                 `---`


You can get the initial "admin" administrator user password by running:

kubectl -n ocis get secrets/admin-user --template='{{.data.password | base64decode | printf "%s\n" }}'


#################################################################################
######   WARNING: Your deployment of oCIS does not follow all best          #####
######   practices for production deployments of oCIS.                      #####
######                                                                      #####
######   Following best practices are not applied:                          #####
######     - `features.externalUserManagement.enabled` should be            #####
######       set to `true`.                                                 #####
######     - `insecure.oidcIdpInsecure` should be set to `false`            #####
######     - `insecure.ocisHttpApiInsecure` should be set to `false`        #####
#################################################################################

...
```
## Screenshots (if appropriate):

## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Technical debt
- [ ] Tests only (no source changes)

## Checklist:
- [x] Code changes
- [ ] Unit tests added
- [ ] Acceptance tests added
- [ ] Documentation generated (`make docs`) and committed
- [ ] Documentation ticket raised: <link>
- [ ] Documentation PR created: <link>
