### PR TITLE
Added `OCIS_URL` to collaboration service

### DIFF
--- a/charts/ocis/templates/collaboration/deployment.yaml
+++ b/charts/ocis/templates/collaboration/deployment.yaml
@@ -99,7 +99,7 @@ spec:
                   key: wopi-secret
 
             - name: OCIS_URL
-              value: "https://{{ .Values.externalDomain }}"
+              value: "https://{{ $.Values.externalDomain }}"
 
           livenessProbe:
             exec:

--- a/charts/ocis/templates/collaboration/deployment.yaml
+++ b/charts/ocis/templates/collaboration/deployment.yaml
@@ -98,6 +98,9 @@ spec:
                   name: {{ include "secrets.collaborationWopiSecret" $ }}
                   key: wopi-secret
 
+            - name: OCIS_URL
+              value: "https://{{ .Values.externalDomain }}"
+
           livenessProbe:
             exec:
               command:


### PR DESCRIPTION
## Description
`OCIS_URL` needs to be added to the collaboration service due to https://github.com/owncloud/ocis/pull/10174. See also https://github.com/owncloud/ocis/pull/10193

## Related Issue
- Fixes https://github.com/owncloud/ocis/pull/10174

## Motivation and Context
See above

## How Has This Been Tested?
- test environment:
- test case 1:
- test case 2:
- ...

## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Technical debt
- [ ] Tests only (no source changes)

## Checklist:
- [x] Code changes
- [ ] Unit tests added
- [ ] Acceptance tests added
- [ ] Documentation generated (`make docs`) and committed
- [ ] Documentation ticket raised: <link>
- [ ] Documentation PR created: <link>
