### PR TITLE
remove per service store settings

### DIFF
--- a/charts/ocis/docs/values-desc-table.adoc
+++ b/charts/ocis/docs/values-desc-table.adoc
@@ -1512,12 +1512,6 @@ a| [subs=-attributes]
 a| [subs=-attributes]
 `{}`
 | Per-service resources configuration. Overrides the default setting from `resources` if set.
-| services.activitylog.store
-a| [subs=-attributes]
-+object+
-a| [subs=-attributes]
-`{}`
-| Per-service store configuration for the activitylog service. Overrides the default setting from `store` if set.
 | services.antivirus
 a| [subs=-attributes]
 +object+
@@ -2088,12 +2082,6 @@ a| [subs=-attributes]
 a| [subs=-attributes]
 `{}`
 | Per-service resources configuration. Overrides the default setting from `resources` if set.
-| services.eventhistory.store
-a| [subs=-attributes]
-+object+
-a| [subs=-attributes]
-`{}`
-| Per-service store configuration for the eventhistory service. Overrides the default setting from `store` if set.
 | services.frontend
 a| [subs=-attributes]
 +object+
@@ -3192,12 +3180,6 @@ a| [subs=-attributes]
 a| [subs=-attributes]
 `{}`
 | Per-service resources configuration. Overrides the default setting from `resources` if set.
-| services.postprocessing.store
-a| [subs=-attributes]
-+object+
-a| [subs=-attributes]
-`{}`
-| Per-service store configuration for the eventhistory service. Overrides the default setting from `store` if set.
 | services.proxy
 a| [subs=-attributes]
 +object+
@@ -3660,12 +3642,6 @@ a| [subs=-attributes]
 a| [subs=-attributes]
 `{}`
 | Per-service resources configuration. Overrides the default setting from `resources` if set.
-| services.sse.store
-a| [subs=-attributes]
-+object+
-a| [subs=-attributes]
-`{}`
-| Per-service store configuration for the eventhistory service. Overrides the default setting from `store` if set.
 | services.storagepubliclink
 a| [subs=-attributes]
 +object+
@@ -4584,12 +4560,6 @@ a| [subs=-attributes]
 a| [subs=-attributes]
 `{}`
 | Per-service resources configuration. Overrides the default setting from `resources` if set.
-| services.userlog.store
-a| [subs=-attributes]
-+object+
-a| [subs=-attributes]
-`{}`
-| Per-service store configuration for the userlog service. Overrides the default setting from `store` if set.
 | services.users
 a| [subs=-attributes]
 +object+

--- a/charts/ocis/docs/values.adoc.yaml
+++ b/charts/ocis/docs/values.adoc.yaml
@@ -910,15 +910,6 @@ services:
     nodeSelector: {}
     # -- Per-service priorityClassName configuration. Overrides the default setting from `priorityClassName` if set.
     priorityClassName: ""
-    # -- Per-service store configuration for the activitylog service. Overrides the default setting from `store` if set.
-    store:
-      {}
-      # -- Configure the store type for the activitylog service. Might be `memory` (only for testing), `redis-sentinel`, `nats-js-kv`
-      # type:
-      # -- Provide a list of comma-separated addresses of `redis-sentinel` or `nats-js` servers here
-      # if the proper store is selected
-      # addresses:
-      # - "{{ .appNameNats }}:9233"
     # -- Per-service PodDisruptionBudget. Overrides the default setting from `podDisruptionBudget` if set.
     podDisruptionBudget: {}
     # -- Per-service autoscaling. Overrides the default setting from `autoscaling` if set.
@@ -1170,15 +1161,6 @@ services:
     nodeSelector: {}
     # -- Per-service priorityClassName configuration. Overrides the default setting from `priorityClassName` if set.
     priorityClassName: ""
-    # -- Per-service store configuration for the eventhistory service. Overrides the default setting from `store` if set.
-    store:
-      {}
-      # -- Configure the store type for the eventhistory service. Might be `memory` (only for testing), `redis-sentinel`, `nats-js-kv`
-      #type:
-      # -- Provide a list of comma-separated addresses of `redis-sentinel` or `nats-js` servers here
-      # if the proper store is selected
-      # addresses: []
-      # - "{{ .appNameNats }}:9233"
     # -- Per-service PodDisruptionBudget. Overrides the default setting from `podDisruptionBudget` if set.
     podDisruptionBudget: {}
     # -- Per-service autoscaling. Overrides the default setting from `autoscaling` if set.
@@ -1631,8 +1613,6 @@ services:
     priorityClassName: ""
     # -- Per-service PodDisruptionBudget. Overrides the default setting from `podDisruptionBudget` if set.
     podDisruptionBudget: {}
-    # -- Per-service store configuration for the eventhistory service. Overrides the default setting from `store` if set.
-    store: {}
     # -- Per-service autoscaling. Overrides the default setting from `autoscaling` if set.
     autoscaling: {}
     # -- Affinity settings for the postprocessing service. See the documentation of this setting in approvider for examples.
@@ -1831,8 +1811,6 @@ services:
     priorityClassName: ""
     # -- Per-service PodDisruptionBudget. Overrides the default setting from `podDisruptionBudget` if set.
     podDisruptionBudget: {}
-    # -- Per-service store configuration for the eventhistory service. Overrides the default setting from `store` if set.
-    store: {}
     # -- Per-service autoscaling. Overrides the default setting from `autoscaling` if set.
     autoscaling: {}
     # -- Affinity settings for the postprocessing service. See the documentation of this setting in approvider for examples.
@@ -2247,15 +2225,6 @@ services:
     nodeSelector: {}
     # -- Per-service priorityClassName configuration. Overrides the default setting from `priorityClassName` if set.
     priorityClassName: ""
-    # -- Per-service store configuration for the userlog service. Overrides the default setting from `store` if set.
-    store:
-      {}
-      # -- Configure the store type for the userlog service. Might be `memory` (only for testing), `redis-sentinel`, `nats-js-kv`
-      # type:
-      # -- Provide a list of comma-separated addresses of `redis-sentinel` or `nats-js` servers here
-      # if the proper store is selected
-      # addresses:
-      # - "{{ .appNameNats }}:9233"
     # -- Per-service PodDisruptionBudget. Overrides the default setting from `podDisruptionBudget` if set.
     podDisruptionBudget: {}
     # -- Per-service autoscaling. Overrides the default setting from `autoscaling` if set.

--- a/charts/ocis/templates/_common/store.tpl
+++ b/charts/ocis/templates/_common/store.tpl
@@ -4,13 +4,13 @@ oCIS store configuration
 
 {{- define "ocis.persistentStore" -}}
 {{- $valid := list "memory" "redis-sentinel" "nats-js-kv" -}}
-{{- if not (has .store.type $valid) -}}
+{{- if not (has .Values.store.type $valid) -}}
 {{- fail "invalid store.type set" -}}
 {{- end -}}
 - name: OCIS_PERSISTENT_STORE
-  value: {{ .store.type | quote }}
+  value: {{ .Values.store.type | quote }}
 - name: OCIS_PERSISTENT_STORE_NODES
-  value: {{ tpl (join "," .store.nodes) . | quote }}
+  value: {{ tpl (join "," .Values.store.nodes) . | quote }}
 {{- end -}}
 
 {{- define "ocis.cacheStore" -}}

--- a/charts/ocis/templates/eventhistory/deployment.yaml
+++ b/charts/ocis/templates/eventhistory/deployment.yaml
@@ -1,5 +1,4 @@
 {{- include "ocis.basicServiceTemplates" (dict "scope" . "appName" "appNameEventhistory" "appNameSuffix" "") -}}
-{{- $_ := set . "store" (default (default (dict) .Values.store) .Values.services.eventhistory.store) -}}
 apiVersion: apps/v1
 kind: Deployment
 {{ include "ocis.metadata" . }}

--- a/charts/ocis/templates/postprocessing/deployment.yaml
+++ b/charts/ocis/templates/postprocessing/deployment.yaml
@@ -1,5 +1,4 @@
 {{- include "ocis.basicServiceTemplates" (dict "scope" . "appName" "appNamePostprocessing" "appNameSuffix" "") -}}
-{{- $_ := set . "store" (default (default (dict) .Values.store) .Values.services.postprocessing.store) -}}
 apiVersion: apps/v1
 kind: Deployment
 {{ include "ocis.metadata" . }}

--- a/charts/ocis/templates/userlog/deployment.yaml
+++ b/charts/ocis/templates/userlog/deployment.yaml
@@ -1,5 +1,4 @@
 {{- include "ocis.basicServiceTemplates" (dict "scope" . "appName" "appNameUserlog" "appNameSuffix" "") -}}
-{{- $_ := set . "store" (default (default (dict) .Values.store) .Values.services.userlog.store) -}}
 apiVersion: apps/v1
 kind: Deployment
 {{ include "ocis.metadata" . }}

--- a/charts/ocis/values.yaml
+++ b/charts/ocis/values.yaml
@@ -909,15 +909,6 @@ services:
     nodeSelector: {}
     # -- Per-service priorityClassName configuration. Overrides the default setting from `priorityClassName` if set.
     priorityClassName: ""
-    # -- Per-service store configuration for the activitylog service. Overrides the default setting from `store` if set.
-    store:
-      {}
-      # -- Configure the store type for the activitylog service. Might be `memory` (only for testing), `redis-sentinel`, `nats-js-kv`
-      # type:
-      # -- Provide a list of comma-separated addresses of `redis-sentinel` or `nats-js` servers here
-      # if the proper store is selected
-      # addresses:
-      # - "{{ .appNameNats }}:9233"
     # -- Per-service PodDisruptionBudget. Overrides the default setting from `podDisruptionBudget` if set.
     podDisruptionBudget: {}
     # -- Per-service autoscaling. Overrides the default setting from `autoscaling` if set.
@@ -1169,15 +1160,6 @@ services:
     nodeSelector: {}
     # -- Per-service priorityClassName configuration. Overrides the default setting from `priorityClassName` if set.
     priorityClassName: ""
-    # -- Per-service store configuration for the eventhistory service. Overrides the default setting from `store` if set.
-    store:
-      {}
-      # -- Configure the store type for the eventhistory service. Might be `memory` (only for testing), `redis-sentinel`, `nats-js-kv`
-      #type:
-      # -- Provide a list of comma-separated addresses of `redis-sentinel` or `nats-js` servers here
-      # if the proper store is selected
-      # addresses: []
-      # - "{{ .appNameNats }}:9233"
     # -- Per-service PodDisruptionBudget. Overrides the default setting from `podDisruptionBudget` if set.
     podDisruptionBudget: {}
     # -- Per-service autoscaling. Overrides the default setting from `autoscaling` if set.
@@ -1630,8 +1612,6 @@ services:
     priorityClassName: ""
     # -- Per-service PodDisruptionBudget. Overrides the default setting from `podDisruptionBudget` if set.
     podDisruptionBudget: {}
-    # -- Per-service store configuration for the eventhistory service. Overrides the default setting from `store` if set.
-    store: {}
     # -- Per-service autoscaling. Overrides the default setting from `autoscaling` if set.
     autoscaling: {}
     # -- Affinity settings for the postprocessing service. See the documentation of this setting in approvider for examples.
@@ -1830,8 +1810,6 @@ services:
     priorityClassName: ""
     # -- Per-service PodDisruptionBudget. Overrides the default setting from `podDisruptionBudget` if set.
     podDisruptionBudget: {}
-    # -- Per-service store configuration for the eventhistory service. Overrides the default setting from `store` if set.
-    store: {}
     # -- Per-service autoscaling. Overrides the default setting from `autoscaling` if set.
     autoscaling: {}
     # -- Affinity settings for the postprocessing service. See the documentation of this setting in approvider for examples.
@@ -2246,15 +2224,6 @@ services:
     nodeSelector: {}
     # -- Per-service priorityClassName configuration. Overrides the default setting from `priorityClassName` if set.
     priorityClassName: ""
-    # -- Per-service store configuration for the userlog service. Overrides the default setting from `store` if set.
-    store:
-      {}
-      # -- Configure the store type for the userlog service. Might be `memory` (only for testing), `redis-sentinel`, `nats-js-kv`
-      # type:
-      # -- Provide a list of comma-separated addresses of `redis-sentinel` or `nats-js` servers here
-      # if the proper store is selected
-      # addresses:
-      # - "{{ .appNameNats }}:9233"
     # -- Per-service PodDisruptionBudget. Overrides the default setting from `podDisruptionBudget` if set.
     podDisruptionBudget: {}
     # -- Per-service autoscaling. Overrides the default setting from `autoscaling` if set.


### PR DESCRIPTION
## Description
Remove per service store settings.

I think this is more of a footgun nowadays and should be removed. Please note that we don't have this setting for the caches, too.

## Related Issue
- stumbled across it in https://github.com/owncloud/ocis-charts/pull/811

## Motivation and Context

## How Has This Been Tested?
- not tested

## Screenshots (if appropriate):

## Types of changes
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [x] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Technical debt
- [ ] Tests only (no source changes)

## Checklist:
- [x] Code changes
- [ ] Unit tests added
- [ ] Acceptance tests added
- [x] Documentation generated (`make docs`) and committed
- [ ] Documentation ticket raised: <link>
- [ ] Documentation PR created: <link>
