### PR TITLE
Activated `livenessProbe` for `sse`

### DIFF
--- a/charts/ocis/templates/sse/deployment.yaml
+++ b/charts/ocis/templates/sse/deployment.yaml
@@ -59,7 +59,7 @@ spec:
                   name: {{ include "secrets.jwtSecret" . }}
                   key: jwt-secret
 
-            # {{- include "ocis.livenessProbe" . | nindent 10 }}
+            {{- include "ocis.livenessProbe" . | nindent 10 }}
 
           resources: {{ toYaml .resources | nindent 12 }}
 


### PR DESCRIPTION
## Description
The `livenessProbe` was disabled for `see`, see discussion in https://github.com/owncloud/ocis-charts/commit/b85da50c7a30f9293c51c4068c7d25dbe1e48e4d#r146037039. This PR enabled the `livenessProbe` again.

## Related Issue
- none

## Motivation and Context
Clean consistent code

## How Has This Been Tested?
Tested on local k3d with `helmfile sync` in the `deployments/development-install` directory with the following diff applied to make it k3d compliant:

<details> <summary>Click to expand</summary>
```diff
diff --git a/deployments/development-install/helmfile.yaml b/deployments/development-install/helmfile.yaml
index 84f2def..eaa663b 100644
--- a/deployments/development-install/helmfile.yaml
+++ b/deployments/development-install/helmfile.yaml
@@ -6,7 +6,7 @@ releases:
       - externalDomain: ocis.kube.owncloud.test
       - ingress:
           enabled: true
-          ingressClassName: nginx
+          #ingressClassName: nginx
           annotations:
             nginx.ingress.kubernetes.io/proxy-body-size: 1024m
           tls:
@@ -28,22 +28,32 @@ releases:
           idm:
             persistence:
               enabled: true
+              accessModes:
+                - ReadWriteOnce
 
           nats:
             persistence:
               enabled: true
+              accessModes:
+                - ReadWriteOnce
 
           search:
             persistence:
               enabled: true
+              accessModes:
+                - ReadWriteOnce
 
           storagesystem:
             persistence:
               enabled: true
+              accessModes:
+                - ReadWriteOnce
 
           storageusers:
             persistence:
               enabled: true
+              accessModes:
+                - ReadWriteOnce
             maintenance:
               cleanUpExpiredUploads:
                 enabled: true
@@ -58,6 +68,8 @@ releases:
           thumbnails:
             persistence:
               enabled: true
+              accessModes:
+                - ReadWriteOnce
             maintenance:
               cleanUpOldThumbnails:
                 enabled: true
@@ -66,3 +78,5 @@ releases:
           web:
             persistence:
               enabled: true
+              accessModes:
+                - ReadWriteOnce
```
</details>

## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Technical debt
- [ ] Tests only (no source changes)

## Checklist:
- [x] Code changes
- [ ] Unit tests added
- [ ] Acceptance tests added
- [ ] Documentation generated (`make docs`) and committed
- [ ] Documentation ticket raised: <link>
- [ ] Documentation PR created: <link>
