### PR TITLE
Added nginx annotation for websockets to office example deployment

### DIFF
--- a/deployments/ocis-office/helmfile.yaml
+++ b/deployments/ocis-office/helmfile.yaml
@@ -63,6 +63,8 @@ releases:
           enabled: true
       - ingress:
           enabled: true
+          annotations:
+            nginx.org/websocket-services: documentserver
           host: onlyoffice.kube.owncloud.test
           ssl:
             enabled: true


### PR DESCRIPTION
## Description
This PR adds an ingres-nginx annotation to the office example deployment. In my tests this was required to make websockets work. Tested on k3d with nginx-ingress installed to replace the traefik default.

## Related Issue
- none

## Motivation and Context
Smoother example deployments

## How Has This Been Tested?
Tested on k3d with traefik disabled and ingress-nginx installed.

## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Technical debt
- [ ] Tests only (no source changes)

## Checklist:
- [ ] Code changes
- [ ] Unit tests added
- [ ] Acceptance tests added
- [ ] Documentation generated (`make docs`) and committed
- [ ] Documentation ticket raised: <link>
- [ ] Documentation PR created: <link>
