### PR TITLE
fix appregistry port name

### DIFF
--- a/charts/ocis/templates/appregistry/deployment.yaml
+++ b/charts/ocis/templates/appregistry/deployment.yaml
@@ -58,7 +58,7 @@ spec:
           resources: {{ toYaml .resources | nindent 12 }}
 
           ports:
-            - name: http
+            - name: grpc
               containerPort: 9242
             - name: metrics-debug
               containerPort: 9243


### PR DESCRIPTION
## Description
fixes the appregistry port 9242 name from `http` to `grpc`

## Related Issue

## Motivation and Context


## How Has This Been Tested?
- not tested

## Screenshots (if appropriate):

## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Technical debt
- [ ] Tests only (no source changes)

## Checklist:
- [x] Code changes
- [ ] Unit tests added
- [ ] Acceptance tests added
- [ ] Documentation generated (`make docs`) and committed
- [ ] Documentation ticket raised: <link>
- [ ] Documentation PR created: <link>
