### PR TITLE
bring back WEB_OPTION_TOKEN_STORAGE_LOCAL config option

### DIFF
--- a/charts/ocis/docs/values.adoc.yaml
+++ b/charts/ocis/docs/values.adoc.yaml
@@ -2310,6 +2310,10 @@ services:
   web:
     # Configuration for web, that ends up in the config.json file.
     config:
+      tokenStorageLocal:
+        #-- Specifies whether the access token will be stored in the local storage when set to ’true’ or in the session storage when set to ‘false’.
+        # If stored in the local storage, login state will be persisted across multiple browser tabs, means no additional logins are required.
+        enabled: true
       contextHelpersReadMore:
         # -- Specifies whether the “Read more” link should be displayed or not.
         enabled: true

--- a/charts/ocis/templates/web/deployment.yaml
+++ b/charts/ocis/templates/web/deployment.yaml
@@ -182,6 +182,9 @@ spec:
             {{- end }}
             {{- end }}
 
+            - name: WEB_OPTION_TOKEN_STORAGE_LOCAL
+              value: {{ .Values.services.web.config.tokenStorageLocal.enabled | quote }}
+
             - name: WEB_JWT_SECRET
               valueFrom:
                 secretKeyRef:

--- a/charts/ocis/values.yaml
+++ b/charts/ocis/values.yaml
@@ -2309,6 +2309,10 @@ services:
   web:
     # Configuration for web, that ends up in the config.json file.
     config:
+      tokenStorageLocal:
+        #-- Specifies whether the access token will be stored in the local storage when set to ’true’ or in the session storage when set to ‘false’.
+        # If stored in the local storage, login state will be persisted across multiple browser tabs, means no additional logins are required.
+        enabled: true
       contextHelpersReadMore:
         # -- Specifies whether the “Read more” link should be displayed or not.
         enabled: true


### PR DESCRIPTION
## Description
brings back the `WEB_OPTION_TOKEN_STORAGE_LOCAL` / `.Values.services.web.config.tokenStorageLocal.enabled` config that was removed for some reason.

I only know that it existet in https://github.com/owncloud/ocis-charts/blob/792b72dbb46986041ee0f16ca08001a55e073b8a/charts/ocis/templates/web/deployment.yaml#L105-L106 but couldn't find out why and when it was removed.

## Related Issue
- Fixes discunct `.Values.services.web.config.tokenStorageLocal.enabled` option

## Motivation and Context

## How Has This Been Tested?
- Verfied using the ocis development deployment example in Minikube -> changing the option is reflected on the /config.json endpoint.

## Screenshots (if appropriate):

## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Technical debt
- [ ] Tests only (no source changes)

## Checklist:
- [x] Code changes
- [ ] Unit tests added
- [ ] Acceptance tests added
- [ ] Documentation generated (`make docs`) and committed
- [ ] Documentation ticket raised: <link>
- [ ] Documentation PR created: <link>
