### PR TITLE
add cronjobs for weekly and daily notifications

### DIFF
--- a/charts/ocis/ci/values.yaml
+++ b/charts/ocis/ci/values.yaml
@@ -226,6 +226,15 @@ services:
       selectorLabels:
         selector1: foobar
 
+  notifications:
+    jobResources:
+      limits:
+        cpu: 123m
+        memory: 123Mi
+      requests:
+        cpu: 123m
+        memory: 123Mi
+
 secretRefs:
   notificationsSmtpSecretRef: "smtp-secret"
   globalNotificationsSecretRef: "global-notification-secret"

--- a/charts/ocis/docs/values-desc-table.adoc
+++ b/charts/ocis/docs/values-desc-table.adoc
@@ -432,6 +432,54 @@ a| [subs=-attributes]
 a| [subs=-attributes]
 `nil`
 | Sender address of emails that will be sent. Example: 'ownCloud <noreply@example.com>'
+| features.emailNotifications.summary.daily.enabled
+a| [subs=-attributes]
++bool+
+a| [subs=-attributes]
+`false`
+| Enables a job, that sends out a summary for the day.
+| features.emailNotifications.summary.daily.schedule
+a| [subs=-attributes]
++string+
+a| [subs=-attributes]
+`"0 0 * * *"`
+| Cron pattern for the job to be run.
+| features.emailNotifications.summary.daily.startingDeadlineSeconds
+a| [subs=-attributes]
++int+
+a| [subs=-attributes]
+`600`
+| Defines the a deadline (in whole seconds) for starting the Job, if that Job misses its scheduled time for any reason.
+| features.emailNotifications.summary.daily.timezone
+a| [subs=-attributes]
++string+
+a| [subs=-attributes]
+`nil`
+| Timezone to be applied to the cron pattern.
+| features.emailNotifications.summary.weekly.enabled
+a| [subs=-attributes]
++bool+
+a| [subs=-attributes]
+`false`
+| Enables a job, that sends out a summary for the week.
+| features.emailNotifications.summary.weekly.schedule
+a| [subs=-attributes]
++string+
+a| [subs=-attributes]
+`"0 0 * * 0"`
+| Cron pattern for the job to be run.
+| features.emailNotifications.summary.weekly.startingDeadlineSeconds
+a| [subs=-attributes]
++int+
+a| [subs=-attributes]
+`600`
+| Defines the a deadline (in whole seconds) for starting the Job, if that Job misses its scheduled time for any reason.
+| features.emailNotifications.summary.weekly.timezone
+a| [subs=-attributes]
++string+
+a| [subs=-attributes]
+`nil`
+| Timezone to be applied to the cron pattern.
 | features.externalUserManagement.adminUUID
 a| [subs=-attributes]
 +string+
@@ -2748,6 +2796,24 @@ a| [subs=-attributes]
 a| [subs=-attributes]
 `""`
 | Image tag.
+| services.notifications.jobNodeSelector
+a| [subs=-attributes]
++object+
+a| [subs=-attributes]
+`{}`
+| Per-service jobNodeSelector configuration. Overrides the default setting from `jobNodeSelector` if set.
+| services.notifications.jobPriorityClassName
+a| [subs=-attributes]
++string+
+a| [subs=-attributes]
+`""`
+| Per-service jobPriorityClassName configuration. Overrides the default setting from `jobPriorityClassName` if set.
+| services.notifications.jobResources
+a| [subs=-attributes]
++object+
+a| [subs=-attributes]
+`{}`
+| Per-service jobResources configuration. Overrides the default setting from `jobResources` if set.
 | services.notifications.nodeSelector
 a| [subs=-attributes]
 +object+

--- a/charts/ocis/docs/values.adoc.yaml
+++ b/charts/ocis/docs/values.adoc.yaml
@@ -218,6 +218,26 @@ features:
       authentication: auto
       # -- Encryption method for the SMTP communication. Possible values are `starttls`, `ssl`, `ssltls`, `tls` and `none`
       encryption: ssltls
+    summary:
+      daily:
+        # -- Enables a job, that sends out a summary for the day.
+        enabled: false
+        # -- Cron pattern for the job to be run.
+        schedule: "0 0 * * *"
+        # -- Timezone to be applied to the cron pattern.
+        timezone:
+        # -- Defines the a deadline (in whole seconds) for starting the Job, if that Job misses its scheduled time for any reason.
+        startingDeadlineSeconds: 600
+      weekly:
+        # -- Enables a job, that sends out a summary for the week.
+        enabled: false
+        # -- Cron pattern for the job to be run.
+        schedule: "0 0 * * 0"
+        # -- Timezone to be applied to the cron pattern.
+        timezone:
+        # -- Defines the a deadline (in whole seconds) for starting the Job, if that Job misses its scheduled time for any reason.
+        startingDeadlineSeconds: 600
+
     branding:
       # -- Enables mail branding. If enabled, you need to provide the text and html template ConfigMap.
       # The image ConfigMap is optional.
@@ -1461,6 +1481,12 @@ services:
       sha: ""
       # -- Image pull policy
       pullPolicy:
+    # -- Per-service jobResources configuration. Overrides the default setting from `jobResources` if set.
+    jobResources: {}
+    # -- Per-service jobNodeSelector configuration. Overrides the default setting from `jobNodeSelector` if set.
+    jobNodeSelector: {}
+    # -- Per-service jobPriorityClassName configuration. Overrides the default setting from `jobPriorityClassName` if set.
+    jobPriorityClassName: ""
 
   # -- OCDAV service.
   # @default -- see detailed service configuration options below

--- a/charts/ocis/templates/frontend/deployment.yaml
+++ b/charts/ocis/templates/frontend/deployment.yaml
@@ -166,6 +166,11 @@ spec:
             - name: FRONTEND_PASSWORD_POLICY_BANNED_PASSWORDS_LIST
               value: /etc/ocis/sharing-banned-passwords.txt
 
+            {{- with .Values.features.emailNotifications.enabled }}
+            - name: FRONTEND_CONFIGURABLE_NOTIFICATIONS
+              value: {{ . | quote }}
+            {{- end }}
+
             - name: OCIS_ENABLE_OCM
               value: {{ .Values.features.ocm.enabled | quote }}
 

--- a/charts/ocis/templates/notifications/deployment.yaml
+++ b/charts/ocis/templates/notifications/deployment.yaml
@@ -26,6 +26,7 @@ spec:
           env:
             {{- include "ocis.serviceRegistry" . | nindent 12 }}
             {{- include "ocis.events" . | nindent 12 }}
+            {{- include "ocis.persistentStore" . | nindent 12 }}
 
             - name: OCIS_DEFAULT_LANGUAGE
               value: {{ default "en" .Values.features.language.default | quote }}

--- a/charts/ocis/templates/notifications/jobs.yaml
+++ b/charts/ocis/templates/notifications/jobs.yaml
@@ -1,0 +1,155 @@
+{{- if .Values.features.emailNotifications.enabled }}
+{{- include "ocis.basicServiceTemplates" (dict "scope" . "appName" "appNameNotifications" "appNameSuffix" "") -}}
+---
+apiVersion: batch/v1
+kind: CronJob
+metadata:
+  name: notifications-daily-notifications
+  namespace: {{ template "ocis.namespace" . }}
+  labels:
+    {{- include "ocis.labels" . | nindent 4 }}
+spec:
+  schedule: {{ .Values.features.emailNotifications.summary.daily.schedule | quote }}
+  {{- with .Values.features.emailNotifications.summary.daily.timezone }}
+  timeZone: {{ . | quote }}
+  {{- end }}
+  successfulJobsHistoryLimit: 3
+  failedJobsHistoryLimit: 3
+  concurrencyPolicy: Forbid
+  startingDeadlineSeconds: {{ .Values.features.emailNotifications.summary.daily.startingDeadlineSeconds }}
+  suspend: {{ not .Values.features.emailNotifications.summary.daily.enabled }}
+  jobTemplate:
+    spec:
+      parallelism: 1
+      ttlSecondsAfterFinished: 86400
+      template:
+        metadata:
+          labels:
+            app: notifications-daily-notifications
+            {{- include "ocis.labels" . | nindent 12 }}
+        spec:
+          restartPolicy: Never
+          {{- include "ocis.securityContextAndtopologySpreadConstraints" . | nindent 10 }}
+          {{- include "ocis.priorityClassName" $.jobPriorityClassName | nindent 10 }}
+          {{- include "ocis.hostAliases" $ | nindent 10 }}
+          nodeSelector: {{ toYaml $.jobNodeSelector | nindent 12 }}
+          containers:
+            - name: notifications-daily-notifications
+              {{- include "ocis.image" . | nindent 14 }}
+              command: ["ocis"]
+              args: ["notifications", "send-email", "--daily"]
+              securityContext:
+                runAsNonRoot: true
+                runAsUser: {{ .Values.securityContext.runAsUser }}
+                runAsGroup: {{ .Values.securityContext.runAsGroup }}
+                readOnlyRootFilesystem: true
+              env:
+                {{- include "ocis.serviceRegistry" . | nindent 16 }}
+                # logging
+                - name: NOTIFICATIONS_LOG_COLOR
+                  value: {{ .Values.logging.color | quote }}
+                - name: NOTIFICATIONS_LOG_LEVEL
+                  value: {{ .Values.logging.level | quote }}
+                - name: NOTIFICATIONS_PRETTY
+                  value: {{ .Values.logging.pretty | quote }}
+
+              resources: {{ toYaml .jobResources | nindent 16 }}
+
+              volumeMounts:
+                - name: tmp-volume
+                  mountPath: /tmp
+                - name: messaging-system-ca
+                  mountPath: /etc/ocis/messaging-system-ca
+                  readOnly: true
+                {{- include "ocis.caPath" $ | nindent 16 }}
+
+          {{- include "ocis.imagePullSecrets" $ | nindent 10 }}
+          volumes:
+            - name: tmp-volume
+              emptyDir: {}
+            - name: messaging-system-ca
+              {{ if and (.Values.messagingSystem.external.enabled) (not .Values.messagingSystem.external.tls.certTrusted) }}
+              secret:
+                secretName: {{ include "secrets.messagingSystemCASecret" . }}
+              {{ else }}
+              emptyDir: {}
+              {{ end }}
+            {{- include "ocis.caVolume" $ | nindent 12}}
+
+---
+apiVersion: batch/v1
+kind: CronJob
+metadata:
+  name: notifications-weekly-notifications
+  namespace: {{ template "ocis.namespace" . }}
+  labels:
+    {{- include "ocis.labels" . | nindent 4 }}
+spec:
+  schedule: {{ .Values.features.emailNotifications.summary.weekly.schedule | quote }}
+  {{- with .Values.features.emailNotifications.summary.weekly.timezone }}
+  timeZone: {{ . | quote }}
+  {{- end }}
+  successfulJobsHistoryLimit: 3
+  failedJobsHistoryLimit: 3
+  concurrencyPolicy: Forbid
+  startingDeadlineSeconds: {{ .Values.features.emailNotifications.summary.weekly.startingDeadlineSeconds }}
+  suspend: {{ not .Values.features.emailNotifications.summary.weekly.enabled }}
+  jobTemplate:
+    spec:
+      parallelism: 1
+      ttlSecondsAfterFinished: 86400
+      template:
+        metadata:
+          labels:
+            app: notifications-weekly-notifications
+            {{- include "ocis.labels" . | nindent 12 }}
+        spec:
+          restartPolicy: Never
+          {{- include "ocis.securityContextAndtopologySpreadConstraints" . | nindent 10 }}
+          {{- include "ocis.priorityClassName" $.jobPriorityClassName | nindent 10 }}
+          {{- include "ocis.hostAliases" $ | nindent 10 }}
+          nodeSelector: {{ toYaml $.jobNodeSelector | nindent 12 }}
+          containers:
+            - name: notifications-weekly-notifications
+              {{- include "ocis.image" . | nindent 14 }}
+              command: ["ocis"]
+              args: ["notifications", "send-email", "--weekly"]
+              securityContext:
+                runAsNonRoot: true
+                runAsUser: {{ .Values.securityContext.runAsUser }}
+                runAsGroup: {{ .Values.securityContext.runAsGroup }}
+                readOnlyRootFilesystem: true
+              env:
+                {{- include "ocis.serviceRegistry" . | nindent 16 }}
+                # logging
+                - name: NOTIFICATIONS_LOG_COLOR
+                  value: {{ .Values.logging.color | quote }}
+                - name: NOTIFICATIONS_LOG_LEVEL
+                  value: {{ .Values.logging.level | quote }}
+                - name: NOTIFICATIONS_PRETTY
+                  value: {{ .Values.logging.pretty | quote }}
+
+              resources: {{ toYaml .jobResources | nindent 16 }}
+
+              volumeMounts:
+                - name: tmp-volume
+                  mountPath: /tmp
+                - name: messaging-system-ca
+                  mountPath: /etc/ocis/messaging-system-ca
+                  readOnly: true
+                {{- include "ocis.caPath" $ | nindent 16 }}
+
+          {{- include "ocis.imagePullSecrets" $ | nindent 10 }}
+          volumes:
+            - name: tmp-volume
+              emptyDir: {}
+            - name: messaging-system-ca
+              {{ if and (.Values.messagingSystem.external.enabled) (not .Values.messagingSystem.external.tls.certTrusted) }}
+              secret:
+                secretName: {{ include "secrets.messagingSystemCASecret" . }}
+              {{ else }}
+              emptyDir: {}
+              {{ end }}
+            {{- include "ocis.caVolume" $ | nindent 12}}
+
+{{- end }}

--- a/charts/ocis/templates/notifications/jobs.yaml
+++ b/charts/ocis/templates/notifications/jobs.yaml
@@ -45,6 +45,7 @@ spec:
                 readOnlyRootFilesystem: true
               env:
                 {{- include "ocis.serviceRegistry" . | nindent 16 }}
+                {{- include "ocis.events" . | nindent 16 }}
                 # logging
                 - name: NOTIFICATIONS_LOG_COLOR
                   value: {{ .Values.logging.color | quote }}
@@ -52,6 +53,9 @@ spec:
                   value: {{ .Values.logging.level | quote }}
                 - name: NOTIFICATIONS_PRETTY
                   value: {{ .Values.logging.pretty | quote }}
+
+                - name: NOTIFICATIONS_SMTP_SENDER #TODO: only needed to satisfy config checks!?
+                  value: {{ .Values.features.emailNotifications.smtp.sender | quote }}
 
               resources: {{ toYaml .jobResources | nindent 16 }}
 
@@ -121,6 +125,7 @@ spec:
                 readOnlyRootFilesystem: true
               env:
                 {{- include "ocis.serviceRegistry" . | nindent 16 }}
+                {{- include "ocis.events" . | nindent 16 }}
                 # logging
                 - name: NOTIFICATIONS_LOG_COLOR
                   value: {{ .Values.logging.color | quote }}
@@ -128,6 +133,9 @@ spec:
                   value: {{ .Values.logging.level | quote }}
                 - name: NOTIFICATIONS_PRETTY
                   value: {{ .Values.logging.pretty | quote }}
+
+                - name: NOTIFICATIONS_SMTP_SENDER #TODO: only needed to satisfy config checks!?
+                  value: {{ .Values.features.emailNotifications.smtp.sender | quote }}
 
               resources: {{ toYaml .jobResources | nindent 16 }}
 

--- a/charts/ocis/values.yaml
+++ b/charts/ocis/values.yaml
@@ -217,6 +217,26 @@ features:
       authentication: auto
       # -- Encryption method for the SMTP communication. Possible values are `starttls`, `ssl`, `ssltls`, `tls` and `none`
       encryption: ssltls
+    summary:
+      daily:
+        # -- Enables a job, that sends out a summary for the day.
+        enabled: false
+        # -- Cron pattern for the job to be run.
+        schedule: "0 0 * * *"
+        # -- Timezone to be applied to the cron pattern.
+        timezone:
+        # -- Defines the a deadline (in whole seconds) for starting the Job, if that Job misses its scheduled time for any reason.
+        startingDeadlineSeconds: 600
+      weekly:
+        # -- Enables a job, that sends out a summary for the week.
+        enabled: false
+        # -- Cron pattern for the job to be run.
+        schedule: "0 0 * * 0"
+        # -- Timezone to be applied to the cron pattern.
+        timezone:
+        # -- Defines the a deadline (in whole seconds) for starting the Job, if that Job misses its scheduled time for any reason.
+        startingDeadlineSeconds: 600
+
     branding:
       # -- Enables mail branding. If enabled, you need to provide the text and html template ConfigMap.
       # The image ConfigMap is optional.
@@ -1460,6 +1480,12 @@ services:
       sha: ""
       # -- Image pull policy
       pullPolicy:
+    # -- Per-service jobResources configuration. Overrides the default setting from `jobResources` if set.
+    jobResources: {}
+    # -- Per-service jobNodeSelector configuration. Overrides the default setting from `jobNodeSelector` if set.
+    jobNodeSelector: {}
+    # -- Per-service jobPriorityClassName configuration. Overrides the default setting from `jobPriorityClassName` if set.
+    jobPriorityClassName: ""
 
   # -- OCDAV service.
   # @default -- see detailed service configuration options below

--- a/deployments/ocis-mail/helmfile.yaml
+++ b/deployments/ocis-mail/helmfile.yaml
@@ -45,6 +45,11 @@ releases:
               encryption: none
             branding:
               enabled: false # you can set this to true if you first run `kubectl -n ocis apply -f mail-templates.yaml`
+            summary:
+              daily:
+                enabled: true
+              weekly:
+                enabled: true
 
       - services:
           idm:


### PR DESCRIPTION
## Description
add cronjobs for daily and weekly notifications

TODO:
- [x] test once the PR is merged https://github.com/owncloud/ocis/pull/10838
- [x] add the new NATS stream to the NACK example
  - After checking with engineering this is not needed as there is no further NATS stream needed now.

## Related Issue
- oCIS command we are using here, is implemented in https://github.com/owncloud/ocis/pull/10838
- https://kiteworks.atlassian.net/browse/OCSRE-459


## Motivation and Context

## How Has This Been Tested?
- Tested on k3d with the diff below:
```diff
diff --git a/deployments/ocis-mail/helmfile.yaml b/deployments/ocis-mail/helmfile.yaml
index 16c31229..f5b84deb 100644
--- a/deployments/ocis-mail/helmfile.yaml
+++ b/deployments/ocis-mail/helmfile.yaml
@@ -22,6 +22,10 @@ releases:
     chart: ../../charts/ocis
     namespace: ocis
     values:
+      - image:
+          repository: owncloud/ocis-rolling
+          tag: master
+          sha: 5d905c5e7b9d4bffa6e5e1ead08bfd00537e02238313943d80809d893790cdd9
       - externalDomain: ocis.kube.owncloud.test
       - ingress:
           enabled: true
@@ -48,8 +52,10 @@ releases:
             summary:
               daily:
                 enabled: true
+                schedule: "* * * * *"
               weekly:
                 enabled: true
+                schedule: "* * * * *"
 
       - services:
           idm:
```

## Screenshots (if appropriate):

## Types of changes
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Technical debt
- [ ] Tests only (no source changes)

## Checklist:
- [x] Code changes
- [ ] Unit tests added
- [ ] Acceptance tests added
- [x] Documentation generated (`make docs`) and committed
- [ ] Documentation ticket raised: <link>
- [ ] Documentation PR created: <link>
