### PR TITLE
dynamic name for jwt-secret ocm service

### DIFF
--- a/charts/ocis/templates/ocm/deployment.yaml
+++ b/charts/ocis/templates/ocm/deployment.yaml
@@ -71,7 +71,7 @@ spec:
             - name: OCM_JWT_SECRET
               valueFrom:
                 secretKeyRef:
-                  name: "jwt-secret"
+                  name: {{ include "secrets.jwtSecret" . }}
                   key: jwt-secret
 
             - name: OCM_OCM_INVITE_MANAGER_INSECURE


### PR DESCRIPTION
## Description
Changed value "jwtSecret: namei:" from hardcoded to dynamic one for ocm service 
```yaml
...
            - name: OCM_JWT_SECRET
              valueFrom:
                secretKeyRef:
                  name: "sealed-jwt-secret"
                  key: jwt-secret
...
```

## How Has This Been Tested?
- test environment: oc, k8s, testing

## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Technical debt
- [ ] Tests only (no source changes)

## Checklist:
- [x] Code changes
- [ ] Unit tests added
- [ ] Acceptance tests added
- [x] Documentation generated (`make docs`) and committed
- [ ] Documentation ticket raised: <link>
- [ ] Documentation PR created: <link>
