### PR TITLE
remove tmp volumes

### DIFF
--- a/charts/ocis/templates/activitylog/deployment.yaml
+++ b/charts/ocis/templates/activitylog/deployment.yaml
@@ -80,16 +80,12 @@ spec:
               containerPort: 9197
 
           volumeMounts:
-            - name: tmp-volume
-              mountPath: /tmp
             - name: messaging-system-ca
               mountPath: /etc/ocis/messaging-system-ca
               readOnly: true
 
       {{- include "ocis.imagePullSecrets" $ | nindent 6 }}
       volumes:
-        - name: tmp-volume
-          emptyDir: {}
         - name: messaging-system-ca
           {{ if and (.Values.messagingSystem.external.enabled) (not .Values.messagingSystem.external.tls.certTrusted) }}
           secret:

--- a/charts/ocis/templates/antivirus/deployment.yaml
+++ b/charts/ocis/templates/antivirus/deployment.yaml
@@ -74,8 +74,6 @@ spec:
               containerPort: 9277
 
           volumeMounts:
-            - name: tmp-volume
-              mountPath: /tmp
             - name: messaging-system-ca
               mountPath: /etc/ocis/messaging-system-ca
               readOnly: true
@@ -83,8 +81,6 @@ spec:
 
       {{- include "ocis.imagePullSecrets" $ | nindent 6 }}
       volumes:
-        - name: tmp-volume
-          emptyDir: {}
         - name: messaging-system-ca
           {{ if and (.Values.messagingSystem.external.enabled) (not .Values.messagingSystem.external.tls.certTrusted) }}
           secret:

--- a/charts/ocis/templates/audit/deployment.yaml
+++ b/charts/ocis/templates/audit/deployment.yaml
@@ -62,8 +62,6 @@ spec:
               containerPort: 9229
 
           volumeMounts:
-            - name: tmp-volume
-              mountPath: /tmp
             - name: messaging-system-ca
               mountPath: /etc/ocis/messaging-system-ca
               readOnly: true
@@ -71,8 +69,6 @@ spec:
 
       {{- include "ocis.imagePullSecrets" $ | nindent 6 }}
       volumes:
-        - name: tmp-volume
-          emptyDir: {}
         - name: messaging-system-ca
           {{ if and (.Values.messagingSystem.external.enabled) (not .Values.messagingSystem.external.tls.certTrusted) }}
           secret:

--- a/charts/ocis/templates/clientlog/deployment.yaml
+++ b/charts/ocis/templates/clientlog/deployment.yaml
@@ -76,8 +76,6 @@ spec:
               containerPort: 9260
 
           volumeMounts:
-            - name: tmp-volume
-              mountPath: /tmp
             - name: messaging-system-ca
               mountPath: /etc/ocis/messaging-system-ca
               readOnly: true
@@ -85,8 +83,6 @@ spec:
 
       {{- include "ocis.imagePullSecrets" $ | nindent 6 }}
       volumes:
-        - name: tmp-volume
-          emptyDir: {}
         - name: messaging-system-ca
           {{ if and (.Values.messagingSystem.external.enabled) (not .Values.messagingSystem.external.tls.certTrusted) }}
           secret:

--- a/charts/ocis/templates/collaboration/deployment.yaml
+++ b/charts/ocis/templates/collaboration/deployment.yaml
@@ -130,15 +130,11 @@ spec:
               containerPort: 9304
 
           volumeMounts:
-            - name: tmp-volume
-              mountPath: /tmp
             {{- include "ocis.caPath" $ | nindent 12}}
 
       {{- include "ocis.imagePullSecrets" $ | nindent 6 }}
 
       volumes:
-        - name: tmp-volume
-          emptyDir: {}
         {{- include "ocis.caVolume" $ | nindent 8}}
 {{ end }}
 {{ end }}

--- a/charts/ocis/templates/eventhistory/deployment.yaml
+++ b/charts/ocis/templates/eventhistory/deployment.yaml
@@ -66,8 +66,6 @@ spec:
               containerPort: 9270
 
           volumeMounts:
-            - name: tmp-volume
-              mountPath: /tmp
             - name: messaging-system-ca
               mountPath: /etc/ocis/messaging-system-ca
               readOnly: true
@@ -75,8 +73,6 @@ spec:
 
       {{- include "ocis.imagePullSecrets" $ | nindent 6 }}
       volumes:
-        - name: tmp-volume
-          emptyDir: {}
         - name: messaging-system-ca
           {{ if and (.Values.messagingSystem.external.enabled) (not .Values.messagingSystem.external.tls.certTrusted) }}
           secret:

--- a/charts/ocis/templates/graph/deployment.yaml
+++ b/charts/ocis/templates/graph/deployment.yaml
@@ -229,8 +229,6 @@ spec:
               containerPort: 9124
 
           volumeMounts:
-            - name: tmp-volume
-              mountPath: /tmp
             - name: messaging-system-ca
               mountPath: /etc/ocis/messaging-system-ca
               readOnly: true
@@ -241,8 +239,6 @@ spec:
 
       {{- include "ocis.imagePullSecrets" $ | nindent 6 }}
       volumes:
-        - name: tmp-volume
-          emptyDir: {}
         - name: messaging-system-ca
           {{ if and (.Values.messagingSystem.external.enabled) (not .Values.messagingSystem.external.tls.certTrusted) }}
           secret:

--- a/charts/ocis/templates/idm/deployment.yaml
+++ b/charts/ocis/templates/idm/deployment.yaml
@@ -122,8 +122,6 @@ spec:
               containerPort: 9239
 
           volumeMounts:
-            - name: tmp-volume
-              mountPath: /tmp
             - name: ldap-cert
               mountPath: /etc/ocis/ldap-cert
               readOnly: true
@@ -133,8 +131,6 @@ spec:
 
       {{- include "ocis.imagePullSecrets" $ | nindent 6 }}
       volumes:
-        - name: tmp-volume
-          emptyDir: {}
         - name: ldap-cert
           secret:
             secretName: {{ include "secrets.ldapCertSecret" . }}

--- a/charts/ocis/templates/idp/deployment.yaml
+++ b/charts/ocis/templates/idp/deployment.yaml
@@ -85,8 +85,6 @@ spec:
               containerPort: 9134
 
           volumeMounts:
-            - name: tmp-volume
-              mountPath: /tmp
             - name: ocis-data-tmp
               mountPath: /var/lib/ocis # we mount that volume to apply fsGroup to that path, so that the idp can write the temporary idp/tmp/identifier-registration.yaml file
             - name: ldap-ca
@@ -99,8 +97,6 @@ spec:
 
       {{- include "ocis.imagePullSecrets" $ | nindent 6 }}
       volumes:
-        - name: tmp-volume
-          emptyDir: {}
         - name: ocis-data-tmp
           emptyDir: {}
         - name: ldap-ca

--- a/charts/ocis/templates/nats/deployment.yaml
+++ b/charts/ocis/templates/nats/deployment.yaml
@@ -76,16 +76,12 @@ spec:
               containerPort: 9234
 
           volumeMounts:
-            - name: tmp-volume
-              mountPath: /tmp
             - name: {{ include "ocis.persistence.dataVolumeName" . }}
               mountPath: /var/lib/ocis
             {{- include "ocis.caPath" $ | nindent 12}}
 
       {{- include "ocis.imagePullSecrets" $ | nindent 6 }}
       volumes:
-        - name: tmp-volume
-          emptyDir: {}
         {{- include "ocis.caVolume" $ | nindent 8}}
         {{- include "ocis.persistence.dataVolume" . | nindent 8 }}
 {{- end }}

--- a/charts/ocis/templates/notifications/deployment.yaml
+++ b/charts/ocis/templates/notifications/deployment.yaml
@@ -109,8 +109,6 @@ spec:
               containerPort: 9174
 
           volumeMounts:
-            - name: tmp-volume
-              mountPath: /tmp
             - name: messaging-system-ca
               mountPath: /etc/ocis/messaging-system-ca
               readOnly: true
@@ -126,8 +124,6 @@ spec:
 
       {{- include "ocis.imagePullSecrets" $ | nindent 6 }}
       volumes:
-        - name: tmp-volume
-          emptyDir: {}
         - name: messaging-system-ca
           {{ if and (.Values.messagingSystem.external.enabled) (not .Values.messagingSystem.external.tls.certTrusted) }}
           secret:

--- a/charts/ocis/templates/ocdav/deployment.yaml
+++ b/charts/ocis/templates/ocdav/deployment.yaml
@@ -83,12 +83,8 @@ spec:
               containerPort: 9163
 
           volumeMounts:
-            - name: tmp-volume
-              mountPath: /tmp
             {{- include "ocis.caPath" $ | nindent 12}}
 
       {{- include "ocis.imagePullSecrets" $ | nindent 6 }}
       volumes:
-        - name: tmp-volume
-          emptyDir: {}
         {{- include "ocis.caVolume" $ | nindent 8}}

--- a/charts/ocis/templates/ocs/deployment.yaml
+++ b/charts/ocis/templates/ocs/deployment.yaml
@@ -76,12 +76,8 @@ spec:
               containerPort: 9114
 
           volumeMounts:
-            - name: tmp-volume
-              mountPath: /tmp
             {{- include "ocis.caPath" $ | nindent 12}}
 
       {{- include "ocis.imagePullSecrets" $ | nindent 6 }}
       volumes:
-        - name: tmp-volume
-          emptyDir: {}
         {{- include "ocis.caVolume" $ | nindent 8}}

--- a/charts/ocis/templates/policies/deployment.yaml
+++ b/charts/ocis/templates/policies/deployment.yaml
@@ -69,8 +69,6 @@ spec:
               containerPort: 9129
 
           volumeMounts:
-            - name: tmp-volume
-              mountPath: /tmp
             - name: messaging-system-ca
               mountPath: /etc/ocis/messaging-system-ca
               readOnly: true
@@ -80,8 +78,6 @@ spec:
 
       {{- include "ocis.imagePullSecrets" $ | nindent 6 }}
       volumes:
-        - name: tmp-volume
-          emptyDir: {}
         - name: messaging-system-ca
           {{ if and (.Values.messagingSystem.external.enabled) (not .Values.messagingSystem.external.tls.certTrusted) }}
           secret:

--- a/charts/ocis/templates/postprocessing/deployment.yaml
+++ b/charts/ocis/templates/postprocessing/deployment.yaml
@@ -80,8 +80,6 @@ spec:
               containerPort: 9255
 
           volumeMounts:
-            - name: tmp-volume
-              mountPath: /tmp
             - name: messaging-system-ca
               mountPath: /etc/ocis/messaging-system-ca
               readOnly: true
@@ -89,8 +87,6 @@ spec:
 
       {{- include "ocis.imagePullSecrets" $ | nindent 6 }}
       volumes:
-        - name: tmp-volume
-          emptyDir: {}
         - name: messaging-system-ca
           {{ if and (.Values.messagingSystem.external.enabled) (not .Values.messagingSystem.external.tls.certTrusted) }}
           secret:

--- a/charts/ocis/templates/proxy/deployment.yaml
+++ b/charts/ocis/templates/proxy/deployment.yaml
@@ -138,16 +138,12 @@ spec:
               containerPort: 9205
 
           volumeMounts:
-            - name: tmp-volume
-              mountPath: /tmp
             - name: configs
               mountPath: /etc/ocis
             {{- include "ocis.caPath" $ | nindent 12}}
 
       {{- include "ocis.imagePullSecrets" $ | nindent 6 }}
       volumes:
-        - name: tmp-volume
-          emptyDir: {}
         - name: configs
           configMap:
             name: {{ .appName }}-config

--- a/charts/ocis/templates/search/deployment.yaml
+++ b/charts/ocis/templates/search/deployment.yaml
@@ -116,8 +116,6 @@ spec:
               containerPort: 9224
 
           volumeMounts:
-            - name: tmp-volume
-              mountPath: /tmp
             - name: messaging-system-ca
               mountPath: /etc/ocis/messaging-system-ca
               readOnly: true
@@ -127,8 +125,6 @@ spec:
 
       {{- include "ocis.imagePullSecrets" $ | nindent 6 }}
       volumes:
-        - name: tmp-volume
-          emptyDir: {}
         - name: messaging-system-ca
           {{ if and (.Values.messagingSystem.external.enabled) (not .Values.messagingSystem.external.tls.certTrusted) }}
           secret:

--- a/charts/ocis/templates/settings/deployment.yaml
+++ b/charts/ocis/templates/settings/deployment.yaml
@@ -108,10 +108,7 @@ spec:
             - name: metrics-debug
               containerPort: 9194
 
-
           volumeMounts:
-            - name: tmp-volume
-              mountPath: /tmp
           {{- if or .Values.features.roles.customRoles .Values.features.roles.customRolesConfigRef }}
             - name: ocis-role-config
               mountPath: /etc/ocis
@@ -121,8 +118,6 @@ spec:
       {{- include "ocis.imagePullSecrets" $ | nindent 6 }}
 
       volumes:
-        - name: tmp-volume
-          emptyDir: {}
       {{- if .Values.features.roles.customRoles }}
         - name: ocis-role-config
           configMap:

--- a/charts/ocis/templates/sse/deployment.yaml
+++ b/charts/ocis/templates/sse/deployment.yaml
@@ -75,8 +75,6 @@ spec:
               containerPort: 9135
 
           volumeMounts:
-            - name: tmp-volume
-              mountPath: /tmp
             - name: messaging-system-ca
               mountPath: /etc/ocis/messaging-system-ca
               readOnly: true
@@ -84,8 +82,6 @@ spec:
 
       {{- include "ocis.imagePullSecrets" $ | nindent 6 }}
       volumes:
-        - name: tmp-volume
-          emptyDir: {}
         - name: messaging-system-ca
           {{ if and (.Values.messagingSystem.external.enabled) (not .Values.messagingSystem.external.tls.certTrusted) }}
           secret:

--- a/charts/ocis/templates/thumbnails/deployment.yaml
+++ b/charts/ocis/templates/thumbnails/deployment.yaml
@@ -103,15 +103,11 @@ spec:
               containerPort: 9189
 
           volumeMounts:
-            - name: tmp-volume
-              mountPath: /tmp
             - name: {{ include "ocis.persistence.dataVolumeName" . }}
               mountPath: /var/lib/ocis
             {{- include "ocis.caPath" $ | nindent 12}}
 
       {{- include "ocis.imagePullSecrets" $ | nindent 6 }}
       volumes:
-        - name: tmp-volume
-          emptyDir: {}
         {{- include "ocis.caVolume" $ | nindent 8}}
         {{- include "ocis.persistence.dataVolume" . | nindent 8 }}

--- a/charts/ocis/templates/userlog/deployment.yaml
+++ b/charts/ocis/templates/userlog/deployment.yaml
@@ -98,8 +98,6 @@ spec:
               containerPort: 9210
 
           volumeMounts:
-            - name: tmp-volume
-              mountPath: /tmp
             - name: messaging-system-ca
               mountPath: /etc/ocis/messaging-system-ca
               readOnly: true
@@ -107,8 +105,6 @@ spec:
 
       {{- include "ocis.imagePullSecrets" $ | nindent 6 }}
       volumes:
-        - name: tmp-volume
-          emptyDir: {}
         - name: messaging-system-ca
           {{ if and (.Values.messagingSystem.external.enabled) (not .Values.messagingSystem.external.tls.certTrusted) }}
           secret:

--- a/charts/ocis/templates/web/deployment.yaml
+++ b/charts/ocis/templates/web/deployment.yaml
@@ -204,8 +204,6 @@ spec:
               containerPort: 9104
 
           volumeMounts:
-            - name: tmp-volume
-              mountPath: /tmp
             - name: configs
               mountPath: /etc/ocis
             {{- if .Values.configRefs.webThemeConfigRef }}
@@ -224,8 +222,6 @@ spec:
 
       {{- include "ocis.imagePullSecrets" $ | nindent 6 }}
       volumes:
-        - name: tmp-volume
-          emptyDir: {}
         - name: configs
           configMap:
             name: {{ .appName }}-config

--- a/charts/ocis/templates/webdav/deployment.yaml
+++ b/charts/ocis/templates/webdav/deployment.yaml
@@ -66,12 +66,8 @@ spec:
               containerPort: 9119
 
           volumeMounts:
-            - name: tmp-volume
-              mountPath: /tmp
             {{- include "ocis.caPath" $ | nindent 12}}
 
       {{- include "ocis.imagePullSecrets" $ | nindent 6 }}
       volumes:
-        - name: tmp-volume
-          emptyDir: {}
         {{- include "ocis.caVolume" $ | nindent 8}}

--- a/charts/ocis/templates/webfinger/deployment.yaml
+++ b/charts/ocis/templates/webfinger/deployment.yaml
@@ -75,12 +75,8 @@ spec:
               containerPort: 8081
 
           volumeMounts:
-            - name: tmp-volume
-              mountPath: /tmp
             {{- include "ocis.caPath" $ | nindent 12}}
 
       {{- include "ocis.imagePullSecrets" $ | nindent 6 }}
       volumes:
-        - name: tmp-volume
-          emptyDir: {}
         {{- include "ocis.caVolume" $ | nindent 8}}


### PR DESCRIPTION
## Description
remove tmp volumes that have been introduced for govips as workaround

## Related Issue
- needs https://github.com/owncloud/ocis/pull/10943 in oCIS version, we're using
- https://github.com/owncloud/ocis/issues/10378
- https://github.com/owncloud/ocis-charts/pull/778

## Motivation and Context

## How Has This Been Tested?
- I built the code and ran it in Minikube. Pods start fine, thumbnails are beeing generated.

## Screenshots (if appropriate):

## Types of changes
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [x] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Technical debt
- [ ] Tests only (no source changes)

## Checklist:
- [x] Code changes
- [ ] Unit tests added
- [ ] Acceptance tests added
- [ ] Documentation generated (`make docs`) and committed
- [ ] Documentation ticket raised: <link>
- [ ] Documentation PR created: <link>
