### PR TITLE
clarify embed mode configuration

### DIFF
--- a/charts/ocis/templates/web/deployment.yaml
+++ b/charts/ocis/templates/web/deployment.yaml
@@ -89,11 +89,9 @@ spec:
               value: {{ .Values.services.web.config.theme.path | quote }}
             {{- end }}
 
-            {{- if .Values.services.web.config.embed.enabled }}
             - name: WEB_OPTION_EMBED_ENABLED
               value: {{ .Values.services.web.config.embed.enabled | quote }}
-            {{- end }}
-
+            {{- if .Values.services.web.config.embed.enabled }}
             {{- if .Values.services.web.config.embed.target }}
             - name: WEB_OPTION_EMBED_TARGET
               value: {{ .Values.services.web.config.embed.target | quote }}
@@ -112,6 +110,7 @@ spec:
             {{- if .Values.services.web.config.embed.delegateAuthenticationOrigin }}
             - name: WEB_OPTION_EMBED_DELEGATE_AUTHENTICATION_ORIGIN
               value: {{ .Values.services.web.config.embed.delegateAuthenticationOrigin | quote }}
+            {{- end }}
             {{- end }}
 
             {{- if .Values.services.web.config.concurrency.resourceBatchActionRequests }}


### PR DESCRIPTION
## Description
The embed mode so far has an effect even though the enabled flag is not set.
After this change, the embed mode must be enabled to have an effect.

## Related Issue
- stumbled across it in https://github.com/owncloud/ocis-charts/pull/811

## Motivation and Context


## How Has This Been Tested?
- tested in https://github.com/owncloud-koko/deployment/pull/706

## Screenshots (if appropriate):

## Types of changes
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [x] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Technical debt
- [ ] Tests only (no source changes)

## Checklist:
- [x] Code changes
- [ ] Unit tests added
- [ ] Acceptance tests added
- [x] Documentation generated (`make docs`) and committed
- [ ] Documentation ticket raised: <link>
- [ ] Documentation PR created: <link>
