### PR TITLE
Add possibility to configure the concurrency for sharing and userlog

### DIFF
--- a/charts/ocis/docs/values-desc-table.adoc
+++ b/charts/ocis/docs/values-desc-table.adoc
@@ -2148,12 +2148,6 @@ a| [subs=-attributes]
 a| [subs=-attributes]
 `""`
 | Image tag.
-| services.frontend.maxConcurrency
-a| [subs=-attributes]
-+string+
-a| [subs=-attributes]
-`"1"`
-| Maximum number of concurrent go-routines. Higher values can potentially get work done faster but will also cause  more load on the system. Values of 0 or below will be ignored and the default value will be used.
 | services.frontend.nodeSelector
 a| [subs=-attributes]
 +object+

--- a/charts/ocis/docs/values-desc-table.adoc
+++ b/charts/ocis/docs/values-desc-table.adoc
@@ -2148,6 +2148,12 @@ a| [subs=-attributes]
 a| [subs=-attributes]
 `""`
 | Image tag.
+| services.frontend.maxConcurrency
+a| [subs=-attributes]
++string+
+a| [subs=-attributes]
+`"1"`
+| Maximum number of concurrent go-routines. Higher values can potentially get work done faster but will also cause  more load on the system. Values of 0 or below will be ignored and the default value will be used.
 | services.frontend.nodeSelector
 a| [subs=-attributes]
 +object+
@@ -3558,6 +3564,12 @@ a| [subs=-attributes]
 a| [subs=-attributes]
 `""`
 | Image tag.
+| services.sharing.maxConcurrency
+a| [subs=-attributes]
++string+
+a| [subs=-attributes]
+`"1"`
+| Maximum number of concurrent go-routines. Higher values can potentially get work done faster but will also cause  more load on the system. Values of 0 or below will be ignored and the default value will be used.
 | services.sharing.nodeSelector
 a| [subs=-attributes]
 +object+
@@ -4560,6 +4572,12 @@ a| [subs=-attributes]
 a| [subs=-attributes]
 `""`
 | Image tag.
+| services.userlog.maxConcurrency
+a| [subs=-attributes]
++string+
+a| [subs=-attributes]
+`"1"`
+| Maximum number of concurrent go-routines. Higher values can potentially get work done faster but will also cause  more load on the system. Values of 0 or below will be ignored and the default value will be used.
 | services.userlog.nodeSelector
 a| [subs=-attributes]
 +object+

--- a/charts/ocis/docs/values-desc-table.adoc
+++ b/charts/ocis/docs/values-desc-table.adoc
@@ -3562,8 +3562,8 @@ a| [subs=-attributes]
 a| [subs=-attributes]
 +string+
 a| [subs=-attributes]
-`"1"`
-| Maximum number of concurrent go-routines. Higher values can potentially get work done faster but will also cause  more load on the system. Values of 0 or below will be ignored and the default value will be used.
+`"20"`
+| Maximum number of concurrent go-routines. Higher values can potentially get work done faster but will also cause more load on the system. Values of 0 or below will be ignored and the default value will be used.
 | services.sharing.nodeSelector
 a| [subs=-attributes]
 +object+
@@ -4571,7 +4571,7 @@ a| [subs=-attributes]
 +string+
 a| [subs=-attributes]
 `"1"`
-| Maximum number of concurrent go-routines. Higher values can potentially get work done faster but will also cause  more load on the system. Values of 0 or below will be ignored and the default value will be used.
+| Maximum number of concurrent go-routines. Higher values can potentially get work done faster but will also cause more load on the system. Values of 0 or below will be ignored and the default value will be used.
 | services.userlog.nodeSelector
 a| [subs=-attributes]
 +object+

--- a/charts/ocis/docs/values.adoc.yaml
+++ b/charts/ocis/docs/values.adoc.yaml
@@ -1816,9 +1816,9 @@ services:
       sha: ""
       # -- Image pull policy
       pullPolicy:
-    # -- Maximum number of concurrent go-routines. Higher values can potentially get work done faster but will also cause 
+    # -- Maximum number of concurrent go-routines. Higher values can potentially get work done faster but will also cause
     # more load on the system. Values of 0 or below will be ignored and the default value will be used.
-    maxConcurrency: "1"
+    maxConcurrency: "20" # this differs from the oCIS product, see https://github.com/owncloud/ocis/issues/10647#issuecomment-2498338980
 
   # -- SSE service
   # @default -- see detailed service configuration options below
@@ -2277,7 +2277,7 @@ services:
       sha: ""
       # -- Image pull policy
       pullPolicy:
-    # -- Maximum number of concurrent go-routines. Higher values can potentially get work done faster but will also cause 
+    # -- Maximum number of concurrent go-routines. Higher values can potentially get work done faster but will also cause
     # more load on the system. Values of 0 or below will be ignored and the default value will be used.
     maxConcurrency: "1"
 

--- a/charts/ocis/docs/values.adoc.yaml
+++ b/charts/ocis/docs/values.adoc.yaml
@@ -1229,9 +1229,6 @@ services:
       sha: ""
       # -- Image pull policy
       pullPolicy:
-    # -- Maximum number of concurrent go-routines. Higher values can potentially get work done faster but will also cause 
-    # more load on the system. Values of 0 or below will be ignored and the default value will be used.
-    maxConcurrency: "1"
 
   # -- GATEWAY service.
   # @default -- see detailed service configuration options below

--- a/charts/ocis/docs/values.adoc.yaml
+++ b/charts/ocis/docs/values.adoc.yaml
@@ -1229,6 +1229,9 @@ services:
       sha: ""
       # -- Image pull policy
       pullPolicy:
+    # -- Maximum number of concurrent go-routines. Higher values can potentially get work done faster but will also cause 
+    # more load on the system. Values of 0 or below will be ignored and the default value will be used.
+    maxConcurrency: "1"
 
   # -- GATEWAY service.
   # @default -- see detailed service configuration options below
@@ -1816,6 +1819,9 @@ services:
       sha: ""
       # -- Image pull policy
       pullPolicy:
+    # -- Maximum number of concurrent go-routines. Higher values can potentially get work done faster but will also cause 
+    # more load on the system. Values of 0 or below will be ignored and the default value will be used.
+    maxConcurrency: "1"
 
   # -- SSE service
   # @default -- see detailed service configuration options below
@@ -2274,6 +2280,9 @@ services:
       sha: ""
       # -- Image pull policy
       pullPolicy:
+    # -- Maximum number of concurrent go-routines. Higher values can potentially get work done faster but will also cause 
+    # more load on the system. Values of 0 or below will be ignored and the default value will be used.
+    maxConcurrency: "1"
 
   # -- USERS service.
   # @default -- see detailed service configuration options below

--- a/charts/ocis/templates/frontend/deployment.yaml
+++ b/charts/ocis/templates/frontend/deployment.yaml
@@ -169,6 +169,9 @@ spec:
             - name: OCIS_ENABLE_OCM
               value: {{ .Values.features.ocm.enabled | quote }}
 
+            - name: FRONTEND_MAX_CONCURRENCY
+              value: {{ .Values.services.frontend.maxConcurrency | quote }}
+
             {{- include "ocis.caEnv" $ | nindent 12}}
 
           {{- include "ocis.livenessProbe" . | nindent 10 }}

--- a/charts/ocis/templates/frontend/deployment.yaml
+++ b/charts/ocis/templates/frontend/deployment.yaml
@@ -169,9 +169,6 @@ spec:
             - name: OCIS_ENABLE_OCM
               value: {{ .Values.features.ocm.enabled | quote }}
 
-            - name: FRONTEND_MAX_CONCURRENCY
-              value: {{ .Values.services.frontend.maxConcurrency | quote }}
-
             {{- include "ocis.caEnv" $ | nindent 12}}
 
           {{- include "ocis.livenessProbe" . | nindent 10 }}

--- a/charts/ocis/templates/sharing/deployment.yaml
+++ b/charts/ocis/templates/sharing/deployment.yaml
@@ -104,6 +104,9 @@ spec:
                   name: {{ include "secrets.storageSystemSecret" . }}
                   key: user-id
 
+            - name: SHARING_USER_JSONCS3_MAX_CONCURRENCY
+              value: {{ .Values.services.sharing.maxConcurrency | quote }}
+
             {{- include "ocis.caEnv" $ | nindent 12}}
 
           {{- include "ocis.livenessProbe" . | nindent 10 }}

--- a/charts/ocis/templates/userlog/deployment.yaml
+++ b/charts/ocis/templates/userlog/deployment.yaml
@@ -91,6 +91,9 @@ spec:
                   name: {{ include "secrets.jwtSecret" . }}
                   key: jwt-secret
 
+            - name: USERLOG_MAX_CONCURRENCY
+              value: {{ .Values.services.userlog.maxConcurrency | quote }}
+
             {{- include "ocis.caEnv" $ | nindent 12}}
 
           {{- include "ocis.livenessProbe" . | nindent 10 }}

--- a/charts/ocis/values.yaml
+++ b/charts/ocis/values.yaml
@@ -1815,9 +1815,9 @@ services:
       sha: ""
       # -- Image pull policy
       pullPolicy:
-    # -- Maximum number of concurrent go-routines. Higher values can potentially get work done faster but will also cause 
+    # -- Maximum number of concurrent go-routines. Higher values can potentially get work done faster but will also cause
     # more load on the system. Values of 0 or below will be ignored and the default value will be used.
-    maxConcurrency: "1"
+    maxConcurrency: "20" # this differs from the oCIS product, see https://github.com/owncloud/ocis/issues/10647#issuecomment-2498338980
 
   # -- SSE service
   # @default -- see detailed service configuration options below
@@ -2276,7 +2276,7 @@ services:
       sha: ""
       # -- Image pull policy
       pullPolicy:
-    # -- Maximum number of concurrent go-routines. Higher values can potentially get work done faster but will also cause 
+    # -- Maximum number of concurrent go-routines. Higher values can potentially get work done faster but will also cause
     # more load on the system. Values of 0 or below will be ignored and the default value will be used.
     maxConcurrency: "1"
 

--- a/charts/ocis/values.yaml
+++ b/charts/ocis/values.yaml
@@ -1228,6 +1228,9 @@ services:
       sha: ""
       # -- Image pull policy
       pullPolicy:
+    # -- Maximum number of concurrent go-routines. Higher values can potentially get work done faster but will also cause 
+    # more load on the system. Values of 0 or below will be ignored and the default value will be used.
+    maxConcurrency: "1"
 
   # -- GATEWAY service.
   # @default -- see detailed service configuration options below
@@ -1815,6 +1818,9 @@ services:
       sha: ""
       # -- Image pull policy
       pullPolicy:
+    # -- Maximum number of concurrent go-routines. Higher values can potentially get work done faster but will also cause 
+    # more load on the system. Values of 0 or below will be ignored and the default value will be used.
+    maxConcurrency: "1"
 
   # -- SSE service
   # @default -- see detailed service configuration options below
@@ -2273,6 +2279,9 @@ services:
       sha: ""
       # -- Image pull policy
       pullPolicy:
+    # -- Maximum number of concurrent go-routines. Higher values can potentially get work done faster but will also cause 
+    # more load on the system. Values of 0 or below will be ignored and the default value will be used.
+    maxConcurrency: "1"
 
   # -- USERS service.
   # @default -- see detailed service configuration options below

--- a/charts/ocis/values.yaml
+++ b/charts/ocis/values.yaml
@@ -1228,9 +1228,6 @@ services:
       sha: ""
       # -- Image pull policy
       pullPolicy:
-    # -- Maximum number of concurrent go-routines. Higher values can potentially get work done faster but will also cause 
-    # more load on the system. Values of 0 or below will be ignored and the default value will be used.
-    maxConcurrency: "1"
 
   # -- GATEWAY service.
   # @default -- see detailed service configuration options below


### PR DESCRIPTION
## Description
This PR adds the possibility to configure the concurrency for sharing and userlog services

## Related Issue
- https://github.com/owncloud/ocis/issues/10647

## Motivation and Context
Adjustabliity 

## How Has This Been Tested?
- test environment:
- test case 1:
- test case 2:
- ...

## Types of changes
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Technical debt
- [ ] Tests only (no source changes)

## Checklist:
- [x] Code changes
- [ ] Unit tests added
- [ ] Acceptance tests added
- [x] Documentation generated (`make docs`) and committed
- [ ] Documentation ticket raised: <link>
- [ ] Documentation PR created: <link>
