### PR TITLE
fix nats deployment example

### DIFF
--- a/charts/ocis/templates/_common/events.tpl
+++ b/charts/ocis/templates/_common/events.tpl
@@ -7,10 +7,12 @@ oCIS events configuration
 - name: OCIS_EVENTS_ENDPOINT
   value: {{ .appNameNats }}:9233
 {{- else }}
+{{- $ocis_events_endpoint := .Values.messagingSystem.external.endpoint | required ".Values.messagingSystem.external.endpoint is required when .Values.messagingSystem.external.enabled is set to true." -}}
+{{- $ocis_events_cluster := .Values.messagingSystem.external.cluster | required ".Values.messagingSystem.external.cluster is required when .Values.messagingSystem.external.enabled is set to true." -}}
 - name: OCIS_EVENTS_ENDPOINT
-  value: {{ .Values.messagingSystem.external.endpoint | quote }}
+  value: {{ $ocis_events_endpoint | quote }}
 - name: OCIS_EVENTS_CLUSTER
-  value: {{ .Values.messagingSystem.external.cluster | quote }}
+  value: {{ $ocis_events_cluster | quote }}
 - name: OCIS_EVENTS_ENABLE_TLS
   value: {{ .Values.messagingSystem.external.tls.enabled | quote }}
 - name: OCIS_EVENTS_TLS_INSECURE

--- a/deployments/ocis-nats/helmfile.yaml
+++ b/deployments/ocis-nats/helmfile.yaml
@@ -99,6 +99,7 @@ releases:
       - messagingSystem:
           external:
             enabled: true
+            cluster: ocis-cluster
             endpoint: nats.ocis-nats.svc.cluster.local:4222
             tls:
               enabled: false


### PR DESCRIPTION
## Description
makes helm installation fail when endpoint and cluster settings are missing and external nats is used

## Related Issue
- Fixes https://github.com/owncloud/ocis-charts/issues/855
- Caused by https://github.com/owncloud/ocis-charts/pull/811/files#diff-8c842c719bd4d586188397f163f81a453a91b973b98b05e09a8cbe8132e269c2L173


## Motivation and Context

This would be another occurence where the usage of https://json-schema.org/understanding-json-schema/reference/conditionals#dependentRequired would help. But the tooling we use, doesn't support it right now.

## How Has This Been Tested?

- `helmfile template` on the ocis-nats deployment example before and after the changes:
  - when `cluster` is not configured, I get: `STDERR:
  Error: execution error at (ocis/templates/userlog/deployment.yaml:28:16): .Values.messagingSystem.external.cluster is required when .Values.messagingSystem.external.enabled is set to true.
  Use --debug flag to render out invalid YAML`

## Screenshots (if appropriate):

## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Technical debt
- [ ] Tests only (no source changes)

## Checklist:
- [x] Code changes
- [ ] Unit tests added
- [ ] Acceptance tests added
- [ ] Documentation generated (`make docs`) and committed
- [ ] Documentation ticket raised: <link>
- [ ] Documentation PR created: <link>
