### PR TITLE
Fixed defaults for `personalDeleteBefore` and `personalDeleteBefore`

### DIFF
--- a/charts/ocis/values.yaml
+++ b/charts/ocis/values.yaml
@@ -4612,14 +4612,14 @@ services:
         # type: string
         # required: true
         # @schema
-        # -- Setting that makes the command delete all trashed personal files older than the value. The value is a number and a unit "d", "h", "m", "s".
-        personalDeleteBefore: 30d
+        # -- Setting that makes the command delete all trashed personal files older than the value. The value is a number and a unit "h", "m", "s".
+        personalDeleteBefore: 720h
         # @schema
         # type: string
         # required: true
         # @schema
-        # -- Setting that makes the command delete all trashed project files older than the value. The value is a number and a unit "d", "h", "m", "s".
-        projectDeleteBefore: 30d
+        # -- Setting that makes the command delete all trashed project files older than the value. The value is a number and a unit "h", "m", "s".
+        projectDeleteBefore: 720h
       # Uploads that were not postprocessed can be automatically processed again by enabling the restart job.
       restartPostprocessing:
         # @schema


### PR DESCRIPTION
## Description
Currently the chart used defaults with the suffix `d` which is not allowed in Go. The maximum suffix is `h` for hours.

## Related Issue
- Fixes [OCSRE-734](https://kiteworks.atlassian.net/browse/OCSRE-734)

## Motivation and Context
Bugfix

## How Has This Been Tested?

## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Technical debt
- [ ] Tests only (no source changes)

## Checklist:
- [x] Code changes
- [ ] Unit tests added
- [ ] Acceptance tests added
- [ ] Documentation generated (`make docs`) and committed
- [ ] Documentation ticket raised: <link>
- [ ] Documentation PR created: <link>
