### PR TITLE
allow to use deployment strategy Recreate

### DIFF
--- a/charts/ocis/templates/_common/_tplvalues.tpl
+++ b/charts/ocis/templates/_common/_tplvalues.tpl
@@ -227,7 +227,11 @@ oCIS deployment strategy
 {{- define "ocis.deploymentStrategy" -}}
   {{- with $.Values.deploymentStrategy }}
 strategy:
-  {{- toYaml . | nindent 2 }}
+  type: {{ .type }}
+  {{- if eq .type "RollingUpdate" }}
+  rollingUpdate:
+  {{- toYaml .rollingUpdate | nindent 4 }}
+  {{- end }}
   {{- end }}
 {{- end -}}
 


### PR DESCRIPTION
## Description
Allow using deployment strategy recreate without disabling schema validation


## Related Issue
- Fixes https://github.com/owncloud/ocis-charts/issues/891

## Motivation and Context

## How Has This Been Tested?
- before:

```
> helmfile template | grep RollingUpdate -A4 -B4
Adding repo nats https://nats-io.github.io/k8s/helm/charts
"nats" has been added to your repositories
Building dependency release=ocis, chart=../../charts/ocis
Building dependency release=nack-streams, chart=/var/folders/7k/mywfwp6572qfcskcptvwtfph0000gp/T/chartify3284257296/ocis-nats/nack-streams
Building dependency release=nack-crds, chart=/var/folders/7k/mywfwp6572qfcskcptvwtfph0000gp/T/chartify3361043014/ocis-nack/nack-crds
Templating release=nats, chart=nats/nats
Templating release=nack-crds, chart=/var/folders/7k/mywfwp6572qfcskcptvwtfph0000gp/T/chartify3361043014/ocis-nack/nack-crds
Templating release=ocis, chart=../../charts/ocis
  strategy:
    rollingUpdate:
      maxSurge: 25%
      maxUnavailable: 25%
    type: RollingUpdate
  template:
    metadata:
      labels:
        app: activitylog
...
```

- after

```
> helmfile template | grep RollingUpdate -A4 -B4
Adding repo nats https://nats-io.github.io/k8s/helm/charts
"nats" has been added to your repositories
Building dependency release=ocis, chart=../../charts/ocis
Building dependency release=nack-streams, chart=/var/folders/7k/mywfwp6572qfcskcptvwtfph0000gp/T/chartify1356546890/ocis-nats/nack-streams
Building dependency release=nack-crds, chart=/var/folders/7k/mywfwp6572qfcskcptvwtfph0000gp/T/chartify3155587116/ocis-nack/nack-crds
Templating release=nats, chart=nats/nats
Templating release=nack-crds, chart=/var/folders/7k/mywfwp6572qfcskcptvwtfph0000gp/T/chartify3155587116/ocis-nack/nack-crds
Templating release=ocis, chart=../../charts/ocis
      app: activitylog
  replicas: 1
  
  strategy:
    type: RollingUpdate
    rollingUpdate:
      maxSurge: 25%
      maxUnavailable: 25%
  template:
```

And with:

```diff
diff --git a/deployments/ocis-nats/helmfile.yaml b/deployments/ocis-nats/helmfile.yaml
index 7b075d5..695e490 100644
--- a/deployments/ocis-nats/helmfile.yaml
+++ b/deployments/ocis-nats/helmfile.yaml
@@ -143,3 +143,6 @@ releases:
           web:
             persistence:
               enabled: true
+
+      - deploymentStrategy:
+          type: Recreate
```

I get:

```
> helmfile template | grep Recreate -A4 -B4     
Adding repo nats https://nats-io.github.io/k8s/helm/charts
"nats" has been added to your repositories
Building dependency release=ocis, chart=../../charts/ocis
Building dependency release=nack-streams, chart=/var/folders/7k/mywfwp6572qfcskcptvwtfph0000gp/T/chartify3040664143/ocis-nats/nack-streams
Building dependency release=nack-crds, chart=/var/folders/7k/mywfwp6572qfcskcptvwtfph0000gp/T/chartify4046695736/ocis-nack/nack-crds
Templating release=nats, chart=nats/nats
Templating release=nack-crds, chart=/var/folders/7k/mywfwp6572qfcskcptvwtfph0000gp/T/chartify4046695736/ocis-nack/nack-crds
Templating release=ocis, chart=../../charts/ocis
      app: activitylog
  replicas: 1
  
  strategy:
    type: Recreate
  template:
    metadata:
      labels:
        app: activitylog
...

```

## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Technical debt
- [ ] Tests only (no source changes)

## Checklist:

- [x] Code changes
- [ ] Unit tests added
- [ ] Acceptance tests added
- [ ] Documentation generated (`make docs`) and committed
- [ ] Documentation ticket raised: <link>
- [ ] Documentation PR created: <link>
