### PR TITLE
Configure extra annotations for oCIS charts deployments

### DIFF
--- a/charts/ocis/docs/values-desc-table.adoc
+++ b/charts/ocis/docs/values-desc-table.adoc
@@ -132,6 +132,12 @@ a| [subs=-attributes]
 a| [subs=-attributes]
 `nil`
 | Domain where oCIS is reachable for the outside world
+| extraAnnotations
+a| [subs=-attributes]
++object+
+a| [subs=-attributes]
+`{}`
+| Custom annotations for all deployments
 | extraLabels
 a| [subs=-attributes]
 +object+

--- a/charts/ocis/docs/values.adoc.yaml
+++ b/charts/ocis/docs/values.adoc.yaml
@@ -1790,6 +1790,9 @@ topologySpreadConstraints: # |
 # -- Custom labels for all manifests
 extraLabels: {}
 
+# @schema
+# $ref: schema/templates.json#/annotationsTemplate
+# @schema
 # -- Custom annotations for all deployments
 extraAnnotations: {}
 

--- a/charts/ocis/docs/values.adoc.yaml
+++ b/charts/ocis/docs/values.adoc.yaml
@@ -1790,6 +1790,9 @@ topologySpreadConstraints: # |
 # -- Custom labels for all manifests
 extraLabels: {}
 
+# -- Custom annotations for all deployments
+extraAnnotations: {}
+
 # Backup related settings
 # Compare to https://doc.owncloud.com/ocis/next/maintenance/b-r/backup_considerations.html
 backup:

--- a/charts/ocis/templates/_common/_tplvalues.tpl
+++ b/charts/ocis/templates/_common/_tplvalues.tpl
@@ -165,6 +165,8 @@ metadata:
   namespace: {{ template "ocis.namespace" . }}
   labels:
     {{- include "ocis.labels" . | nindent 4 }}
+  annotations:
+    {{- include .Values.extraAnnotations . | nindent 4 }}
 {{- end -}}
 
 {{/*

--- a/charts/ocis/templates/_common/_tplvalues.tpl
+++ b/charts/ocis/templates/_common/_tplvalues.tpl
@@ -165,8 +165,10 @@ metadata:
   namespace: {{ template "ocis.namespace" . }}
   labels:
     {{- include "ocis.labels" . | nindent 4 }}
+  {{- with .Values.extraAnnotations }}
   annotations:
-    {{- include .Values.extraAnnotations . | nindent 4 }}
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
 {{- end -}}
 
 {{/*

--- a/charts/ocis/values.schema.json
+++ b/charts/ocis/values.schema.json
@@ -284,12 +284,6 @@
     "extraAnnotations": {
       "additionalProperties": false,
       "description": "Custom annotations for all deployments",
-      "patternProperties": {
-        ".*": {
-          "required": [],
-          "type": "string"
-        }
-      },
       "required": [],
       "title": "extraAnnotations",
       "type": "object"
@@ -12561,6 +12555,7 @@
     "secretRefs",
     "customCAChain",
     "securityContext",
+    "extraAnnotations",
     "backup",
     "replicas",
     "extraResources",

--- a/charts/ocis/values.schema.json
+++ b/charts/ocis/values.schema.json
@@ -281,19 +281,6 @@
       "title": "externalDomain",
       "type": "string"
     },
-    "extraLabels": {
-      "additionalProperties": false,
-      "description": "Custom labels for all manifests",
-      "patternProperties": {
-        ".*": {
-          "required": [],
-          "type": "string"
-        }
-      },
-      "required": [],
-      "title": "extraLabels",
-      "type": "object"
-    },
     "extraAnnotations": {
       "additionalProperties": false,
       "description": "Custom annotations for all deployments",
@@ -305,6 +292,19 @@
       },
       "required": [],
       "title": "extraAnnotations",
+      "type": "object"
+    },
+    "extraLabels": {
+      "additionalProperties": false,
+      "description": "Custom labels for all manifests",
+      "patternProperties": {
+        ".*": {
+          "required": [],
+          "type": "string"
+        }
+      },
+      "required": [],
+      "title": "extraLabels",
       "type": "object"
     },
     "extraResources": {

--- a/charts/ocis/values.schema.json
+++ b/charts/ocis/values.schema.json
@@ -294,6 +294,19 @@
       "title": "extraLabels",
       "type": "object"
     },
+    "extraAnnotations": {
+      "additionalProperties": false,
+      "description": "Custom annotations for all deployments",
+      "patternProperties": {
+        ".*": {
+          "required": [],
+          "type": "string"
+        }
+      },
+      "required": [],
+      "title": "extraAnnotations",
+      "type": "object"
+    },
     "extraResources": {
       "description": "Include arbitrary resources, eg. config maps or a cert-manager issuer (see example below)\nExtra resources to be included.",
       "items": {

--- a/charts/ocis/values.schema.json
+++ b/charts/ocis/values.schema.json
@@ -284,6 +284,12 @@
     "extraAnnotations": {
       "additionalProperties": false,
       "description": "Custom annotations for all deployments",
+      "patternProperties": {
+        ".*": {
+          "required": [],
+          "type": "string"
+        }
+      },
       "required": [],
       "title": "extraAnnotations",
       "type": "object"

--- a/charts/ocis/values.schema.json
+++ b/charts/ocis/values.schema.json
@@ -12561,7 +12561,6 @@
     "secretRefs",
     "customCAChain",
     "securityContext",
-    "extraAnnotations",
     "backup",
     "replicas",
     "extraResources",

--- a/charts/ocis/values.yaml
+++ b/charts/ocis/values.yaml
@@ -1789,6 +1789,9 @@ topologySpreadConstraints: # |
 # -- Custom labels for all manifests
 extraLabels: {}
 
+# -- Custom annotations for all deployments
+extraAnnotations: {}
+
 # Backup related settings
 # Compare to https://doc.owncloud.com/ocis/next/maintenance/b-r/backup_considerations.html
 backup:

--- a/charts/ocis/values.yaml
+++ b/charts/ocis/values.yaml
@@ -1789,6 +1789,9 @@ topologySpreadConstraints: # |
 # -- Custom labels for all manifests
 extraLabels: {}
 
+# @schema
+# $ref: schema/templates.json#/annotationsTemplate
+# @schema
 # -- Custom annotations for all deployments
 extraAnnotations: {}
 


### PR DESCRIPTION
## Description
Configures the ocis charts to accept extra common annotations in the deployments.

## Related Issue

## Motivation and Context
The oCIS deployments do not accept any annotations at the moment, we need a way to be able to specify common annotations for all the deployments.

## How Has This Been Tested?
Tested with `helm template`, with the right `Values.yml` file which configures a `reloader.stakater.com/auto: "true"` annotation:
```yaml
# Source: ocis/templates/activitylog/deployment.yaml
apiVersion: apps/v1
kind: Deployment
metadata:
  name: activitylog
  namespace: default
  labels:
    helm.sh/chart: ocis-0.7.0
    app.kubernetes.io/name: ocis
    app.kubernetes.io/instance: ocis
    app.kubernetes.io/version: "7.1.1"
    app.kubernetes.io/managed-by: Helm
  annotations:
    reloader.stakater.com/auto: "true"
--
# Source: ocis/templates/antivirus/deployment.yaml
apiVersion: apps/v1
kind: Deployment
metadata:
  name: antivirus
  namespace: default
  labels:
    helm.sh/chart: ocis-0.7.0
    app.kubernetes.io/name: ocis
    app.kubernetes.io/instance: ocis
    app.kubernetes.io/version: "7.1.1"
    app.kubernetes.io/managed-by: Helm
  annotations:
    reloader.stakater.com/auto: "true"
--
# Source: ocis/templates/appregistry/deployment.yaml
apiVersion: apps/v1
kind: Deployment
metadata:
  name: appregistry
  namespace: default
  labels:
    helm.sh/chart: ocis-0.7.0
    app.kubernetes.io/name: ocis
    app.kubernetes.io/instance: ocis
    app.kubernetes.io/version: "7.1.1"
    app.kubernetes.io/managed-by: Helm
  annotations:
    reloader.stakater.com/auto: "true"
--
# Source: ocis/templates/audit/deployment.yaml
apiVersion: apps/v1
kind: Deployment
metadata:
  name: audit
  namespace: default
  labels:
    helm.sh/chart: ocis-0.7.0
    app.kubernetes.io/name: ocis
    app.kubernetes.io/instance: ocis
    app.kubernetes.io/version: "7.1.1"
    app.kubernetes.io/managed-by: Helm
  annotations:
    reloader.stakater.com/auto: "true"
--
# Source: ocis/templates/authmachine/deployment.yaml
apiVersion: apps/v1
kind: Deployment
metadata:
  name: authmachine
  namespace: default
  labels:
    helm.sh/chart: ocis-0.7.0
    app.kubernetes.io/name: ocis
    app.kubernetes.io/instance: ocis
    app.kubernetes.io/version: "7.1.1"
    app.kubernetes.io/managed-by: Helm
  annotations:
    reloader.stakater.com/auto: "true"
--
# Source: ocis/templates/authservice/deployment.yaml
apiVersion: apps/v1
kind: Deployment
metadata:
  name: authservice
  namespace: default
  labels:
    helm.sh/chart: ocis-0.7.0
    app.kubernetes.io/name: ocis
    app.kubernetes.io/instance: ocis
    app.kubernetes.io/version: "7.1.1"
    app.kubernetes.io/managed-by: Helm
  annotations:
    reloader.stakater.com/auto: "true"
--
# Source: ocis/templates/clientlog/deployment.yaml
apiVersion: apps/v1
kind: Deployment
metadata:
  name: clientlog
  namespace: default
  labels:
    helm.sh/chart: ocis-0.7.0
    app.kubernetes.io/name: ocis
    app.kubernetes.io/instance: ocis
    app.kubernetes.io/version: "7.1.1"
    app.kubernetes.io/managed-by: Helm
  annotations:
    reloader.stakater.com/auto: "true"
--
# Source: ocis/templates/collaboration/deployment.yaml
apiVersion: apps/v1
kind: Deployment
metadata:
  name: collaboration-bycs-office
  namespace: default
  labels:
    helm.sh/chart: ocis-0.7.0
    app.kubernetes.io/name: ocis
    app.kubernetes.io/instance: ocis
    app.kubernetes.io/version: "7.1.1"
    app.kubernetes.io/managed-by: Helm
  annotations:
    reloader.stakater.com/auto: "true"
--
# Source: ocis/templates/eventhistory/deployment.yaml
apiVersion: apps/v1
kind: Deployment
metadata:
  name: eventhistory
  namespace: default
  labels:
    helm.sh/chart: ocis-0.7.0
    app.kubernetes.io/name: ocis
    app.kubernetes.io/instance: ocis
    app.kubernetes.io/version: "7.1.1"
    app.kubernetes.io/managed-by: Helm
  annotations:
    reloader.stakater.com/auto: "true"
--
# Source: ocis/templates/frontend/deployment.yaml
apiVersion: apps/v1
kind: Deployment
metadata:
  name: frontend
  namespace: default
  labels:
    helm.sh/chart: ocis-0.7.0
    app.kubernetes.io/name: ocis
    app.kubernetes.io/instance: ocis
    app.kubernetes.io/version: "7.1.1"
    app.kubernetes.io/managed-by: Helm
  annotations:
    reloader.stakater.com/auto: "true"
--
# Source: ocis/templates/gateway/deployment.yaml
apiVersion: apps/v1
kind: Deployment
metadata:
  name: gateway
  namespace: default
  labels:
    helm.sh/chart: ocis-0.7.0
    app.kubernetes.io/name: ocis
    app.kubernetes.io/instance: ocis
    app.kubernetes.io/version: "7.1.1"
    app.kubernetes.io/managed-by: Helm
  annotations:
    reloader.stakater.com/auto: "true"
--
# Source: ocis/templates/graph/deployment.yaml
apiVersion: apps/v1
kind: Deployment
metadata:
  name: graph
  namespace: default
  labels:
    helm.sh/chart: ocis-0.7.0
    app.kubernetes.io/name: ocis
    app.kubernetes.io/instance: ocis
    app.kubernetes.io/version: "7.1.1"
    app.kubernetes.io/managed-by: Helm
  annotations:
    reloader.stakater.com/auto: "true"
--
# Source: ocis/templates/groups/deployment.yaml
apiVersion: apps/v1
kind: Deployment
metadata:
  name: groups
  namespace: default
  labels:
    helm.sh/chart: ocis-0.7.0
    app.kubernetes.io/name: ocis
    app.kubernetes.io/instance: ocis
    app.kubernetes.io/version: "7.1.1"
    app.kubernetes.io/managed-by: Helm
  annotations:
    reloader.stakater.com/auto: "true"
--
# Source: ocis/templates/notifications/deployment.yaml
apiVersion: apps/v1
kind: Deployment
metadata:
  name: notifications
  namespace: default
  labels:
    helm.sh/chart: ocis-0.7.0
    app.kubernetes.io/name: ocis
    app.kubernetes.io/instance: ocis
    app.kubernetes.io/version: "7.1.1"
    app.kubernetes.io/managed-by: Helm
  annotations:
    reloader.stakater.com/auto: "true"
--
# Source: ocis/templates/ocdav/deployment.yaml
apiVersion: apps/v1
kind: Deployment
metadata:
  name: ocdav
  namespace: default
  labels:
    helm.sh/chart: ocis-0.7.0
    app.kubernetes.io/name: ocis
    app.kubernetes.io/instance: ocis
    app.kubernetes.io/version: "7.1.1"
    app.kubernetes.io/managed-by: Helm
  annotations:
    reloader.stakater.com/auto: "true"
--
# Source: ocis/templates/ocs/deployment.yaml
apiVersion: apps/v1
kind: Deployment
metadata:
  name: ocs
  namespace: default
  labels:
    helm.sh/chart: ocis-0.7.0
    app.kubernetes.io/name: ocis
    app.kubernetes.io/instance: ocis
    app.kubernetes.io/version: "7.1.1"
    app.kubernetes.io/managed-by: Helm
  annotations:
    reloader.stakater.com/auto: "true"
--
# Source: ocis/templates/policies/deployment.yaml
apiVersion: apps/v1
kind: Deployment
metadata:
  name: policies
  namespace: default
  labels:
    helm.sh/chart: ocis-0.7.0
    app.kubernetes.io/name: ocis
    app.kubernetes.io/instance: ocis
    app.kubernetes.io/version: "7.1.1"
    app.kubernetes.io/managed-by: Helm
spec:
  selector:
--
# Source: ocis/templates/postprocessing/deployment.yaml
apiVersion: apps/v1
kind: Deployment
metadata:
  name: postprocessing
  namespace: default
  labels:
    helm.sh/chart: ocis-0.7.0
    app.kubernetes.io/name: ocis
    app.kubernetes.io/instance: ocis
    app.kubernetes.io/version: "7.1.1"
    app.kubernetes.io/managed-by: Helm
  annotations:
    reloader.stakater.com/auto: "true"
--
# Source: ocis/templates/proxy/deployment.yaml
apiVersion: apps/v1
kind: Deployment
metadata:
  name: proxy
  namespace: default
  labels:
    helm.sh/chart: ocis-0.7.0
    app.kubernetes.io/name: ocis
    app.kubernetes.io/instance: ocis
    app.kubernetes.io/version: "7.1.1"
    app.kubernetes.io/managed-by: Helm
  annotations:
    reloader.stakater.com/auto: "true"
--
# Source: ocis/templates/search/deployment.yaml
apiVersion: apps/v1
kind: Deployment
metadata:
  name: search
  namespace: default
  labels:
    helm.sh/chart: ocis-0.7.0
    app.kubernetes.io/name: ocis
    app.kubernetes.io/instance: ocis
    app.kubernetes.io/version: "7.1.1"
    app.kubernetes.io/managed-by: Helm
  annotations:
    reloader.stakater.com/auto: "true"
--
# Source: ocis/templates/settings/deployment.yaml
apiVersion: apps/v1
kind: Deployment
metadata:
  name: settings
  namespace: default
  labels:
    helm.sh/chart: ocis-0.7.0
    app.kubernetes.io/name: ocis
    app.kubernetes.io/instance: ocis
    app.kubernetes.io/version: "7.1.1"
    app.kubernetes.io/managed-by: Helm
  annotations:
    reloader.stakater.com/auto: "true"
--
# Source: ocis/templates/sharing/deployment.yaml
apiVersion: apps/v1
kind: Deployment
metadata:
  name: sharing
  namespace: default
  labels:
    helm.sh/chart: ocis-0.7.0
    app.kubernetes.io/name: ocis
    app.kubernetes.io/instance: ocis
    app.kubernetes.io/version: "7.1.1"
    app.kubernetes.io/managed-by: Helm
  annotations:
    reloader.stakater.com/auto: "true"
--
# Source: ocis/templates/sse/deployment.yaml
apiVersion: apps/v1
kind: Deployment
metadata:
  name: sse
  namespace: default
  labels:
    helm.sh/chart: ocis-0.7.0
    app.kubernetes.io/name: ocis
    app.kubernetes.io/instance: ocis
    app.kubernetes.io/version: "7.1.1"
    app.kubernetes.io/managed-by: Helm
  annotations:
    reloader.stakater.com/auto: "true"
--
# Source: ocis/templates/storagepubliclink/deployment.yaml
apiVersion: apps/v1
kind: Deployment
metadata:
  name: storagepubliclink
  namespace: default
  labels:
    helm.sh/chart: ocis-0.7.0
    app.kubernetes.io/name: ocis
    app.kubernetes.io/instance: ocis
    app.kubernetes.io/version: "7.1.1"
    app.kubernetes.io/managed-by: Helm
  annotations:
    reloader.stakater.com/auto: "true"
--
# Source: ocis/templates/storageshares/deployment.yaml
apiVersion: apps/v1
kind: Deployment
metadata:
  name: storageshares
  namespace: default
  labels:
    helm.sh/chart: ocis-0.7.0
    app.kubernetes.io/name: ocis
    app.kubernetes.io/instance: ocis
    app.kubernetes.io/version: "7.1.1"
    app.kubernetes.io/managed-by: Helm
  annotations:
    reloader.stakater.com/auto: "true"
--
# Source: ocis/templates/storagesystem/deployment.yaml
apiVersion: apps/v1
kind: Deployment
metadata:
  name: storagesystem
  namespace: default
  labels:
    helm.sh/chart: ocis-0.7.0
    app.kubernetes.io/name: ocis
    app.kubernetes.io/instance: ocis
    app.kubernetes.io/version: "7.1.1"
    app.kubernetes.io/managed-by: Helm
  annotations:
    reloader.stakater.com/auto: "true"
--
# Source: ocis/templates/storageusers/deployment.yaml
apiVersion: apps/v1
kind: Deployment
metadata:
  name: storageusers
  namespace: default
  labels:
    helm.sh/chart: ocis-0.7.0
    app.kubernetes.io/name: ocis
    app.kubernetes.io/instance: ocis
    app.kubernetes.io/version: "7.1.1"
    app.kubernetes.io/managed-by: Helm
  annotations:
    reloader.stakater.com/auto: "true"
--
# Source: ocis/templates/thumbnails/deployment.yaml
apiVersion: apps/v1
kind: Deployment
metadata:
  name: thumbnails
  namespace: default
  labels:
    helm.sh/chart: ocis-0.7.0
    app.kubernetes.io/name: ocis
    app.kubernetes.io/instance: ocis
    app.kubernetes.io/version: "7.1.1"
    app.kubernetes.io/managed-by: Helm
  annotations:
    reloader.stakater.com/auto: "true"
--
# Source: ocis/templates/userlog/deployment.yaml
apiVersion: apps/v1
kind: Deployment
metadata:
  name: userlog
  namespace: default
  labels:
    helm.sh/chart: ocis-0.7.0
    app.kubernetes.io/name: ocis
    app.kubernetes.io/instance: ocis
    app.kubernetes.io/version: "7.1.1"
    app.kubernetes.io/managed-by: Helm
  annotations:
    reloader.stakater.com/auto: "true"
--
# Source: ocis/templates/users/deployment.yaml
apiVersion: apps/v1
kind: Deployment
metadata:
  name: users
  namespace: default
  labels:
    helm.sh/chart: ocis-0.7.0
    app.kubernetes.io/name: ocis
    app.kubernetes.io/instance: ocis
    app.kubernetes.io/version: "7.1.1"
    app.kubernetes.io/managed-by: Helm
  annotations:
    reloader.stakater.com/auto: "true"
--
# Source: ocis/templates/web/deployment.yaml
apiVersion: apps/v1
kind: Deployment
metadata:
  name: web
  namespace: default
  labels:
    helm.sh/chart: ocis-0.7.0
    app.kubernetes.io/name: ocis
    app.kubernetes.io/instance: ocis
    app.kubernetes.io/version: "7.1.1"
    app.kubernetes.io/managed-by: Helm
  annotations:
    reloader.stakater.com/auto: "true"
--
# Source: ocis/templates/webdav/deployment.yaml
apiVersion: apps/v1
kind: Deployment
metadata:
  name: webdav
  namespace: default
  labels:
    helm.sh/chart: ocis-0.7.0
    app.kubernetes.io/name: ocis
    app.kubernetes.io/instance: ocis
    app.kubernetes.io/version: "7.1.1"
    app.kubernetes.io/managed-by: Helm
  annotations:
    reloader.stakater.com/auto: "true"
--
# Source: ocis/templates/webfinger/deployment.yaml
apiVersion: apps/v1
kind: Deployment
metadata:
  name: webfinger
  namespace: default
  labels:
    helm.sh/chart: ocis-0.7.0
    app.kubernetes.io/name: ocis
    app.kubernetes.io/instance: ocis
    app.kubernetes.io/version: "7.1.1"
    app.kubernetes.io/managed-by: Helm
  annotations:
    reloader.stakater.com/auto: "true"
```

## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Technical debt
- [ ] Tests only (no source changes)

## Checklist:
<!-- Tick the checkboxes when done. -->
<!-- Raise documentation ticket in https://github.com/owncloud/docs-ocis/issues -->
<!-- or create documentation PR in https://github.com/owncloud/docs-ocis/tree/master/modules/ROOT/pages/deployment/container -->
- [x] Code changes
- [ ] Unit tests added
- [ ] Acceptance tests added
- [x] Documentation generated (`make docs`) and committed
- [ ] Documentation ticket raised: <link>
- [ ] Documentation PR created: <link>
