### PR TITLE
fix corrupt csp config when icon uri is null instead of empty string

### DIFF
--- a/charts/ocis/templates/proxy/config.yaml
+++ b/charts/ocis/templates/proxy/config.yaml
@@ -78,7 +78,7 @@ data:
         {{- end }}
         {{- if .Values.features.appsIntegration.enabled }}
         {{- range $officeSuite := .Values.features.appsIntegration.wopiIntegration.officeSuites }}
-        {{- if and $officeSuite.enabled (ne $officeSuite.iconURI "")}}
+        {{- if and $officeSuite.enabled (not $officeSuite.iconURI)}}
         - {{ $officeSuite.iconURI | quote }}
         {{- end }}
         {{- end }}


### PR DESCRIPTION
## Description

fix corrupt csp config when icon uri is null instead of empty string

## Related Issue

## Motivation and Context

## How Has This Been Tested?

- I rendered the office deployment example with following changes:

```diff
diff --git a/deployments/ocis-office/helmfile.yaml b/deployments/ocis-office/helmfile.yaml
index cb00802e..c2da25c6 100644
--- a/deployments/ocis-office/helmfile.yaml
+++ b/deployments/ocis-office/helmfile.yaml
@@ -152,7 +152,7 @@ releases:
                   uri: "https://collabora.kube.owncloud.test"
                   insecure: true
                   disableProof: false
-                  iconURI: https://collabora.kube.owncloud.test/favicon.ico
+                  #iconURI: https://collabora.kube.owncloud.test/favicon.ico
                   ingress:
                     # Collabora connects to the collaboration service via Ingress in this case
                     enabled: true
```

before the change (with main branch) and after the change (with this PR)::

```diff
# Source: ocis/templates/proxy/config.yaml                      # Source: ocis/templates/proxy/config.yaml
apiVersion: v1                                                  apiVersion: v1
kind: ConfigMap                                                 kind: ConfigMap
metadata:                                                       metadata:
  name: proxy-config                                              name: proxy-config
  namespace: ocis                                                 namespace: ocis
  labels:                                                         labels:
    helm.sh/chart: ocis-0.7.0                                       helm.sh/chart: ocis-0.7.0
    app.kubernetes.io/name: ocis                                    app.kubernetes.io/name: ocis
    app.kubernetes.io/instance: ocis                                app.kubernetes.io/instance: ocis
    app.kubernetes.io/version: "7.0.0-rc.3"                         app.kubernetes.io/version: "7.0.0-rc.3"
    app.kubernetes.io/managed-by: Helm                              app.kubernetes.io/managed-by: Helm
data:                                                           data:
  proxy.yaml: |                                                   proxy.yaml: |
    ---                                                             ---
    policy_selector:                                                policy_selector:
      static:                                                         static:
        policy: ocis                                                    policy: ocis

  csp.yaml: |                                                     csp.yaml: |
    ---                                                             ---
    directives:                                                     directives:
      child-src:                                                      child-src:
        - '''self'''                                                    - '''self'''
      connect-src:                                                    connect-src:
        - '''self'''                                                    - '''self'''
      default-src:                                                    default-src:
        - '''none'''                                                    - '''none'''
      font-src:                                                       font-src:
        - '''self'''                                                    - '''self'''
      frame-ancestors:                                                frame-ancestors:
        - '''self'''                                                    - '''self'''
      frame-src:                                                      frame-src:
        - '''self'''                                                    - '''self'''
        - 'blob:'                                                       - 'blob:'
        - "https://collabora.kube.owncloud.test/"                       - "https://collabora.kube.owncloud.test/"
        - "https://onlyoffice.kube.owncloud.test/"                      - "https://onlyoffice.kube.owncloud.test/"
      img-src:                                                        img-src:
        - '''self'''                                                    - '''self'''
        - 'data:'                                                       - 'data:'
        - 'blob:'                                                       - 'blob:'
        -                                                               - 
        - "https://onlyoffice.kube.owncloud.test/web-apps/app <
      manifest-src:                                                   manifest-src:
        - '''self'''                                                    - '''self'''
      media-src:                                                      media-src:
        - '''self'''                                                    - '''self'''
      object-src:                                                     object-src:
        - '''self'''                                                    - '''self'''
        - 'blob:'                                                       - 'blob:'
      script-src:                                                     script-src:
        - '''self'''                                                    - '''self'''
        - '''unsafe-inline'''                                           - '''unsafe-inline'''
      style-src:                                                      style-src:
        - '''self'''                                                    - '''self'''
        - '''unsafe-inline'''                                           - '''unsafe-inline'''
```

## Screenshots (if appropriate):

## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Technical debt
- [ ] Tests only (no source changes)

## Checklist:
- [x] Code changes
- [ ] Unit tests added
- [ ] Acceptance tests added
- [ ] Documentation generated (`make docs`) and committed
- [ ] Documentation ticket raised: <link>
- [ ] Documentation PR created: <link>
