### PR TITLE
fix sharing min length user search for oCIS 7

### DIFF
--- a/charts/ocis/templates/graph/deployment.yaml
+++ b/charts/ocis/templates/graph/deployment.yaml
@@ -55,6 +55,9 @@ spec:
             - name: GRAPH_SPACES_WEBDAV_BASE
               value: "https://{{ .Values.externalDomain }}"
 
+            - name: GRAPH_IDENTITY_SEARCH_MIN_LENGTH
+              value: {{ .Values.features.sharing.users.search.minLengthLimit | quote }}
+
             {{- if .Values.features.roles.availableUnifiedRoles }}
             - name: GRAPH_AVAILABLE_ROLES
               value: {{ tpl (join "," .Values.features.roles.availableUnifiedRoles) . | quote }}


### PR DESCRIPTION
## Description

From what I understand, oCIS 5 used the ocs API for creating user shares.
Therefore the FRONTEND_SEARCH_MIN_LENGTH config option was sufficient, to
configure both the ocs api (running in the frontend service) as well as
the capabilities endpoint (running in the frontend service) to  both
enforce the minimum search limit on the server side and inform oC Web about
the backend requirements.

With oCIS 7, the user sharing was moved to the graph api (which lives in the graph service)
and therefore we need to both configure the capabilities (oC Web uses that) and the graph
to have the backend side enforcement.


## Related Issue

- https://kiteworks.atlassian.net/browse/OCSRE-423

## Motivation and Context

## How Has This Been Tested?
- Deployed in Minikube with following change:
```diff
diff --git a/deployments/development-install/helmfile.yaml b/deployments/development-install/helmfile.yaml
index 84f2def4..3f96ffc7 100644
--- a/deployments/development-install/helmfile.yaml
+++ b/deployments/development-install/helmfile.yaml
@@ -23,6 +23,10 @@ releases:
 
       - features:
           demoUsers: true
+          sharing:
+            users:
+              search:
+                minLengthLimit: 2
 
       - services:
           idm:
```

Before this fix, the graph api will return HTTP 403 when searching for a user with 2 characters.
After the fix, the graph api will accept the user search with 2 characters.

## Screenshots (if appropriate):

## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Technical debt
- [ ] Tests only (no source changes)

## Checklist:
- [x] Code changes
- [ ] Unit tests added
- [ ] Acceptance tests added
- [ ] Documentation generated (`make docs`) and committed
- [ ] Documentation ticket raised: <link>
- [ ] Documentation PR created: <link>
