### PR TITLE
remove metadata backend environment variable

### DIFF
--- a/charts/ocis/templates/storageusers/jobs.yaml
+++ b/charts/ocis/templates/storageusers/jobs.yaml
@@ -60,8 +60,6 @@ spec:
                 {{- if  eq .Values.services.storageusers.storageBackend.driver "s3ng" }}
                 - name: STORAGE_USERS_DRIVER
                   value: s3ng
-                - name: STORAGE_USERS_S3NG_METADATA_BACKEND
-                  value: {{ .Values.services.storageusers.storageBackend.driverConfig.s3ng.metadataBackend | quote }}
                 - name: STORAGE_USERS_S3NG_ENDPOINT
                   value: {{ .Values.services.storageusers.storageBackend.driverConfig.s3ng.endpoint | quote }}
                 - name: STORAGE_USERS_S3NG_REGION


### PR DESCRIPTION
## Description
Removes the STORAGE_USERS_S3NG_METADATA_BACKEND envirnment variable that was using a undocumented / already removed configuration value.

Probably this was missed when we removed the _METADATA_BACKEND options before


## Related Issue
- Removed in oCIS via https://github.com/owncloud/ocis/pull/10113

## Motivation and Context

## How Has This Been Tested?
- tested in CI only

## Screenshots (if appropriate):

## Types of changes
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [x] Technical debt
- [ ] Tests only (no source changes)

## Checklist:
- [x] Code changes
- [ ] Unit tests added
- [ ] Acceptance tests added
- [ ] Documentation generated (`make docs`) and committed
- [ ] Documentation ticket raised: <link>
- [ ] Documentation PR created: <link>
