### PR TITLE
remove unused config options at `features.appsIntegration.wopiIntegration`

### DIFF
--- a/charts/ocis/docs/values-desc-table.adoc
+++ b/charts/ocis/docs/values-desc-table.adoc
@@ -324,12 +324,6 @@ a| [subs=-attributes]
 a| [subs=-attributes]
 `""`
 | URI of the office suite.
-| features.appsIntegration.wopiIntegration.wopiFolderURI
-a| [subs=-attributes]
-+string+
-a| [subs=-attributes]
-`"https://{{ .Values.externalDomain }}"`
-| Base url to navigate back from the app to the containing folder in the file list.
 | features.appsIntegration.wopiIntegration.wopiFolderURIPathTemplate
 a| [subs=-attributes]
 +string+

--- a/charts/ocis/docs/values.adoc.yaml
+++ b/charts/ocis/docs/values.adoc.yaml
@@ -280,8 +280,6 @@ features:
     wopiIntegration:
       # -- URL of the https://github.com/cs3org/wopiserver[cs3org/wopiserver]. Can be deployed https://artifacthub.io/packages/helm/cs3org/wopiserver[with this Chart].
       wopiServerURI: ""
-      # -- Base url to navigate back from the app to the containing folder in the file list.
-      wopiFolderURI: https://{{ .Values.externalDomain }}
       # -- Path template for the url to navigate back from the app to the containing folder in the file list.
       # null uses the default value of oCIS, so that one also can set it to "" to not have a path template.
       wopiFolderURIPathTemplate: null

--- a/charts/ocis/values.yaml
+++ b/charts/ocis/values.yaml
@@ -279,8 +279,6 @@ features:
     wopiIntegration:
       # -- URL of the https://github.com/cs3org/wopiserver[cs3org/wopiserver]. Can be deployed https://artifacthub.io/packages/helm/cs3org/wopiserver[with this Chart].
       wopiServerURI: ""
-      # -- Base url to navigate back from the app to the containing folder in the file list.
-      wopiFolderURI: https://{{ .Values.externalDomain }}
       # -- Path template for the url to navigate back from the app to the containing folder in the file list.
       # null uses the default value of oCIS, so that one also can set it to "" to not have a path template.
       wopiFolderURIPathTemplate: null


### PR DESCRIPTION
## Description
remove unused config options at `features.appsIntegration.wopiIntegration`, those haven't been in use since we switch from the cs3org/wopiserver to the oCIS collaboration service.

## Related Issue
- Cleanup after https://github.com/owncloud/ocis-charts/pull/567
- found during implementing https://github.com/owncloud/ocis-charts/pull/811

## Motivation and Context

## How Has This Been Tested?
- look at the `ocis-office` deployment example, it doesn't use those config options
- search in the code, it only appears in the documentation that is generated from the values.yaml

## Screenshots (if appropriate):

## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Technical debt
- [ ] Tests only (no source changes)

## Checklist:
- [x] Code changes
- [ ] Unit tests added
- [ ] Acceptance tests added
- [x] Documentation generated (`make docs`) and committed
- [ ] Documentation ticket raised: <link>
- [ ] Documentation PR created: <link>
