### PR TITLE
Fix storage-users-clean-expired-uploads CronJob

### DIFF
--- a/charts/ocis/templates/storageusers/jobs.yaml
+++ b/charts/ocis/templates/storageusers/jobs.yaml
@@ -45,6 +45,7 @@ spec:
                 readOnlyRootFilesystem: true
               env:
                 {{- include "ocis.serviceRegistry" . | nindent 16 }}
+                {{- include "ocis.cacheStore" . | nindent 16 }}
                 # logging
                 - name: STORAGE_USERS_LOG_COLOR
                   value: {{ .Values.logging.color | quote }}


### PR DESCRIPTION
<!--
Thanks for submitting a change to ownCloud!

This is the bug tracker for the oCIS Helm Chart.

For fixing potential security issues please see https://owncloud.org/security/

To make it possible for us to get your change reviewed and merged please carefully fill out the requested information below.

Please note that any kind of change needs to first be submitted to the master branch which holds the next version of the oCIS Helm Chart.

Please set the following labels:

- Set label "Status:Needs-Review" for review or "Status:In-Progress" if the PR still has open tasks.
- Assignment: assign to self
- Reviewers: pick at least one
-->

## Description

The CronJob storage-users-clean-expired-uploads kept failing because it couldn't connect to the cache storage (nats in the default configuration)

This change adds the missing templating function call that configures the necessary environment variables for the job.

## Related Issue

- Fixes #939

## Motivation and Context

I was getting worried about expired uploads piling up on my instance.

## How Has This Been Tested?

I tested it in my local environment.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Technical debt
- [ ] Tests only (no source changes)

## Checklist:
<!-- Tick the checkboxes when done. -->
<!-- Raise documentation ticket in https://github.com/owncloud/docs-ocis/issues -->
<!-- or create documentation PR in https://github.com/owncloud/docs-ocis/tree/master/modules/ROOT/pages/deployment/container>
- [x] Code changes
- [ ] Unit tests added
- [ ] Acceptance tests added
- [ ] Documentation generated (`make docs`) and committed
- [ ] Documentation ticket raised: <link>
- [ ] Documentation PR created: <link>
