### PR TITLE
Fix required for accessMode

### DIFF
--- a/charts/ocis/docs/values.adoc.yaml
+++ b/charts/ocis/docs/values.adoc.yaml
@@ -2520,7 +2520,7 @@ services:
       #     - ReadOnlyMany
       #     - ReadWriteMany
       #     - ReadWriteOncePod
-      #   required: true
+      # required: true
       # @schema
       # -- Persistent volume access modes.
       accessModes:

--- a/charts/ocis/values.schema.json
+++ b/charts/ocis/values.schema.json
@@ -4059,6 +4059,7 @@
               },
               "required": [
                 "enabled",
+                "accessModes",
                 "size"
               ],
               "title": "persistence",

--- a/charts/ocis/values.yaml
+++ b/charts/ocis/values.yaml
@@ -2519,7 +2519,7 @@ services:
       #     - ReadOnlyMany
       #     - ReadWriteMany
       #     - ReadWriteOncePod
-      #   required: true
+      # required: true
       # @schema
       # -- Persistent volume access modes.
       accessModes:
@@ -3074,7 +3074,7 @@ services:
       #     - ReadOnlyMany
       #     - ReadWriteMany
       #     - ReadWriteOncePod
-      #   required: true
+      # required: true
       # @schema
       # -- Persistent volume access modes.
       accessModes:
@@ -3259,7 +3259,7 @@ services:
       #     - ReadOnlyMany
       #     - ReadWriteMany
       #     - ReadWriteOncePod
-      #   required: true
+      # required: true
       # @schema
       # -- Persistent volume access modes.
       accessModes:
@@ -3590,7 +3590,7 @@ services:
       #     - ReadOnlyMany
       #     - ReadWriteMany
       #     - ReadWriteOncePod
-      #   required: true
+      # required: true
       # @schema
       # -- Persistent volume access modes.
       accessModes:
@@ -3986,7 +3986,7 @@ services:
       #     - ReadOnlyMany
       #     - ReadWriteMany
       #     - ReadWriteOncePod
-      #   required: true
+      # required: true
       # @schema
       # -- Persistent volume access modes.
       accessModes:
@@ -4467,7 +4467,7 @@ services:
       #     - ReadOnlyMany
       #     - ReadWriteMany
       #     - ReadWriteOncePod
-      #   required: true
+      # required: true
       # @schema
       # -- Persistent volume access modes. Needs to be `[ReadWriteMany]` when having more than one replica for this service.
       accessModes:
@@ -4862,7 +4862,7 @@ services:
       #     - ReadOnlyMany
       #     - ReadWriteMany
       #     - ReadWriteOncePod
-      #   required: true
+      # required: true
       # @schema
       # -- Persistent volume access modes. Needs to be `[ReadWriteMany]` when having more than one replica for this service.
       accessModes:
@@ -5047,7 +5047,7 @@ services:
       #     - ReadOnlyMany
       #     - ReadWriteMany
       #     - ReadWriteOncePod
-      #   required: true
+      # required: true
       # @schema
       # -- Persistent volume access modes. Needs to be `[ReadWriteMany]` when having more than one replica for this service or persistence needs to be disabled.
       accessModes:
@@ -5599,7 +5599,7 @@ services:
       #     - ReadOnlyMany
       #     - ReadWriteMany
       #     - ReadWriteOncePod
-      #   required: true
+      # required: true
       # @schema
       # -- Persistent volume access modes. Needs to be `[ReadWriteMany]` when having more than one replica for this service or persistence needs to be disabled.
       accessModes:


### PR DESCRIPTION
## Description
This PR fixes the required json schema annotation for `accessMode`. It was already present but not taken into account as there were two white space in between.

## Related Issue
- Fixes OCSRE-917

## How Has This Been Tested?
- test environment:
- test case 1:
- test case 2:
- ...

## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Technical debt
- [ ] Tests only (no source changes)

## Checklist:
- [x] Code changes
- [ ] Unit tests added
- [ ] Acceptance tests added
- [ ] Documentation generated (`make docs`) and committed
- [ ] Documentation ticket raised: <link>
- [ ] Documentation PR created: <link>
