### PR TITLE
fix typo in maxInputWidth

### DIFF
--- a/charts/ocis/docs/values-desc-table.adoc
+++ b/charts/ocis/docs/values-desc-table.adoc
@@ -4506,7 +4506,7 @@ a| [subs=-attributes]
 a| [subs=-attributes]
 `7680`
 | Sets a maximium height of an imput image which is being processed.
-| services.thumbnails.quota.maxInputWitdth
+| services.thumbnails.quota.maxInputWidth
 a| [subs=-attributes]
 +int+
 a| [subs=-attributes]

--- a/charts/ocis/docs/values.adoc.yaml
+++ b/charts/ocis/docs/values.adoc.yaml
@@ -2152,7 +2152,7 @@ services:
       # -- Sets a maximum file size of an input image which is being processed. Usable common abbreviations: [KB, KiB, MB, MiB, GB, GiB, TB, TiB, PB, PiB, EB, EiB], example: 2GB.
       maxFileSize: 50MB
       # -- Sets a maximium width of an imput image which is being processed.
-      maxInputWitdth: 7680
+      maxInputWidth: 7680
       # -- Sets a maximium height of an imput image which is being processed.
       maxInputHeight: 7680
     # -- Persistence settings.

--- a/charts/ocis/templates/thumbnails/deployment.yaml
+++ b/charts/ocis/templates/thumbnails/deployment.yaml
@@ -72,7 +72,7 @@ spec:
             - name: THUMBNAILS_MAX_INPUT_IMAGE_FILE_SIZE
               value: {{ .Values.services.thumbnails.quota.maxFileSize | quote }}
             - name: THUMBNAILS_MAX_INPUT_WIDTH
-              value: {{ .Values.services.thumbnails.quota.maxInputWitdth | quote }}
+              value: {{ .Values.services.thumbnails.quota.maxInputWidth | quote }}
             - name: THUMBNAILS_MAX_INPUT_HEIGHT
               value: {{ .Values.services.thumbnails.quota.maxInputHeight | quote }}
 

--- a/charts/ocis/values.yaml
+++ b/charts/ocis/values.yaml
@@ -2151,7 +2151,7 @@ services:
       # -- Sets a maximum file size of an input image which is being processed. Usable common abbreviations: [KB, KiB, MB, MiB, GB, GiB, TB, TiB, PB, PiB, EB, EiB], example: 2GB.
       maxFileSize: 50MB
       # -- Sets a maximium width of an imput image which is being processed.
-      maxInputWitdth: 7680
+      maxInputWidth: 7680
       # -- Sets a maximium height of an imput image which is being processed.
       maxInputHeight: 7680
     # -- Persistence settings.


### PR DESCRIPTION
## Description

fixes a typo in maxInputWidth

## Related Issue

## Motivation and Context


## How Has This Been Tested?
- not tested

## Screenshots (if appropriate):

## Types of changes
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [x] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Technical debt
- [ ] Tests only (no source changes)

## Checklist:
- [x] Code changes
- [ ] Unit tests added
- [ ] Acceptance tests added
- [x] Documentation generated (`make docs`) and committed
- [ ] Documentation ticket raised: <link>
- [ ] Documentation PR created: <link>
