### PR TITLE
allow to configure timezone for cronjobs

### DIFF
--- a/charts/ocis/ci/values.yaml
+++ b/charts/ocis/ci/values.yaml
@@ -180,10 +180,13 @@ services:
     maintenance:
       cleanUpExpiredUploads:
         enabled: true
+        timezone: Europe/Berlin
       purgeExpiredTrashBinItems:
         enabled: true
+        timezone: Etc/GMT-5
       restartPostprocessing:
         enabled: true
+        timezone: GMT+0
 
   thumbnails:
     persistence:

--- a/charts/ocis/docs/values-desc-table.adoc
+++ b/charts/ocis/docs/values-desc-table.adoc
@@ -4032,6 +4032,12 @@ a| [subs=-attributes]
 a| [subs=-attributes]
 `600`
 | Defines the a deadline (in whole seconds) for starting the Job, if that Job misses its scheduled time for any reason.
+| services.storageusers.maintenance.cleanUpExpiredUploads.timezone
+a| [subs=-attributes]
++string+
+a| [subs=-attributes]
+`nil`
+| Timezone to be applied to the cron pattern.
 | services.storageusers.maintenance.cleanUpExpiredUploads.uploadExpiration
 a| [subs=-attributes]
 +int+
@@ -4092,6 +4098,12 @@ a| [subs=-attributes]
 a| [subs=-attributes]
 `600`
 | Defines the a deadline (in whole seconds) for starting the Job, if that Job misses its scheduled time for any reason.
+| services.storageusers.maintenance.purgeExpiredTrashBinItems.timezone
+a| [subs=-attributes]
++string+
+a| [subs=-attributes]
+`nil`
+| Timezone to be applied to the cron pattern.
 | services.storageusers.maintenance.restartPostprocessing.enabled
 a| [subs=-attributes]
 +bool+
@@ -4110,6 +4122,12 @@ a| [subs=-attributes]
 a| [subs=-attributes]
 `600`
 | Defines the a deadline (in whole seconds) for starting the Job, if that Job misses its scheduled time for any reason.
+| services.storageusers.maintenance.restartPostprocessing.timezone
+a| [subs=-attributes]
++string+
+a| [subs=-attributes]
+`nil`
+| Timezone to be applied to the cron pattern.
 | services.storageusers.nodeSelector
 a| [subs=-attributes]
 +object+
@@ -4368,6 +4386,12 @@ a| [subs=-attributes]
 a| [subs=-attributes]
 `600`
 | Defines the a deadline (in whole seconds) for starting the Job, if that Job misses its scheduled time for any reason.
+| services.thumbnails.maintenance.cleanUpOldThumbnails.timezone
+a| [subs=-attributes]
++string+
+a| [subs=-attributes]
+`nil`
+| Timezone to be applied to the cron pattern.
 | services.thumbnails.maintenance.image.pullPolicy
 a| [subs=-attributes]
 +string+

--- a/charts/ocis/docs/values.adoc.yaml
+++ b/charts/ocis/docs/values.adoc.yaml
@@ -2026,6 +2026,8 @@ services:
         enabled: false
         # -- Cron pattern for the job to be run.
         schedule: "0 * * * *"
+        # -- Timezone to be applied to the cron pattern.
+        timezone:
         # -- Defines the a deadline (in whole seconds) for starting the Job, if that Job misses its scheduled time for any reason.
         startingDeadlineSeconds: 600
         # -- Duration in seconds after which uploads will expire.
@@ -2037,6 +2039,8 @@ services:
         enabled: false
         # -- Cron pattern for the job to be run.
         schedule: "0 * * * *"
+        # -- Timezone to be applied to the cron pattern.
+        timezone:
         # -- Defines the a deadline (in whole seconds) for starting the Job, if that Job misses its scheduled time for any reason.
         startingDeadlineSeconds: 600
         # -- Setting that makes the command delete all trashed personal files older than the value. The value is a number and a unit "d", "h", "m", "s".
@@ -2049,6 +2053,8 @@ services:
         enabled: false
         # -- Cron pattern for the job to be run.
         schedule: "0 * * * *"
+        # -- Timezone to be applied to the cron pattern.
+        timezone:
         # -- Defines the a deadline (in whole seconds) for starting the Job, if that Job misses its scheduled time for any reason.
         startingDeadlineSeconds: 600
       # Image for the storageusers service maintenance jobs
@@ -2190,6 +2196,8 @@ services:
         enabled: false
         # -- Cron pattern for the job to be run.
         schedule: "0 * * * *"
+        # -- Timezone to be applied to the cron pattern.
+        timezone:
         # -- Defines the a deadline (in whole seconds) for starting the Job, if that Job misses its scheduled time for any reason.
         startingDeadlineSeconds: 600
         # -- Setting that makes the command delete all thumbnails older than the value. The value is a number in days.

--- a/charts/ocis/templates/storageusers/jobs.yaml
+++ b/charts/ocis/templates/storageusers/jobs.yaml
@@ -9,7 +9,10 @@ metadata:
   labels:
     {{- include "ocis.labels" . | nindent 4 }}
 spec:
-  schedule: "{{ .Values.services.storageusers.maintenance.cleanUpExpiredUploads.schedule }}"
+  schedule: {{ .Values.services.storageusers.maintenance.cleanUpExpiredUploads.schedule | quote }}
+  {{- with .Values.services.storageusers.maintenance.cleanUpExpiredUploads.timezone }}
+  timeZone: {{ . | quote }}
+  {{- end }}
   successfulJobsHistoryLimit: 3
   failedJobsHistoryLimit: 3
   concurrencyPolicy: Forbid
@@ -136,7 +139,10 @@ metadata:
   labels:
     {{- include "ocis.labels" . | nindent 4 }}
 spec:
-  schedule: "{{ .Values.services.storageusers.maintenance.purgeExpiredTrashBinItems.schedule }}"
+  schedule: {{ .Values.services.storageusers.maintenance.purgeExpiredTrashBinItems.schedule | quote }}
+  {{- with .Values.services.storageusers.maintenance.purgeExpiredTrashBinItems.timezone }}
+  timeZone: {{ . | quote }}
+  {{- end }}
   successfulJobsHistoryLimit: 3
   failedJobsHistoryLimit: 3
   concurrencyPolicy: Forbid
@@ -239,7 +245,10 @@ metadata:
   labels:
     {{- include "ocis.labels" . | nindent 4 }}
 spec:
-  schedule: "{{ .Values.services.storageusers.maintenance.restartPostprocessing.schedule }}"
+  schedule: {{ .Values.services.storageusers.maintenance.restartPostprocessing.schedule | quote }}
+  {{- with .Values.services.storageusers.maintenance.restartPostprocessing.timezone }}
+  timeZone: {{ . | quote }}
+  {{- end }}
   successfulJobsHistoryLimit: 3
   failedJobsHistoryLimit: 3
   concurrencyPolicy: Forbid

--- a/charts/ocis/templates/thumbnails/jobs.yaml
+++ b/charts/ocis/templates/thumbnails/jobs.yaml
@@ -11,7 +11,10 @@ metadata:
   annotations:
     ignore-check.kube-linter.io/latest-tag: "using the stable tag on this busybox image is better than having an outdated image"
 spec:
-  schedule: "{{ .Values.services.thumbnails.maintenance.cleanUpOldThumbnails.schedule }}"
+  schedule: {{ .Values.services.thumbnails.maintenance.cleanUpOldThumbnails.schedule | quote }}
+  {{- with .Values.services.thumbnails.maintenance.cleanUpOldThumbnails.timezone }}
+  timeZone: {{ . | quote }}
+  {{- end }}
   successfulJobsHistoryLimit: 3
   failedJobsHistoryLimit: 3
   concurrencyPolicy: Forbid

--- a/charts/ocis/values.yaml
+++ b/charts/ocis/values.yaml
@@ -2025,6 +2025,8 @@ services:
         enabled: false
         # -- Cron pattern for the job to be run.
         schedule: "0 * * * *"
+        # -- Timezone to be applied to the cron pattern.
+        timezone:
         # -- Defines the a deadline (in whole seconds) for starting the Job, if that Job misses its scheduled time for any reason.
         startingDeadlineSeconds: 600
         # -- Duration in seconds after which uploads will expire.
@@ -2036,6 +2038,8 @@ services:
         enabled: false
         # -- Cron pattern for the job to be run.
         schedule: "0 * * * *"
+        # -- Timezone to be applied to the cron pattern.
+        timezone:
         # -- Defines the a deadline (in whole seconds) for starting the Job, if that Job misses its scheduled time for any reason.
         startingDeadlineSeconds: 600
         # -- Setting that makes the command delete all trashed personal files older than the value. The value is a number and a unit "d", "h", "m", "s".
@@ -2048,6 +2052,8 @@ services:
         enabled: false
         # -- Cron pattern for the job to be run.
         schedule: "0 * * * *"
+        # -- Timezone to be applied to the cron pattern.
+        timezone:
         # -- Defines the a deadline (in whole seconds) for starting the Job, if that Job misses its scheduled time for any reason.
         startingDeadlineSeconds: 600
       # Image for the storageusers service maintenance jobs
@@ -2189,6 +2195,8 @@ services:
         enabled: false
         # -- Cron pattern for the job to be run.
         schedule: "0 * * * *"
+        # -- Timezone to be applied to the cron pattern.
+        timezone:
         # -- Defines the a deadline (in whole seconds) for starting the Job, if that Job misses its scheduled time for any reason.
         startingDeadlineSeconds: 600
         # -- Setting that makes the command delete all thumbnails older than the value. The value is a number in days.

--- a/deployments/development-install/helmfile.yaml
+++ b/deployments/development-install/helmfile.yaml
@@ -48,12 +48,15 @@ releases:
               cleanUpExpiredUploads:
                 enabled: true
                 schedule: "* * * * *"
+                timezone: Europe/Berlin
               purgeExpiredTrashBinItems:
                 enabled: true
                 schedule: "* * * * *"
+                timezone: Etc/GMT-5
               restartPostprocessing:
                 enabled: true
                 schedule: "* * * * *"
+                timezone: GMT+0
 
           thumbnails:
             persistence:


### PR DESCRIPTION
## Description
allow configuring timezones on cronjobs

## Related Issue

## Motivation and Context
I want to be able to schedule cronjobs eg. during night (and it should reflect eg. daylight savings time)

## How Has This Been Tested?
- I installed the development install in Minikube and looked at the CronJobs:

```
NAMESPACE   NAME                                          SCHEDULE    TIMEZONE        SUSPEND   ACTIVE   LAST SCHEDULE   AGE
ocis        storage-users-clean-expired-uploads           * * * * *   Europe/Berlin   False     0        44s             2m11s
ocis        storage-users-purge-expired-trash-bin-items   * * * * *   Etc/GMT-5       False     0        44s             2m11s
ocis        storage-users-restart-postprocessing          * * * * *   GMT+0           False     0        44s             2m11s
ocis        thumbnails-cleanup                            * * * * *   <none>          False     0        44s             2m11s

```

## Screenshots (if appropriate):

## Types of changes
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Technical debt
- [ ] Tests only (no source changes)

## Checklist:
- [x] Code changes
- [ ] Unit tests added
- [ ] Acceptance tests added
- [x] Documentation generated (`make docs`) and committed
- [ ] Documentation ticket raised: <link>
- [ ] Documentation PR created: <link>
