### PR TITLE
disable feedback link by default

### DIFF
--- a/charts/ocis/docs/values-desc-table.adoc
+++ b/charts/ocis/docs/values-desc-table.adoc
@@ -4612,7 +4612,7 @@ a| [subs=-attributes]
 a| [subs=-attributes]
 +bool+
 a| [subs=-attributes]
-`true`
+`false`
 | Enables the feedback link in the Web UI.
 | services.web.config.feedbackLink.href
 a| [subs=-attributes]

--- a/charts/ocis/docs/values.adoc.yaml
+++ b/charts/ocis/docs/values.adoc.yaml
@@ -5203,7 +5203,7 @@ services:
         # required: true
         # @schema
         # -- Enables the feedback link in the Web UI.
-        enabled: true
+        enabled: false
         # @schema
         # type: [string, null]
         # format: uri

--- a/charts/ocis/values.schema.json
+++ b/charts/ocis/values.schema.json
@@ -11544,7 +11544,7 @@
                       ]
                     },
                     "enabled": {
-                      "default": true,
+                      "default": false,
                       "description": "Enables the feedback link in the Web UI.",
                       "required": [],
                       "title": "enabled",

--- a/charts/ocis/values.yaml
+++ b/charts/ocis/values.yaml
@@ -5202,7 +5202,7 @@ services:
         # required: true
         # @schema
         # -- Enables the feedback link in the Web UI.
-        enabled: true
+        enabled: false
         # @schema
         # type: [string, null]
         # format: uri


### PR DESCRIPTION
## Description
disable the feedback link by default

## Related Issue

## Motivation and Context

## How Has This Been Tested?

## Screenshots (if appropriate):

## Types of changes
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [x] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Technical debt
- [ ] Tests only (no source changes)

## Checklist:
- [x] Code changes
- [ ] Unit tests added
- [ ] Acceptance tests added
- [ ] Documentation generated (`make docs`) and committed
- [ ] Documentation ticket raised: <link>
- [ ] Documentation PR created: <link>
