### PR TITLE
add minimal apptokens feature

### DIFF
--- a/charts/ocis/ci/deployment-values.yaml
+++ b/charts/ocis/ci/deployment-values.yaml
@@ -17,6 +17,11 @@ insecure:
   oidcIdpInsecure: true
   ocisHttpApiInsecure: true
 services:
+  authapp:
+    persistence:
+      enabled: true
+      accessModes:
+        - ReadWriteOnce
   idm:
     persistence:
       enabled: true

--- a/charts/ocis/ci/values.yaml
+++ b/charts/ocis/ci/values.yaml
@@ -92,6 +92,8 @@ features:
         icon: ""
         default_app: ""
         allow_creation: true
+  appTokens:
+    enabled: true
   virusscan:
     enabled: true
   policies:

--- a/charts/ocis/docs/values-desc-table.adoc
+++ b/charts/ocis/docs/values-desc-table.adoc
@@ -132,6 +132,12 @@ a| [subs=-attributes]
 a| [subs=-attributes]
 `[]`
 | Extra resources to be included.
+| features.appTokens.enabled
+a| [subs=-attributes]
++bool+
+a| [subs=-attributes]
+`false`
+| Enables generation of app tokens on the cli to integrate other services. Use this to generate a bearer auth token that can be used by other services to intergrate with oCIS.
 | features.appsIntegration.enabled
 a| [subs=-attributes]
 +bool+
@@ -1681,6 +1687,144 @@ a| [subs=-attributes]
 `""`
 | Per-service priorityClassName configuration. Overrides the default setting from `priorityClassName` if set.
 | services.audit.resources
+a| [subs=-attributes]
++object+
+a| [subs=-attributes]
+`{}`
+| Per-service resources configuration. Overrides the default setting from `resources` if set.
+| services.authapp
+a| [subs=-attributes]
++object+
+a| [subs=-attributes]
+see detailed service configuration options below
+| AUTH APP service.
+| services.authapp.affinity
+a| [subs=-attributes]
++object+
+a| [subs=-attributes]
+`{}`
+| Affinity settings for the authapp service. See the documentation of this setting in approvider for examples.
+| services.authapp.autoscaling
+a| [subs=-attributes]
++object+
+a| [subs=-attributes]
+`{}`
+| Per-service autoscaling. Overrides the default setting from `autoscaling` if set.
+| services.authapp.extraLabels
+a| [subs=-attributes]
++object+
+a| [subs=-attributes]
+`{}`
+| Per-service custom labels
+| services.authapp.image.pullPolicy
+a| [subs=-attributes]
++string+
+a| [subs=-attributes]
+`nil`
+| Image pull policy
+| services.authapp.image.repository
+a| [subs=-attributes]
++string+
+a| [subs=-attributes]
+`""`
+| Image repository
+| services.authapp.image.sha
+a| [subs=-attributes]
++string+
+a| [subs=-attributes]
+`""`
+| Image sha / digest (optional).
+| services.authapp.image.tag
+a| [subs=-attributes]
++string+
+a| [subs=-attributes]
+`""`
+| Image tag.
+| services.authapp.nodeSelector
+a| [subs=-attributes]
++object+
+a| [subs=-attributes]
+`{}`
+| Per-service nodeSelector configuration. Overrides the default setting from `nodeSelector` if set.
+| services.authapp.persistence
+a| [subs=-attributes]
++object+
+a| [subs=-attributes]
+see detailed persistence configuration options below
+| Persistence settings.
+| services.authapp.persistence.accessModes
+a| [subs=-attributes]
++list+
+a| [subs=-attributes]
+`["ReadWriteMany"]`
+| Persistent volume access modes. Needs to be `["ReadWriteMany"]` when having more than one replica for this service.
+| services.authapp.persistence.annotations
+a| [subs=-attributes]
++object+
+a| [subs=-attributes]
+`{}`
+| Persistent volume annotations.
+| services.authapp.persistence.chownInitContainer
+a| [subs=-attributes]
++bool+
+a| [subs=-attributes]
+`false`
+| Enables an initContainer to chown the volume. The initContainer is run as root. This is not needed if the driver applies the fsGroup from the securityContext. The image specified in `initContainerImage` will be used for this container.
+| services.authapp.persistence.claimName
+a| [subs=-attributes]
++string+
+a| [subs=-attributes]
+`""`
+| Use a custom name for the PVC instead of the default one.
+| services.authapp.persistence.enabled
+a| [subs=-attributes]
++bool+
+a| [subs=-attributes]
+`false`
+| Enables persistence. Needs to be enabled on production installations. If not enabled, pod restarts will invialidate all app tokens Also scaling this service to more than one replica is not possible if the pods don't share the same volume.
+| services.authapp.persistence.existingClaim
+a| [subs=-attributes]
++string+
+a| [subs=-attributes]
+`nil`
+| Use an existing PersistentVolumeClaim for persistence.
+| services.authapp.persistence.finalizers
+a| [subs=-attributes]
++list+
+a| [subs=-attributes]
+`["kubernetes.io/pvc-protection"]`
+| Persistent volume finalizers.
+| services.authapp.persistence.selectorLabels
+a| [subs=-attributes]
++object+
+a| [subs=-attributes]
+`{}`
+| Persistent volume selector labels.
+| services.authapp.persistence.size
+a| [subs=-attributes]
++string+
+a| [subs=-attributes]
+`"10Mi"`
+| Size of the persistent volume.
+| services.authapp.persistence.storageClassName
+a| [subs=-attributes]
++string+
+a| [subs=-attributes]
+`nil`
+| Storage class to use. Uses the default storage class if not set.
+| services.authapp.podDisruptionBudget
+a| [subs=-attributes]
++object+
+a| [subs=-attributes]
+`{}`
+| Per-service PodDisruptionBudget. Overrides the default setting from `podDisruptionBudget` if set.
+| services.authapp.priorityClassName
+a| [subs=-attributes]
++string+
+a| [subs=-attributes]
+`""`
+| Per-service priorityClassName configuration. Overrides the default setting from `priorityClassName` if set.
+| services.authapp.resources
 a| [subs=-attributes]
 +object+
 a| [subs=-attributes]

--- a/charts/ocis/docs/values.adoc.yaml
+++ b/charts/ocis/docs/values.adoc.yaml
@@ -369,6 +369,11 @@ features:
       # icon: ""
       # default_app: ""
       # allow_creation: true
+  # App Tokens
+  appTokens:
+    # -- Enables generation of app tokens on the cli to integrate other services.
+    # Use this to generate a bearer auth token that can be used by other services to intergrate with oCIS.
+    enabled: false
   # External user management
   externalUserManagement:
     # -- Enables external user management (and disables internal user management).
@@ -1010,6 +1015,66 @@ services:
     # -- Per-service autoscaling. Overrides the default setting from `autoscaling` if set.
     autoscaling: {}
     # -- Affinity settings for the audit service. See the documentation of this setting in approvider for examples.
+    affinity: {}
+    # -- Per-service custom labels
+    extraLabels: {}
+    # Per-service image configuration. Overrides the default setting from `image` if set.
+    image:
+      # -- Image repository
+      repository: ""
+      # -- Image tag.
+      tag: ""
+      # -- Image sha / digest (optional).
+      sha: ""
+      # -- Image pull policy
+      pullPolicy:
+
+  # -- AUTH APP service.
+  # @default -- see detailed service configuration options below
+  authapp:
+    # -- Persistence settings.
+    # @default -- see detailed persistence configuration options below
+    persistence:
+      # -- Enables persistence.
+      # Needs to be enabled on production installations.
+      # If not enabled, pod restarts will invialidate all app tokens
+      # Also scaling this service to more than one replica is not possible if the pods don't share the same volume.
+      enabled: false
+      # -- Enables an initContainer to chown the volume.
+      # The initContainer is run as root.
+      # This is not needed if the driver applies the fsGroup from the securityContext.
+      # The image specified in `initContainerImage` will be used for this container.
+      chownInitContainer: false
+      # -- Storage class to use.
+      # Uses the default storage class if not set.
+      storageClassName:
+      # -- Persistent volume access modes. Needs to be `["ReadWriteMany"]` when having more than one replica for this service.
+      accessModes:
+        - ReadWriteMany
+      # -- Size of the persistent volume.
+      size: 10Mi
+      # -- Persistent volume annotations.
+      annotations: {}
+      # -- Persistent volume finalizers.
+      finalizers:
+        - kubernetes.io/pvc-protection
+      # -- Persistent volume selector labels.
+      selectorLabels: {}
+      # -- Use a custom name for the PVC instead of the default one.
+      claimName: ""
+      # -- Use an existing PersistentVolumeClaim for persistence.
+      existingClaim:
+    # -- Per-service resources configuration. Overrides the default setting from `resources` if set.
+    resources: {}
+    # -- Per-service nodeSelector configuration. Overrides the default setting from `nodeSelector` if set.
+    nodeSelector: {}
+    # -- Per-service priorityClassName configuration. Overrides the default setting from `priorityClassName` if set.
+    priorityClassName: ""
+    # -- Per-service PodDisruptionBudget. Overrides the default setting from `podDisruptionBudget` if set.
+    podDisruptionBudget: {}
+    # -- Per-service autoscaling. Overrides the default setting from `autoscaling` if set.
+    autoscaling: {}
+    # -- Affinity settings for the authapp service. See the documentation of this setting in approvider for examples.
     affinity: {}
     # -- Per-service custom labels
     extraLabels: {}

--- a/charts/ocis/templates/_common/_tplvalues.tpl
+++ b/charts/ocis/templates/_common/_tplvalues.tpl
@@ -36,6 +36,7 @@ Adds the app names to the scope and set the name of the app based on the input p
   {{- $_ := set .scope "appNameActivitylog" "activitylog" -}}
   {{- $_ := set .scope "appNameAppRegistry" "appregistry" -}}
   {{- $_ := set .scope "appNameAudit" "audit" -}}
+  {{- $_ := set .scope "appNameAuthApp" "authapp" -}}
   {{- $_ := set .scope "appNameAuthMachine" "authmachine" -}}
   {{- $_ := set .scope "appNameAuthService" "authservice" -}}
   {{- $_ := set .scope "appNameAntivirus" "antivirus" -}}

--- a/charts/ocis/templates/authapp/deployment.yaml
+++ b/charts/ocis/templates/authapp/deployment.yaml
@@ -1,0 +1,98 @@
+{{ if .Values.features.appTokens.enabled }}
+{{- include "ocis.basicServiceTemplates" (dict "scope" . "appName" "appNameAuthApp" "appNameSuffix" "") -}}
+apiVersion: apps/v1
+kind: Deployment
+{{ include "ocis.metadata" . }}
+spec:
+  {{- include "ocis.selector" . | nindent 2 }}
+  {{- if and (not .Values.autoscaling.enabled) (.Values.replicas) }}
+  replicas: {{ .Values.replicas }}
+  {{- end }}
+  {{- include "ocis.deploymentStrategy" . | nindent 2 }}
+  template:
+    {{- include "ocis.templateMetadata" (dict "scope" $ "configCheck" false) | nindent 4 }}
+    spec:
+      {{- include "ocis.affinity" $ | nindent 6 }}
+      {{- include "ocis.securityContextAndtopologySpreadConstraints" . | nindent 6 }}
+      {{- include "ocis.priorityClassName" $.priorityClassName | nindent 6 }}
+      {{- include "ocis.hostAliases" $ | nindent 6 }}
+      nodeSelector: {{ toYaml $.nodeSelector | nindent 8 }}
+      containers:
+        - name: {{ .appName }}
+          {{- include "ocis.image" $ | nindent 10 }}
+          command: ["ocis"]
+          args: ["auth-app", "server"]
+          {{- include "ocis.containerSecurityContext" . | nindent 10 }}
+          env:
+            {{- include "ocis.serviceRegistry" . | nindent 12 }}
+
+            - name: AUTH_APP_LOG_COLOR
+              value: {{ .Values.logging.color | quote }}
+            - name: AUTH_APP_LOG_LEVEL
+              value: {{ .Values.logging.level | quote }}
+            - name: AUTH_APP_LOG_PRETTY
+              value: {{ .Values.logging.pretty | quote }}
+
+            - name: AUTH_APP_TRACING_ENABLED
+              value: "{{ .Values.tracing.enabled }}"
+            - name: AUTH_APP_TRACING_TYPE
+              value: {{ .Values.tracing.type | quote }}
+            - name: AUTH_APP_TRACING_ENDPOINT
+              value: {{ .Values.tracing.endpoint | quote }}
+            - name: AUTH_APP_TRACING_COLLECTOR
+              value: {{ .Values.tracing.collector | quote }}
+
+            - name: AUTH_APP_DEBUG_PPROF
+              value: {{ .Values.debug.profiling | quote }}
+
+            - name: AUTH_APP_GRPC_ADDR
+              value: 0.0.0.0:9246
+            - name: AUTH_APP_HTTP_ADDR
+              value: 0.0.0.0:9247
+            - name: AUTH_APP_DEBUG_ADDR
+              value: 0.0.0.0:9245
+
+            - name: AUTH_APP_JWT_SECRET
+              valueFrom:
+                secretKeyRef:
+                  name: {{ include "secrets.jwtSecret" . }}
+                  key: jwt-secret
+
+            - name: AUTH_APP_MACHINE_AUTH_API_KEY
+              valueFrom:
+                secretKeyRef:
+                  name: {{ include "secrets.machineAuthAPIKeySecret" . }}
+                  key: machine-auth-api-key
+
+            # we only support generating app tokens on the cli to integrate with services
+            # no impersonation
+            - name: AUTH_APP_ENABLE_IMPERSONATION
+              value: "false"
+            # no user groups in token
+            - name: AUTH_APP_SKIP_USER_GROUPS_IN_TOKEN
+              value: "true"
+
+          {{- include "ocis.livenessProbe" . | nindent 10 }}
+
+          resources: {{ toYaml .resources | nindent 12 }}
+
+          ports:
+            - name: grpc
+              containerPort: 9246
+            - name: http
+              containerPort: 9247
+            - name: metrics-debug
+              containerPort: 9245
+
+          volumeMounts:
+            - name: tmp-volume
+              mountPath: /tmp
+            - name: {{ include "ocis.persistence.dataVolumeName" . }}
+              mountPath: /var/lib/ocis
+
+      {{- include "ocis.imagePullSecrets" $ | nindent 6 }}
+      volumes:
+        - name: tmp-volume
+          emptyDir: {}
+        {{- include "ocis.persistence.dataVolume" . | nindent 8 }}
+{{ end }}

--- a/charts/ocis/templates/authapp/hpa.yaml
+++ b/charts/ocis/templates/authapp/hpa.yaml
@@ -1,0 +1,5 @@
+{{ if .Values.features.appTokens.enabled }}
+{{- include "ocis.basicServiceTemplates" (dict "scope" . "appName" "appNameAuthApp" "appNameSuffix" "") -}}
+{{- $_ := set . "autoscaling" (default (default (dict) .Values.autoscaling) .Values.services.authapp.autoscaling) -}}
+{{ include "ocis.hpa" . }}
+{{ end }}

--- a/charts/ocis/templates/authapp/pdb.yaml
+++ b/charts/ocis/templates/authapp/pdb.yaml
@@ -1,0 +1,4 @@
+{{ if .Values.features.appTokens.enabled }}
+{{- include "ocis.basicServiceTemplates" (dict "scope" . "appName" "appNameAuthApp" "appNameSuffix" "") -}}
+{{ include "ocis.pdb" . }}
+{{ end }}

--- a/charts/ocis/templates/authapp/pvc.yaml
+++ b/charts/ocis/templates/authapp/pvc.yaml
@@ -1,0 +1,39 @@
+{{ if .Values.features.appTokens.enabled }}
+{{- if and .Values.services.authapp.persistence.enabled (not .Values.services.authapp.persistence.existingClaim)}}
+{{- include "ocis.basicServiceTemplates" (dict "scope" . "appName" "appNameAuthApp" "appNameSuffix" "") -}}
+apiVersion: v1
+kind: PersistentVolumeClaim
+metadata:
+  name: {{ include "ocis.persistence.dataVolumeName" . }}
+  namespace: {{ template "ocis.namespace" . }}
+  labels:
+    {{- include "ocis.labels" . | nindent 4 }}
+    {{- with .Values.backup.pvcLabels }}
+    {{ toYaml . | nindent 4 }}
+    {{- end }}
+  {{- with .Values.services.appauth.persistence.annotations  }}
+  annotations:
+{{ toYaml . | indent 4 }}
+  {{- end }}
+  {{- with .Values.services.appauth.persistence.finalizers  }}
+  finalizers:
+{{ toYaml . | indent 4 }}
+  {{- end }}
+spec:
+  accessModes:
+    {{- range .Values.services.appauth.persistence.accessModes }}
+    - {{ . | quote }}
+    {{- end }}
+  resources:
+    requests:
+      storage: {{ .Values.services.appauth.persistence.size | quote }}
+  {{- if .Values.services.appauth.persistence.storageClassName }}
+  storageClassName: {{ .Values.services.appauth.persistence.storageClassName }}
+  {{- end -}}
+  {{- with .Values.services.appauth.persistence.selectorLabels }}
+  selector:
+    matchLabels:
+{{ toYaml . | indent 6 }}
+  {{- end }}
+{{- end -}}
+{{ end }}

--- a/charts/ocis/templates/authapp/secret.yaml
+++ b/charts/ocis/templates/authapp/secret.yaml
@@ -1,0 +1,7 @@
+{{ if .Values.features.appTokens.enabled }}
+{{- if or (not .Values.secretRefs.machineAuthApiKeySecretRef) }}
+{{- $params := (dict)}}
+{{- $_ := set $params "machine-auth-api-key" (randAlphaNum 30) }}
+{{- include "ocis.secret" (dict "scope" . "name" "machine-auth-api-key" "params" $params)}}
+{{- end }}
+{{ end }}

--- a/charts/ocis/templates/authapp/service.yaml
+++ b/charts/ocis/templates/authapp/service.yaml
@@ -1,0 +1,28 @@
+{{ if .Values.features.appTokens.enabled }}
+{{- include "ocis.basicServiceTemplates" (dict "scope" . "appName" "appNameAuthApp" "appNameSuffix" "") -}}
+apiVersion: v1
+kind: Service
+metadata:
+  name: {{ .appName }}
+  namespace: {{ template "ocis.namespace" . }}
+  labels:
+    app: {{ .appName }}
+    ocis-metrics: enabled
+    {{- include "ocis.labels" . | nindent 4 }}
+spec:
+  selector:
+    app: {{ .appName }}
+  ports:
+    - name: grpc
+      port: 9246
+      protocol: TCP
+      appProtocol: {{ .Values.service.appProtocol.grpc | quote}}
+    - name: http
+      port: 9247
+      protocol: TCP
+      appProtocol: {{ .Values.service.appProtocol.http | quote}}
+    - name: metrics-debug
+      port: 9245
+      protocol: TCP
+      appProtocol: {{ .Values.service.appProtocol.http | quote}}
+{{ end }}

--- a/charts/ocis/templates/proxy/deployment.yaml
+++ b/charts/ocis/templates/proxy/deployment.yaml
@@ -104,6 +104,11 @@ spec:
                   name: {{ include "secrets.serviceAccountSecret" . }}
                   key: service-account-secret
 
+            {{- if .Values.features.appTokens.enabled }}
+            - name: PROXY_ENABLE_APP_AUTH
+              value: "true"
+            {{- end }}
+
             - name: PROXY_CSP_CONFIG_FILE_LOCATION
               value: /etc/ocis/csp.yaml
 

--- a/charts/ocis/values.yaml
+++ b/charts/ocis/values.yaml
@@ -368,6 +368,11 @@ features:
       # icon: ""
       # default_app: ""
       # allow_creation: true
+  # App Tokens
+  appTokens:
+    # -- Enables generation of app tokens on the cli to integrate other services.
+    # Use this to generate a bearer auth token that can be used by other services to intergrate with oCIS.
+    enabled: false
   # External user management
   externalUserManagement:
     # -- Enables external user management (and disables internal user management).
@@ -1009,6 +1014,66 @@ services:
     # -- Per-service autoscaling. Overrides the default setting from `autoscaling` if set.
     autoscaling: {}
     # -- Affinity settings for the audit service. See the documentation of this setting in approvider for examples.
+    affinity: {}
+    # -- Per-service custom labels
+    extraLabels: {}
+    # Per-service image configuration. Overrides the default setting from `image` if set.
+    image:
+      # -- Image repository
+      repository: ""
+      # -- Image tag.
+      tag: ""
+      # -- Image sha / digest (optional).
+      sha: ""
+      # -- Image pull policy
+      pullPolicy:
+
+  # -- AUTH APP service.
+  # @default -- see detailed service configuration options below
+  authapp:
+    # -- Persistence settings.
+    # @default -- see detailed persistence configuration options below
+    persistence:
+      # -- Enables persistence.
+      # Needs to be enabled on production installations.
+      # If not enabled, pod restarts will invialidate all app tokens
+      # Also scaling this service to more than one replica is not possible if the pods don't share the same volume.
+      enabled: false
+      # -- Enables an initContainer to chown the volume.
+      # The initContainer is run as root.
+      # This is not needed if the driver applies the fsGroup from the securityContext.
+      # The image specified in `initContainerImage` will be used for this container.
+      chownInitContainer: false
+      # -- Storage class to use.
+      # Uses the default storage class if not set.
+      storageClassName:
+      # -- Persistent volume access modes. Needs to be `["ReadWriteMany"]` when having more than one replica for this service.
+      accessModes:
+        - ReadWriteMany
+      # -- Size of the persistent volume.
+      size: 10Mi
+      # -- Persistent volume annotations.
+      annotations: {}
+      # -- Persistent volume finalizers.
+      finalizers:
+        - kubernetes.io/pvc-protection
+      # -- Persistent volume selector labels.
+      selectorLabels: {}
+      # -- Use a custom name for the PVC instead of the default one.
+      claimName: ""
+      # -- Use an existing PersistentVolumeClaim for persistence.
+      existingClaim:
+    # -- Per-service resources configuration. Overrides the default setting from `resources` if set.
+    resources: {}
+    # -- Per-service nodeSelector configuration. Overrides the default setting from `nodeSelector` if set.
+    nodeSelector: {}
+    # -- Per-service priorityClassName configuration. Overrides the default setting from `priorityClassName` if set.
+    priorityClassName: ""
+    # -- Per-service PodDisruptionBudget. Overrides the default setting from `podDisruptionBudget` if set.
+    podDisruptionBudget: {}
+    # -- Per-service autoscaling. Overrides the default setting from `autoscaling` if set.
+    autoscaling: {}
+    # -- Affinity settings for the authapp service. See the documentation of this setting in approvider for examples.
     affinity: {}
     # -- Per-service custom labels
     extraLabels: {}


### PR DESCRIPTION
Fixes #707 

This PR adds a minimal app tokens feature:

* External services can use the bearer tokens to make requests on external endpoints, eg. to create storage spaces and manage space membership.

* For security reasons, bearer tokens can only be generated by the admin on the CLI, token generation via the web api is not enabled.

* Use this only for services under your control. The generated tokens are not scoped and can execute any actions permitted by the associated user.

* Allow users to generate app tokens for other clients is tracked in https://github.com/owncloud/ocis/issues/7711


