### PR TITLE
show the inital admin message only when no external usermanagement is used

### DIFF
--- a/charts/ocis/templates/NOTES.txt
+++ b/charts/ocis/templates/NOTES.txt
@@ -13,17 +13,17 @@ You're now running
                 \   \ .'   '---'
                  `---`
 
-
-You can get the initial "admin" administrator user password by running:
-
-kubectl -n {{ .Release.Namespace }} get secrets/admin-user --template='{{"{{"}}.data.password | base64decode | printf "%s\n" {{"}}"}}'
-
 {{ $noExternalUserManagement := not .Values.features.externalUserManagement.enabled -}}
 {{- $demoUsers := .Values.features.demoUsers -}}
 {{- $oidcIdpInsecure := .Values.insecure.oidcIdpInsecure -}}
 {{- $ocisHttpApiInsecure := .Values.insecure.ocisHttpApiInsecure -}}
 {{- $externalLDAPinsecure := and .Values.features.externalUserManagement.enabled .Values.features.externalUserManagement.ldap.insecure -}}
 {{- $noSMTPencryption := and .Values.features.emailNotifications.enabled (eq .Values.features.emailNotifications.smtp.encryption "none") -}}
+
+{{- if $noExternalUserManagement }}
+You can get the initial "admin" administrator user password by running:
+kubectl -n {{ .Release.Namespace }} get secrets/{{ .Values.secretRefs.adminUserSecretRef | default "admin-user" }} --template='{{"{{"}}.data.password | base64decode | printf "%s\n" {{"}}"}}'
+{{- end }}
 
 {{ if or $noExternalUserManagement $demoUsers $oidcIdpInsecure $ocisHttpApiInsecure $externalLDAPinsecure $noSMTPencryption }}
 #################################################################################


### PR DESCRIPTION
## Description

We're now showing the message about the initial admin only if the builtin user management is used.
For an external user managment this message doesn't make any sense (the secret itself is also behind this conditional).


## Related Issue

## Motivation and Context

have no irritating messages in a context where it doesn't apply

## How Has This Been Tested?
- deploying with builtin user management:

```
Release "ocis" has been upgraded. Happy Helming!
NAME: ocis
LAST DEPLOYED: Wed Oct 16 07:37:19 2024
NAMESPACE: ocis
STATUS: deployed
REVISION: 8
TEST SUITE: None
NOTES:
You're now running
                 ,----..      ,---,   .--.--.
                /   /   \  ,`--.' |  /  /    '.
       ,---.   |   :     : |   :  : |  :  /`. /
      '   ,'\  .   |  ;. / :   |  ' ;  |  |--`
     /   /   | .   ; /--`  |   :  | |  :  ;_
    .   ; ,. : ;   | ;     '   '  ;  \  \    `.
    '   | |: : |   : |     |   |  |   `----.   \
    '   | .; : .   | '___  '   :  ;   __ \  \  |
    |   :    | '   ; : .'| |   |  '  /  /`--'  /
     \   \  /  '   | '/  : '   :  | '--'.     /
      `----'   |   :    /  ;   |.'    `--'---'
                \   \ .'   '---'
                 `---`


You can get the initial "admin" administrator user password by running:
kubectl -n ocis get secrets/admin-user --template='{{.data.password | base64decode | printf "%s\n" }}'


#################################################################################
######   WARNING: Your deployment of oCIS does not follow all best          #####
######   practices for production deployments of oCIS.                      #####
######                                                                      #####
######   Following best practices are not applied:                          #####
...
```

- deploying with external user managment:

```
Release "ocis" has been upgraded. Happy Helming!
NAME: ocis
LAST DEPLOYED: Wed Oct 16 07:38:15 2024
NAMESPACE: ocis
STATUS: deployed
REVISION: 9
TEST SUITE: None
NOTES:
You're now running
                 ,----..      ,---,   .--.--.
                /   /   \  ,`--.' |  /  /    '.
       ,---.   |   :     : |   :  : |  :  /`. /
      '   ,'\  .   |  ;. / :   |  ' ;  |  |--`
     /   /   | .   ; /--`  |   :  | |  :  ;_
    .   ; ,. : ;   | ;     '   '  ;  \  \    `.
    '   | |: : |   : |     |   |  |   `----.   \
    '   | .; : .   | '___  '   :  ;   __ \  \  |
    |   :    | '   ; : .'| |   |  '  /  /`--'  /
     \   \  /  '   | '/  : '   :  | '--'.     /
      `----'   |   :    /  ;   |.'    `--'---'
                \   \ .'   '---'
                 `---`




#################################################################################
######   WARNING: Your deployment of oCIS does not follow all best          #####
######   practices for production deployments of oCIS.                      #####
######                                                                      #####
######   Following best practices are not applied:                          #####
...
```

## Screenshots (if appropriate):

## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Technical debt
- [ ] Tests only (no source changes)

## Checklist:
- [x] Code changes
- [ ] Unit tests added
- [ ] Acceptance tests added
- [ ] Documentation generated (`make docs`) and committed
- [ ] Documentation ticket raised: <link>
- [ ] Documentation PR created: <link>
