### PR TITLE
allow global settings in schema

### DIFF
--- a/charts/ocis/docs/values-desc-table.adoc
+++ b/charts/ocis/docs/values-desc-table.adoc
@@ -828,6 +828,12 @@ a| [subs=-attributes]
 a| [subs=-attributes]
 `nil`
 | Sets a maximum file size for scans. Only this many bytes of a file will be scanned. 0 means unlimited and is the default. Usable common abbreviations: [KB, KiB, MB, MiB, GB, GiB, TB, TiB, PB, PiB, EB, EiB], example: 2GB.
+| global
+a| [subs=-attributes]
++object+
+a| [subs=-attributes]
+`{}`
+|
 | hostAliases
 a| [subs=-attributes]
 +list+

--- a/charts/ocis/docs/values.adoc.yaml
+++ b/charts/ocis/docs/values.adoc.yaml
@@ -5692,3 +5692,12 @@ service:
     # -- appProtocol to be used for service ports that use the nats wire protocol. Not used if `messagingSystem.external.enabled` equals `true`.
     nats: tcp
 
+# @schema
+# type: object
+# required: false
+# additionalProperties: true
+# @schema
+# Needs to be added to the schema, so that this chart can be used as subchart when `global` is set.
+# see https://github.com/owncloud/ocis-charts/issues/872
+global: {}
+

--- a/charts/ocis/values.schema.json
+++ b/charts/ocis/values.schema.json
@@ -1884,6 +1884,13 @@
       "title": "features",
       "type": "object"
     },
+    "global": {
+      "additionalProperties": true,
+      "description": "Needs to be added to the schema, so that this chart can be used as subchart when `global` is set.\nsee https://github.com/owncloud/ocis-charts/issues/872",
+      "required": [],
+      "title": "global",
+      "type": "object"
+    },
     "hostAliases": {
       "description": "provide custom hostnames to every oCIS pods",
       "items": {

--- a/charts/ocis/values.yaml
+++ b/charts/ocis/values.yaml
@@ -5690,3 +5690,12 @@ service:
     # @schema
     # -- appProtocol to be used for service ports that use the nats wire protocol. Not used if `messagingSystem.external.enabled` equals `true`.
     nats: tcp
+
+# @schema
+# type: object
+# required: false
+# additionalProperties: true
+# @schema
+# Needs to be added to the schema, so that this chart can be used as subchart when `global` is set.
+# see https://github.com/owncloud/ocis-charts/issues/872
+global: {}


### PR DESCRIPTION
## Description

allow configuring global options, when oCIS is used as sub-chart

## Related Issue
- Fixes https://github.com/owncloud/ocis-charts/issues/872

## Motivation and Context

## How Has This Been Tested?
- `helmfile template` with following modifications on the development-install example:

```diff
diff --git a/deployments/development-install/helmfile.yaml b/deployments/development-install/helmfile.yaml
index d66b89b..bdadea1 100644
--- a/deployments/development-install/helmfile.yaml
+++ b/deployments/development-install/helmfile.yaml
@@ -69,3 +69,6 @@ releases:
           web:
             persistence:
               enabled: true
+
+      - global:
+          foo: bar
```

## Screenshots (if appropriate):

## Types of changes
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Technical debt
- [ ] Tests only (no source changes)

## Checklist:
- [x] Code changes
- [ ] Unit tests added
- [ ] Acceptance tests added
- [ ] Documentation generated (`make docs`) and committed
- [ ] Documentation ticket raised: <link>
- [ ] Documentation PR created: <link>
