### PR TITLE
Add more parameters to cleanup jobs

### DIFF
--- a/charts/ocis/templates/storageusers/jobs.yaml
+++ b/charts/ocis/templates/storageusers/jobs.yaml
@@ -37,7 +37,7 @@ spec:
             - name: storage-users-clean-expired-uploads
               {{- include "ocis.jobContainerImageOcis" . | nindent 14 }}
               command: ["ocis"]
-              args: ["storage-users", "uploads", "sessions", "--clean"]
+              args: ["storage-users", "uploads", "sessions", "--clean", "--expired", "--processing=false"]
               securityContext:
                 runAsNonRoot: true
                 runAsUser: {{ .Values.securityContext.runAsUser }}


### PR DESCRIPTION
## Description
This PR adds some more parameters to the uploads cleanup job, so that only expired uploads are clean and only those which are not currently being processed.

## Related Issue
- nothing specific. Side finding.

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->


## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Technical debt
- [ ] Tests only (no source changes)

## Checklist:
- [x] Code changes
- [ ] Unit tests added
- [ ] Acceptance tests added
- [ ] Documentation generated (`make docs`) and committed
- [ ] Documentation ticket raised: <link>
- [ ] Documentation PR created: <link>
