### PR TITLE
allow enabling async metadata propagation

### DIFF
--- a/charts/ocis/docs/values-desc-table.adoc
+++ b/charts/ocis/docs/values-desc-table.adoc
@@ -3774,6 +3774,12 @@ a| [subs=-attributes]
 a| [subs=-attributes]
 `{}`
 | Affinity settings for the storageusers service. See the documentation of this setting in approvider for examples.
+| services.storageusers.asyncPropagation
+a| [subs=-attributes]
++object+
+a| [subs=-attributes]
+`{"delay":"5s","enabled":false}`
+| Enable asynchronous metadata propagation
 | services.storageusers.autoscaling
 a| [subs=-attributes]
 +object+

--- a/charts/ocis/docs/values.adoc.yaml
+++ b/charts/ocis/docs/values.adoc.yaml
@@ -1882,6 +1882,11 @@ services:
         # -- Number of event consumers to be started that concurrently consume events (eg. postprocessing related events)
         concurrency: 10
 
+    # -- Enable asynchronous metadata propagation
+    asyncPropagation:
+      enabled: false
+      delay: "5s"
+
     storageBackend:
       # -- Configures the storage driver. Possible values are "ocis" and "s3ng".
       # The oCIS driver stores all data in the persistent volume if persistence is enabled.

--- a/charts/ocis/templates/storageusers/deployment.yaml
+++ b/charts/ocis/templates/storageusers/deployment.yaml
@@ -75,6 +75,14 @@ spec:
             - name: STORAGE_USERS_DATA_SERVER_URL
               value: "http://{{ .appName }}:9158/data"
 
+            # propagation strategy
+            {{- if .Values.services.storageusers.asyncPropagation.enabled }}
+            - name: OCIS_DECOMPOSEDFS_PROPAGATOR
+              value: "async"
+            - name: STORAGE_USERS_ASYNC_PROPAGATOR_PROPAGATION_DELAY
+              value: {{ .Values.services.storageusers.asyncPropagation.delay | quote }}
+            {{- end }}
+
             # oCIS storage driver (decomposed filesystem)
             {{- if  eq .Values.services.storageusers.storageBackend.driver "ocis" }}
             - name: STORAGE_USERS_DRIVER

--- a/charts/ocis/values.yaml
+++ b/charts/ocis/values.yaml
@@ -1881,6 +1881,11 @@ services:
         # -- Number of event consumers to be started that concurrently consume events (eg. postprocessing related events)
         concurrency: 10
 
+    # -- Enable asynchronous metadata propagation
+    asyncPropagation:
+      enabled: false
+      delay: "5s"
+
     storageBackend:
       # -- Configures the storage driver. Possible values are "ocis" and "s3ng".
       # The oCIS driver stores all data in the persistent volume if persistence is enabled.


### PR DESCRIPTION
This PR allows enabling the async pmetadata propagation. It defaults to off and a 5s delay. 